### PR TITLE
MDBList added to Setup Wizard, Groups page poster caching improvements

### DIFF
--- a/homescreen-hero-ui/src/components/GroupCoverMosaic.tsx
+++ b/homescreen-hero-ui/src/components/GroupCoverMosaic.tsx
@@ -8,6 +8,8 @@ interface GroupCoverMosaicProps {
 export default function GroupCoverMosaic({ collections }: GroupCoverMosaicProps) {
     const [posters, setPosters] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
+    const [imagesLoaded, setImagesLoaded] = useState(false);
+    const [isFirstLoad, setIsFirstLoad] = useState(false);
 
     useEffect(() => {
         const fetchPosters = async () => {
@@ -16,12 +18,45 @@ export default function GroupCoverMosaic({ collections }: GroupCoverMosaicProps)
                 return;
             }
 
+            const collectionNames = collections.join(',');
+            const cacheKey = `group-posters-${collectionNames}`;
+
+            // Check sessionStorage for cached posters
+            const cachedData = sessionStorage.getItem(cacheKey);
+            if (cachedData) {
+                try {
+                    const cached = JSON.parse(cachedData);
+                    const posterUrls = cached.posters || [];
+
+                    // Preload images before showing them
+                    await preloadImages(posterUrls);
+
+                    setPosters(posterUrls);
+                    setIsFirstLoad(false);
+                    setImagesLoaded(true);
+                    setLoading(false);
+                    return;
+                } catch (error) {
+                    console.error("Failed to parse cached posters:", error);
+                }
+            }
+
+            // If no cache, fetch from API
             try {
-                const collectionNames = collections.join(',');
                 const response = await fetchWithAuth(`/api/collections/group-posters?collection_names=${encodeURIComponent(collectionNames)}`);
                 if (response.ok) {
                     const data = await response.json();
-                    setPosters(data.posters || []);
+                    const posterUrls = data.posters || [];
+
+                    // Cache the result
+                    sessionStorage.setItem(cacheKey, JSON.stringify(data));
+
+                    // Preload images before showing them
+                    await preloadImages(posterUrls);
+
+                    setPosters(posterUrls);
+                    setIsFirstLoad(true);
+                    setImagesLoaded(true);
                 }
             } catch (error) {
                 console.error("Failed to fetch group posters:", error);
@@ -33,7 +68,28 @@ export default function GroupCoverMosaic({ collections }: GroupCoverMosaicProps)
         fetchPosters();
     }, [collections]);
 
-    if (loading || !posters || posters.length === 0) {
+    // Preload all images before rendering
+    const preloadImages = (imageUrls: string[]): Promise<void> => {
+        return new Promise((resolve) => {
+            if (!imageUrls || imageUrls.length === 0) {
+                resolve();
+                return;
+            }
+
+            const imagePromises = imageUrls.slice(0, 6).map((url) => {
+                return new Promise<void>((resolve) => {
+                    const img = new Image();
+                    img.onload = () => resolve();
+                    img.onerror = () => resolve(); // Resolve even on error to prevent hanging
+                    img.src = url;
+                });
+            });
+
+            Promise.all(imagePromises).then(() => resolve());
+        });
+    };
+
+    if (loading || !imagesLoaded || !posters || posters.length === 0) {
         // Return null to let the parent show the gradient fallback
         return null;
     }
@@ -45,10 +101,10 @@ export default function GroupCoverMosaic({ collections }: GroupCoverMosaicProps)
                 {posters.slice(0, 6).map((poster, index) => (
                     <div
                         key={index}
-                        className="flex-1 overflow-hidden opacity-40 animate-fade-in rounded-lg"
-                        style={{
+                        className={`flex-1 overflow-hidden opacity-40 rounded-lg ${isFirstLoad ? 'animate-fade-in' : ''}`}
+                        style={isFirstLoad ? {
                             animationDelay: `${index * 0.1}s`,
-                        }}
+                        } : undefined}
                     >
                         <img
                             src={poster}

--- a/homescreen-hero-ui/src/pages/QuickStartPage.tsx
+++ b/homescreen-hero-ui/src/pages/QuickStartPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Wizard, useWizard } from "react-use-wizard";
-import { ArrowRight, ArrowLeft, Check, ExternalLink, Shield, Server, Database, Sparkles, Clock } from "lucide-react";
+import { ArrowRight, ArrowLeft, Check, ExternalLink, Shield, Server, Database, Sparkles, Clock, List } from "lucide-react";
 import { Switch } from "@headlessui/react";
 import PosterBackground from "../components/PosterBackground";
 import { getShuffledStaticPosters } from "../utils/staticPosters";
@@ -12,6 +12,7 @@ type EnvVars = {
     auth_password_from_env: boolean;
     auth_secret_from_env: boolean;
     trakt_client_id_from_env: boolean;
+    mdblist_api_key_from_env: boolean;
 };
 
 type Library = {
@@ -29,6 +30,9 @@ type WizardData = {
     traktEnabled: boolean;
     traktClientId: string;
     traktBaseUrl: string;
+    mdblistEnabled: boolean;
+    mdblistApiKey: string;
+    mdblistBaseUrl: string;
     rotationEnabled: boolean;
     rotationIntervalHours: number;
     rotationMaxCollections: number;
@@ -47,6 +51,9 @@ export default function QuickStartPage() {
         traktEnabled: false,
         traktClientId: "",
         traktBaseUrl: "https://api.trakt.tv",
+        mdblistEnabled: false,
+        mdblistApiKey: "",
+        mdblistBaseUrl: "https://api.mdblist.com",
         rotationEnabled: false,
         rotationIntervalHours: 12,
         rotationMaxCollections: 5,
@@ -60,6 +67,7 @@ export default function QuickStartPage() {
         auth_password_from_env: false,
         auth_secret_from_env: false,
         trakt_client_id_from_env: false,
+        mdblist_api_key_from_env: false,
     });
 
     useEffect(() => {
@@ -84,6 +92,7 @@ export default function QuickStartPage() {
                         <AuthStep wizardData={wizardData} setWizardData={setWizardData} envVars={envVars} />
                         <PlexStep wizardData={wizardData} setWizardData={setWizardData} envVars={envVars} />
                         <TraktStep wizardData={wizardData} setWizardData={setWizardData} envVars={envVars} />
+                        <MDBListStep wizardData={wizardData} setWizardData={setWizardData} envVars={envVars} />
                         <RotationStep wizardData={wizardData} setWizardData={setWizardData} />
                         <CompleteStep wizardData={wizardData} />
                     </Wizard>
@@ -112,7 +121,7 @@ function WelcomeStep() {
                     Welcome to HomeScreen Hero
                 </h1>
                 <p className="text-sm text-slate-600 dark:text-slate-400">
-                    Let's get you set up in just a few quick steps. We'll configure your Plex connection, select your libraries, and optionally set up authentication and Trakt integration.
+                    Let's get you set up in just a few quick steps. We'll configure your Plex connection, select your libraries, and optionally set up authentication, Trakt, and MDBList integrations.
                 </p>
             </div>
 
@@ -705,6 +714,214 @@ function TraktStep({ wizardData, setWizardData, envVars }: { wizardData: WizardD
     );
 }
 
+function MDBListStep({ wizardData, setWizardData, envVars }: { wizardData: WizardData; setWizardData: (data: WizardData) => void; envVars: EnvVars }) {
+    const { nextStep, previousStep } = useWizard();
+    const [localMDBListEnabled, setLocalMDBListEnabled] = useState(wizardData.mdblistEnabled);
+    const [localMDBListApiKey, setLocalMDBListApiKey] = useState(wizardData.mdblistApiKey);
+    const [localMDBListBaseUrl, setLocalMDBListBaseUrl] = useState(wizardData.mdblistBaseUrl);
+    const [testingMDBList, setTestingMDBList] = useState(false);
+    const [mdblistTestSuccess, setMDBListTestSuccess] = useState(false);
+    const [error, setError] = useState("");
+
+    const handleTestMDBList = async () => {
+        if ((!localMDBListApiKey && !envVars.mdblist_api_key_from_env) || !localMDBListBaseUrl) {
+            setError("Please enter both MDBList API Key and Base URL before testing");
+            return;
+        }
+
+        try {
+            setTestingMDBList(true);
+            setError("");
+            setMDBListTestSuccess(false);
+
+            // Test MDBList connection
+            const response = await fetch("/api/health/mdblist");
+            if (!response.ok) {
+                throw new Error("MDBList connection test failed");
+            }
+
+            const healthData = await response.json();
+            if (!healthData.ok) {
+                throw new Error(healthData.error || "MDBList connection test failed");
+            }
+
+            setMDBListTestSuccess(true);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "MDBList connection test failed");
+            setMDBListTestSuccess(false);
+        } finally {
+            setTestingMDBList(false);
+        }
+    };
+
+    const handleNext = () => {
+        setWizardData({
+            ...wizardData,
+            mdblistEnabled: localMDBListEnabled,
+            mdblistApiKey: localMDBListApiKey,
+            mdblistBaseUrl: localMDBListBaseUrl,
+        });
+        nextStep();
+    };
+
+    const handleSkip = () => {
+        setWizardData({
+            ...wizardData,
+            mdblistEnabled: false,
+            mdblistApiKey: "",
+            mdblistBaseUrl: "https://api.mdblist.com",
+        });
+        nextStep();
+    };
+
+    return (
+        <div className="space-y-6 animate-in fade-in duration-500">
+            <div className="text-center space-y-2">
+                <List className="h-12 w-12 text-primary mx-auto" />
+                <h2 className="text-2xl font-bold text-slate-900 dark:text-white">MDBList Integration</h2>
+                <p className="text-sm text-slate-600 dark:text-slate-400">
+                    Optionally sync MDBList collections with your Plex libraries
+                </p>
+            </div>
+
+            <div className="space-y-4">
+                <div className="flex items-center gap-3 p-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-900/50">
+                    <input
+                        id="mdblistEnabled"
+                        type="checkbox"
+                        checked={localMDBListEnabled}
+                        onChange={(e) => setLocalMDBListEnabled(e.target.checked)}
+                        className="h-4 w-4 rounded border-slate-300 dark:border-slate-700 text-primary focus:ring-2 focus:ring-primary"
+                    />
+                    <label htmlFor="mdblistEnabled" className="flex-1 cursor-pointer">
+                        <div className="text-sm font-semibold text-slate-900 dark:text-white">
+                            Enable MDBList integration
+                        </div>
+                        <div className="text-xs text-slate-500 dark:text-slate-400">
+                            Sync MDBList collections to create Plex collections automatically
+                        </div>
+                    </label>
+                </div>
+
+                {localMDBListEnabled && (
+                    <div className="space-y-4 pl-4 border-l-2 border-primary">
+                        <div>
+                            <label htmlFor="mdblistApiKey" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                MDBList API Key
+                            </label>
+                            {envVars.mdblist_api_key_from_env ? (
+                                <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
+                                    <p className="text-sm text-blue-700 dark:text-blue-400">
+                                        ✓ MDBList API Key configured via environment variable (HSH_MDBLIST_API_KEY)
+                                    </p>
+                                </div>
+                            ) : (
+                                <>
+                                    <input
+                                        id="mdblistApiKey"
+                                        type="password"
+                                        value={localMDBListApiKey}
+                                        onChange={(e) => setLocalMDBListApiKey(e.target.value)}
+                                        required={localMDBListEnabled}
+                                        placeholder="Your MDBList API key"
+                                        className="w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                                    />
+                                    <p className="mt-1 text-xs text-slate-500 dark:text-slate-400 flex items-center gap-1">
+                                        <a
+                                            href="https://mdblist.com/preferences/"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-primary hover:underline inline-flex items-center gap-1"
+                                        >
+                                            Get your API key from MDBList
+                                            <ExternalLink className="h-3 w-3" />
+                                        </a>
+                                    </p>
+                                </>
+                            )}
+                        </div>
+
+                        <div>
+                            <label htmlFor="mdblistBaseUrl" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                MDBList API Base URL
+                            </label>
+                            <input
+                                id="mdblistBaseUrl"
+                                type="text"
+                                value={localMDBListBaseUrl}
+                                onChange={(e) => setLocalMDBListBaseUrl(e.target.value)}
+                                required={localMDBListEnabled}
+                                placeholder="https://api.mdblist.com"
+                                className="w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                            />
+                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                Default is fine for most users. Only change if using a custom MDBList instance.
+                            </p>
+                        </div>
+
+                        <button
+                            type="button"
+                            onClick={handleTestMDBList}
+                            disabled={testingMDBList || (!localMDBListApiKey && !envVars.mdblist_api_key_from_env) || !localMDBListBaseUrl}
+                            className="w-full py-2.5 px-4 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-900 dark:text-white font-medium rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                        >
+                            {testingMDBList ? (
+                                <>
+                                    <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                    </svg>
+                                    Testing connection...
+                                </>
+                            ) : mdblistTestSuccess ? (
+                                <>
+                                    <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
+                                    Connection successful!
+                                </>
+                            ) : (
+                                "Test MDBList Connection"
+                            )}
+                        </button>
+                    </div>
+                )}
+
+                {error && (
+                    <div className="p-4 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 text-sm">
+                        {error}
+                    </div>
+                )}
+            </div>
+
+            <div className="flex gap-3">
+                <button
+                    onClick={() => previousStep()}
+                    className="flex-1 py-3 px-4 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-900 dark:text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2"
+                >
+                    <ArrowLeft className="h-5 w-5" />
+                    Back
+                </button>
+                {!localMDBListEnabled && (
+                    <button
+                        onClick={handleSkip}
+                        className="flex-1 py-3 px-4 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-900 dark:text-white font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2"
+                    >
+                        Skip
+                        <ArrowRight className="h-5 w-5" />
+                    </button>
+                )}
+                <button
+                    onClick={handleNext}
+                    disabled={localMDBListEnabled && !localMDBListApiKey && !envVars.mdblist_api_key_from_env}
+                    className="flex-1 py-3 px-4 bg-gradient-to-r from-primary to-purple-600 hover:from-primary/90 hover:to-purple-600/90 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                >
+                    Next
+                    <ArrowRight className="h-5 w-5" />
+                </button>
+            </div>
+        </div>
+    );
+}
+
 function RotationStep({ wizardData, setWizardData }: { wizardData: WizardData; setWizardData: (data: WizardData) => void }) {
     const { nextStep, previousStep } = useWizard();
     const [localRotationEnabled, setLocalRotationEnabled] = useState(wizardData.rotationEnabled);
@@ -861,6 +1078,9 @@ function CompleteStep({ wizardData }: { wizardData: WizardData }) {
                     trakt_enabled: wizardData.traktEnabled,
                     trakt_client_id: wizardData.traktEnabled ? wizardData.traktClientId : null,
                     trakt_base_url: wizardData.traktBaseUrl,
+                    mdblist_enabled: wizardData.mdblistEnabled,
+                    mdblist_api_key: wizardData.mdblistEnabled ? wizardData.mdblistApiKey : null,
+                    mdblist_base_url: wizardData.mdblistBaseUrl,
                     libraries: wizardData.selectedLibraries,
                     auth_enabled: wizardData.authEnabled,
                     auth_username: wizardData.authUsername,
@@ -917,6 +1137,12 @@ function CompleteStep({ wizardData }: { wizardData: WizardData }) {
                     <span className="text-sm font-medium text-slate-700 dark:text-slate-300">Trakt</span>
                     <span className="text-sm text-slate-900 dark:text-white">
                         {wizardData.traktEnabled ? "Enabled" : "Disabled"}
+                    </span>
+                </div>
+                <div className="flex justify-between items-center">
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">MDBList</span>
+                    <span className="text-sm text-slate-900 dark:text-white">
+                        {wizardData.mdblistEnabled ? "Enabled" : "Disabled"}
                     </span>
                 </div>
                 <div className="flex justify-between items-center">

--- a/homescreen_hero/web/routers/config.py
+++ b/homescreen_hero/web/routers/config.py
@@ -234,6 +234,7 @@ class EnvVarsResponse(BaseModel):
     auth_password_from_env: bool
     auth_secret_from_env: bool
     trakt_client_id_from_env: bool
+    mdblist_api_key_from_env: bool
 
 
 # Incoming payload for quick start setup.
@@ -243,6 +244,9 @@ class QuickStartRequest(BaseModel):
     trakt_enabled: bool = False
     trakt_client_id: Optional[str] = None
     trakt_base_url: str = "https://api.trakt.tv"
+    mdblist_enabled: bool = False
+    mdblist_api_key: Optional[str] = None
+    mdblist_base_url: str = "https://api.mdblist.com"
     libraries: List[str] = []
     auth_enabled: bool = False
     auth_username: Optional[str] = None
@@ -1613,6 +1617,7 @@ def check_env_vars() -> EnvVarsResponse:
         auth_password_from_env=bool(os.getenv("HSH_AUTH_PASSWORD")),
         auth_secret_from_env=bool(os.getenv("HSH_AUTH_SECRET_KEY")),
         trakt_client_id_from_env=bool(os.getenv("HSH_TRAKT_CLIENT_ID")),
+        mdblist_api_key_from_env=bool(os.getenv("HSH_MDBLIST_API_KEY")),
     )
 
 
@@ -1687,6 +1692,27 @@ def quick_start_setup(payload: QuickStartRequest) -> ConfigSaveResponse:
             minimal_config["trakt"] = {
                 "enabled": False,
                 "base_url": payload.trakt_base_url,
+                "sources": []
+            }
+
+        # Add MDBList if enabled
+        # Use environment variable if payload value is empty
+        mdblist_api_key = payload.mdblist_api_key or os.getenv("HSH_MDBLIST_API_KEY", "")
+        mdblist_api_key_from_env = os.getenv("HSH_MDBLIST_API_KEY")
+
+        if payload.mdblist_enabled and mdblist_api_key:
+            minimal_config["mdblist"] = {
+                "enabled": True,
+                "base_url": payload.mdblist_base_url,
+                "sources": []
+            }
+            # Only write api_key to config if not from environment variable
+            if not mdblist_api_key_from_env:
+                minimal_config["mdblist"]["api_key"] = mdblist_api_key
+        else:
+            minimal_config["mdblist"] = {
+                "enabled": False,
+                "base_url": payload.mdblist_base_url,
                 "sources": []
             }
 


### PR DESCRIPTION
## Summary
- Added sessionStorage caching for group posters to prevent unnecessary API calls on page refresh
- Implemented image preloading to ensure all posters load simultaneously before display
- Animation now only plays on first load, subsequent page refreshes show posters instantly
- Includes previous MDBList setup wizard integration

## Changes
### GroupCoverMosaic.tsx
- Added sessionStorage-based caching with unique keys per group
- Implemented `preloadImages()` function to wait for all images to load before rendering
- Added `imagesLoaded` state to track preload completion
- Conditional animation - only applies on first load (when fetching from API)
- Prevents "popcorn" effect where posters pop in at different times

## Benefits
- **Faster UX**: Posters load from cache on refresh instead of making API calls
- **Smoother visuals**: All posters appear simultaneously, no staggered pop-in
- **Better performance**: Session-based cache reduces server load
- **Polished experience**: No repetitive animations on every page visit