### PR TITLE
Feature: Add Weighted and LRU rotation strategies

### DIFF
--- a/homescreen-hero-ui/src/pages/QuickStartPage.tsx
+++ b/homescreen-hero-ui/src/pages/QuickStartPage.tsx
@@ -804,7 +804,11 @@ function RotationStep({ wizardData, setWizardData }: { wizardData: WizardData; s
                             >
                                 <div className="relative">
                                     <Listbox.Button className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/70 text-left flex items-center justify-between">
-                                        <span>{wizardData.rotationStrategy === "weighted" ? "Weighted" : "Random"}</span>
+                                        <span>
+                                            {wizardData.rotationStrategy === "weighted" ? "Weighted" :
+                                             wizardData.rotationStrategy === "lru" ? "Least Recently Used" :
+                                             "Random"}
+                                        </span>
                                         <ChevronDown size={16} className="text-slate-400" />
                                     </Listbox.Button>
 
@@ -824,6 +828,15 @@ function RotationStep({ wizardData, setWizardData }: { wizardData: WizardData; s
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-white text-sm">
                                                 <span className="data-[selected]:font-medium">Weighted</span>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                        <Listbox.Option
+                                            value="lru"
+                                            className="px-4 py-3 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-white text-sm">
+                                                <span className="data-[selected]:font-medium">Least Recently Used</span>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
                                         </Listbox.Option>

--- a/homescreen-hero-ui/src/pages/QuickStartPage.tsx
+++ b/homescreen-hero-ui/src/pages/QuickStartPage.tsx
@@ -1013,10 +1013,10 @@ function RotationStep({ wizardData, setWizardData }: { wizardData: WizardData; s
                             <Listbox
                                 value={wizardData.rotationStrategy}
                                 onChange={(val) =>
-                                    setWizardData((prev) => ({
-                                        ...prev,
+                                    setWizardData({
+                                        ...wizardData,
                                         rotationStrategy: val,
-                                    }))
+                                    })
                                 }
                             >
                                 <div className="relative">

--- a/homescreen-hero-ui/src/pages/QuickStartPage.tsx
+++ b/homescreen-hero-ui/src/pages/QuickStartPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Wizard, useWizard } from "react-use-wizard";
-import { ArrowRight, ArrowLeft, Check, ExternalLink, Shield, Server, Database, Sparkles, Clock, ChevronDown, L>ist } from "lucide-react";
+import { ArrowRight, ArrowLeft, Check, ExternalLink, Shield, Server, Database, Sparkles, Clock, ChevronDown, List } from "lucide-react";
 import { Switch, Listbox } from "@headlessui/react";
 import PosterBackground from "../components/PosterBackground";
 import { getShuffledStaticPosters } from "../utils/staticPosters";

--- a/homescreen-hero-ui/src/pages/QuickStartPage.tsx
+++ b/homescreen-hero-ui/src/pages/QuickStartPage.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Wizard, useWizard } from "react-use-wizard";
-import { ArrowRight, ArrowLeft, Check, ExternalLink, Shield, Server, Database, Sparkles, Clock } from "lucide-react";
-import { Switch } from "@headlessui/react";
+import { ArrowRight, ArrowLeft, Check, ExternalLink, Shield, Server, Database, Sparkles, Clock, ChevronDown } from "lucide-react";
+import { Switch, Listbox } from "@headlessui/react";
 import PosterBackground from "../components/PosterBackground";
 import { getShuffledStaticPosters } from "../utils/staticPosters";
 
@@ -793,11 +793,45 @@ function RotationStep({ wizardData, setWizardData }: { wizardData: WizardData; s
                             <label htmlFor="strategy" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
                                 Strategy
                             </label>
-                            <div className="w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-white">
-                                Random
-                            </div>
+                            <Listbox
+                                value={wizardData.rotationStrategy}
+                                onChange={(val) =>
+                                    setWizardData((prev) => ({
+                                        ...prev,
+                                        rotationStrategy: val,
+                                    }))
+                                }
+                            >
+                                <div className="relative">
+                                    <Listbox.Button className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/70 text-left flex items-center justify-between">
+                                        <span>{wizardData.rotationStrategy === "weighted" ? "Weighted" : "Random"}</span>
+                                        <ChevronDown size={16} className="text-slate-400" />
+                                    </Listbox.Button>
+
+                                    <Listbox.Options className="absolute z-10 mt-1 w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg shadow-lg overflow-hidden focus:outline-none">
+                                        <Listbox.Option
+                                            value="random"
+                                            className="px-4 py-3 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-white text-sm">
+                                                <span className="data-[selected]:font-medium">Random</span>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                        <Listbox.Option
+                                            value="weighted"
+                                            className="px-4 py-3 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-white text-sm">
+                                                <span className="data-[selected]:font-medium">Weighted</span>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                    </Listbox.Options>
+                                </div>
+                            </Listbox>
                             <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                                Random is currently the only supported strategy
+                                Choose how groups are prioritized during rotation
                             </p>
                         </div>
 

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -559,7 +559,11 @@ export default function SettingsPage() {
                             >
                                 <div className="relative">
                                     <Listbox.Button className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 text-left flex items-center justify-between data-[disabled]:opacity-50">
-                                        <span>{rotationSettings.strategy === "weighted" ? "Weighted" : "Random"}</span>
+                                        <span>
+                                            {rotationSettings.strategy === "weighted" ? "Weighted" :
+                                             rotationSettings.strategy === "lru" ? "Least Recently Used" :
+                                             "Random"}
+                                        </span>
                                         <ChevronDown size={16} className="text-slate-400" />
                                     </Listbox.Button>
 
@@ -579,6 +583,15 @@ export default function SettingsPage() {
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
                                                 <span className="data-[selected]:font-medium">Weighted</span>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                        <Listbox.Option
+                                            value="lru"
+                                            className="px-3 py-2 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
+                                                <span className="data-[selected]:font-medium">Least Recently Used</span>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
                                         </Listbox.Option>

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -546,7 +546,7 @@ export default function SettingsPage() {
                             />
                         </FieldRow>
 
-                        <FieldRow label="Strategy" hint="Random is currently the only supported strategy.">
+                        <FieldRow label="Strategy" hint="Choose how groups are prioritized during rotation.">
                             <Listbox
                                 value={rotationSettings.strategy}
                                 onChange={(val) =>
@@ -559,7 +559,7 @@ export default function SettingsPage() {
                             >
                                 <div className="relative">
                                     <Listbox.Button className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 text-left flex items-center justify-between data-[disabled]:opacity-50">
-                                        <span>Random</span>
+                                        <span>{rotationSettings.strategy === "weighted" ? "Weighted" : "Random"}</span>
                                         <ChevronDown size={16} className="text-slate-400" />
                                     </Listbox.Button>
 
@@ -570,6 +570,15 @@ export default function SettingsPage() {
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
                                                 <span className="data-[selected]:font-medium">Random</span>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                        <Listbox.Option
+                                            value="weighted"
+                                            className="px-3 py-2 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
+                                                <span className="data-[selected]:font-medium">Weighted</span>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
                                         </Listbox.Option>

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -43,7 +43,7 @@ class RotationSettings(BaseModel):
     )
     strategy: str = Field(
         default="random",
-        description="Selection strategy: 'random' (process groups in config order) or 'weighted' (process groups by weight, highest first)",
+        description="Selection strategy: 'random' (random selection), 'weighted' (sort groups by weight), or 'lru' (pick least recently used collections)",
     )
     allow_repeats: bool = Field(
         default=False,

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -43,7 +43,7 @@ class RotationSettings(BaseModel):
     )
     strategy: str = Field(
         default="random",
-        description="Selection strategy: 'random', 'weighted', etc.",
+        description="Selection strategy: 'random' (process groups in config order) or 'weighted' (process groups by weight, highest first)",
     )
     allow_repeats: bool = Field(
         default=False,
@@ -71,7 +71,7 @@ class CollectionGroupConfig(BaseModel):
     weight: int = Field(
         default=1,
         ge=1,
-        description="Relative priority of this group vs other groups (future use)",
+        description="Relative priority of this group vs other groups (used when strategy='weighted'). Higher weight = higher priority.",
     )
     min_gap_rotations: int = Field(
         default=0,

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -16,6 +16,33 @@ from .db import CollectionUsage
 
 logger = logging.getLogger(__name__)
 
+
+def _get_ordered_groups(
+    groups: List[CollectionGroupConfig],
+    strategy: str,
+    rng: random.Random,
+) -> List[CollectionGroupConfig]:
+    """
+    Order groups based on the selection strategy.
+
+    Args:
+        groups: List of all groups from config
+        strategy: Selection strategy ('random' or 'weighted')
+        rng: Random number generator for reproducibility
+
+    Returns:
+        Ordered list of groups to process
+    """
+    if strategy == "weighted":
+        # Sort groups by weight (descending), then by config order for ties
+        # Higher weight = processed first = higher priority
+        logger.debug("Using weighted strategy: sorting groups by weight")
+        return sorted(groups, key=lambda g: (-g.weight, groups.index(g)))
+    else:
+        # Default 'random' strategy: keep original config order
+        logger.debug("Using random strategy: keeping original group order")
+        return list(groups)
+
 def _parse_month_day(value: str) -> Tuple[int, int]:
     try:
         month_str, day_str = value.split("-", 1)
@@ -107,7 +134,10 @@ def run_rotation_with_history(
         "Starting rotation with history: %d max rotations observed", max_rotation_id
     )
 
-    for group in config.groups:
+    # Order groups based on strategy
+    ordered_groups = _get_ordered_groups(config.groups, config.rotation.strategy, rng)
+
+    for group in ordered_groups:
         is_active = _group_is_active(group, today)
 
         result = GroupSelectionResult(
@@ -227,9 +257,13 @@ def run_rotation_dry(
     selected_set: Set[str] = set()
     group_results: List[GroupSelectionResult] = []
 
-    # Groups are considered in the order they appear in config.yaml
+    # Groups are ordered based on strategy (weighted or random/config order)
     logger.info("Starting dry rotation for %d groups", len(config.groups))
-    for group in config.groups:
+
+    # Order groups based on strategy
+    ordered_groups = _get_ordered_groups(config.groups, config.rotation.strategy, rng)
+
+    for group in ordered_groups:
         is_active = _group_is_active(group, today)
 
         result = GroupSelectionResult(

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -27,7 +27,7 @@ def _get_ordered_groups(
 
     Args:
         groups: List of all groups from config
-        strategy: Selection strategy ('random' or 'weighted')
+        strategy: Selection strategy ('random', 'weighted', or 'lru')
         rng: Random number generator for reproducibility
 
     Returns:
@@ -39,9 +39,50 @@ def _get_ordered_groups(
         logger.debug("Using weighted strategy: sorting groups by weight")
         return sorted(groups, key=lambda g: (-g.weight, groups.index(g)))
     else:
-        # Default 'random' strategy: keep original config order
-        logger.debug("Using random strategy: keeping original group order")
+        # Default 'random' and 'lru' strategies: keep original config order
+        # LRU strategy affects collection selection within groups, not group order
+        logger.debug(f"Using {strategy} strategy: keeping original group order")
         return list(groups)
+
+
+def _select_collections_from_group(
+    available: List[str],
+    k: int,
+    strategy: str,
+    usage_map: Dict[str, CollectionUsage],
+    rng: random.Random,
+) -> List[str]:
+    """
+    Select k collections from the available list based on strategy.
+
+    Args:
+        available: List of collection names to choose from
+        k: Number of collections to select
+        strategy: Selection strategy ('random', 'weighted', or 'lru')
+        usage_map: Mapping of collection names to usage data
+        rng: Random number generator for reproducibility
+
+    Returns:
+        List of selected collection names
+    """
+    if strategy == "lru":
+        # Sort by last_rotation_id (ascending), prioritizing least recently used
+        # Collections never used (None) are sorted first
+        def sort_key(collection_name: str) -> Tuple[int, int]:
+            usage = usage_map.get(collection_name)
+            if usage is None or usage.last_rotation_id is None:
+                # Never used - highest priority (sort first)
+                return (0, 0)
+            else:
+                # Used before - sort by rotation ID (older = higher priority)
+                # Secondary sort by times_used (less used = higher priority)
+                return (1, usage.last_rotation_id)
+
+        sorted_collections = sorted(available, key=sort_key)
+        return sorted_collections[:k]
+    else:
+        # Default random selection
+        return rng.sample(available, k=k)
 
 def _parse_month_day(value: str) -> Tuple[int, int]:
     try:
@@ -206,7 +247,10 @@ def run_rotation_with_history(
             group_results.append(result)
             continue
 
-        chosen = rng.sample(available, k=k)
+        # Select collections based on strategy
+        chosen = _select_collections_from_group(
+            available, k, config.rotation.strategy, usage_map, rng
+        )
 
         selected.extend(chosen)
         selected_set.update(chosen)
@@ -262,6 +306,9 @@ def run_rotation_dry(
 
     # Order groups based on strategy
     ordered_groups = _get_ordered_groups(config.groups, config.rotation.strategy, rng)
+
+    # For dry run, we don't have usage history, so use empty map
+    usage_map: Dict[str, CollectionUsage] = {}
 
     for group in ordered_groups:
         is_active = _group_is_active(group, today)
@@ -327,7 +374,10 @@ def run_rotation_dry(
             group_results.append(result)
             continue
 
-        chosen = rng.sample(available, k=k)
+        # Select collections based on strategy
+        chosen = _select_collections_from_group(
+            available, k, config.rotation.strategy, usage_map, rng
+        )
 
         selected.extend(chosen)
         selected_set.update(chosen)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -9,6 +9,7 @@ from homescreen_hero.core.rotation import (
     _is_date_in_range,
     _group_is_active,
     _passes_gap_rule,
+    _get_ordered_groups,
 )
 from homescreen_hero.core.config.schema import CollectionGroupConfig, DateRange
 
@@ -184,3 +185,137 @@ class TestPassesGapRule:
         }
         # Current rotation is 10, last used at 7, gap is exactly 3
         assert _passes_gap_rule("Test Collection", group, max_rotation_id=10, usage_map=usage_map) is True
+
+
+class TestGetOrderedGroups:
+    """Tests for _get_ordered_groups function"""
+
+    def test_random_strategy_preserves_order(self):
+        """Random strategy should preserve original config order"""
+        groups = [
+            CollectionGroupConfig(
+                name="Group A",
+                enabled=True,
+                weight=5,
+                collections=["Collection A"]
+            ),
+            CollectionGroupConfig(
+                name="Group B",
+                enabled=True,
+                weight=10,
+                collections=["Collection B"]
+            ),
+            CollectionGroupConfig(
+                name="Group C",
+                enabled=True,
+                weight=1,
+                collections=["Collection C"]
+            ),
+        ]
+        rng = random.Random(42)
+        ordered = _get_ordered_groups(groups, "random", rng)
+
+        # Order should be preserved
+        assert ordered[0].name == "Group A"
+        assert ordered[1].name == "Group B"
+        assert ordered[2].name == "Group C"
+
+    def test_weighted_strategy_sorts_by_weight(self):
+        """Weighted strategy should sort groups by weight (descending)"""
+        groups = [
+            CollectionGroupConfig(
+                name="Group A",
+                enabled=True,
+                weight=5,
+                collections=["Collection A"]
+            ),
+            CollectionGroupConfig(
+                name="Group B",
+                enabled=True,
+                weight=10,
+                collections=["Collection B"]
+            ),
+            CollectionGroupConfig(
+                name="Group C",
+                enabled=True,
+                weight=1,
+                collections=["Collection C"]
+            ),
+        ]
+        rng = random.Random(42)
+        ordered = _get_ordered_groups(groups, "weighted", rng)
+
+        # Should be sorted by weight descending: B(10), A(5), C(1)
+        assert ordered[0].name == "Group B"
+        assert ordered[0].weight == 10
+        assert ordered[1].name == "Group A"
+        assert ordered[1].weight == 5
+        assert ordered[2].name == "Group C"
+        assert ordered[2].weight == 1
+
+    def test_weighted_strategy_with_equal_weights(self):
+        """Weighted strategy should preserve config order for groups with same weight"""
+        groups = [
+            CollectionGroupConfig(
+                name="Group A",
+                enabled=True,
+                weight=5,
+                collections=["Collection A"]
+            ),
+            CollectionGroupConfig(
+                name="Group B",
+                enabled=True,
+                weight=5,
+                collections=["Collection B"]
+            ),
+            CollectionGroupConfig(
+                name="Group C",
+                enabled=True,
+                weight=5,
+                collections=["Collection C"]
+            ),
+        ]
+        rng = random.Random(42)
+        ordered = _get_ordered_groups(groups, "weighted", rng)
+
+        # All have same weight, should preserve original order
+        assert ordered[0].name == "Group A"
+        assert ordered[1].name == "Group B"
+        assert ordered[2].name == "Group C"
+
+    def test_weighted_strategy_mixed_weights(self):
+        """Weighted strategy with mixed weights including duplicates"""
+        groups = [
+            CollectionGroupConfig(
+                name="Group A",
+                enabled=True,
+                weight=3,
+                collections=["Collection A"]
+            ),
+            CollectionGroupConfig(
+                name="Group B",
+                enabled=True,
+                weight=10,
+                collections=["Collection B"]
+            ),
+            CollectionGroupConfig(
+                name="Group C",
+                enabled=True,
+                weight=3,
+                collections=["Collection C"]
+            ),
+            CollectionGroupConfig(
+                name="Group D",
+                enabled=True,
+                weight=7,
+                collections=["Collection D"]
+            ),
+        ]
+        rng = random.Random(42)
+        ordered = _get_ordered_groups(groups, "weighted", rng)
+
+        # Should be: B(10), D(7), A(3), C(3) - A before C due to config order
+        assert ordered[0].name == "Group B"
+        assert ordered[1].name == "Group D"
+        assert ordered[2].name == "Group A"
+        assert ordered[3].name == "Group C"

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -10,6 +10,7 @@ from homescreen_hero.core.rotation import (
     _group_is_active,
     _passes_gap_rule,
     _get_ordered_groups,
+    _select_collections_from_group,
 )
 from homescreen_hero.core.config.schema import CollectionGroupConfig, DateRange
 
@@ -319,3 +320,80 @@ class TestGetOrderedGroups:
         assert ordered[1].name == "Group D"
         assert ordered[2].name == "Group A"
         assert ordered[3].name == "Group C"
+
+
+class TestSelectCollectionsFromGroup:
+    """Tests for _select_collections_from_group function"""
+
+    def test_random_strategy_uses_random_sample(self):
+        """Random strategy should use random sampling"""
+        available = ["Collection A", "Collection B", "Collection C", "Collection D"]
+        usage_map = {}
+        rng = random.Random(42)
+
+        chosen = _select_collections_from_group(available, 2, "random", usage_map, rng)
+
+        assert len(chosen) == 2
+        assert all(c in available for c in chosen)
+
+    def test_lru_strategy_prioritizes_never_used(self):
+        """LRU strategy should prioritize collections never used"""
+        available = ["Never Used", "Used Recently", "Used Long Ago"]
+        usage_map = {
+            "Used Recently": MockCollectionUsage("Used Recently", 10),
+            "Used Long Ago": MockCollectionUsage("Used Long Ago", 5),
+            # "Never Used" not in usage_map
+        }
+        rng = random.Random(42)
+
+        chosen = _select_collections_from_group(available, 2, "lru", usage_map, rng)
+
+        # Should pick "Never Used" first, then "Used Long Ago" (older rotation ID)
+        assert chosen[0] == "Never Used"
+        assert chosen[1] == "Used Long Ago"
+
+    def test_lru_strategy_orders_by_rotation_id(self):
+        """LRU strategy should order by last_rotation_id ascending"""
+        available = ["Recent 1", "Old 1", "Recent 2", "Old 2"]
+        usage_map = {
+            "Recent 1": MockCollectionUsage("Recent 1", 20),
+            "Old 1": MockCollectionUsage("Old 1", 5),
+            "Recent 2": MockCollectionUsage("Recent 2", 15),
+            "Old 2": MockCollectionUsage("Old 2", 8),
+        }
+        rng = random.Random(42)
+
+        chosen = _select_collections_from_group(available, 3, "lru", usage_map, rng)
+
+        # Should be ordered by rotation ID: Old 1 (5), Old 2 (8), Recent 2 (15)
+        assert chosen == ["Old 1", "Old 2", "Recent 2"]
+
+    def test_lru_strategy_all_never_used(self):
+        """LRU strategy with all collections never used"""
+        available = ["A", "B", "C", "D"]
+        usage_map = {}
+        rng = random.Random(42)
+
+        chosen = _select_collections_from_group(available, 2, "lru", usage_map, rng)
+
+        # All have same priority (never used), should take first k from sorted
+        assert len(chosen) == 2
+        assert all(c in available for c in chosen)
+
+    def test_lru_strategy_respects_k_parameter(self):
+        """LRU strategy should respect the k parameter"""
+        available = ["A", "B", "C", "D", "E"]
+        usage_map = {
+            "A": MockCollectionUsage("A", 1),
+            "B": MockCollectionUsage("B", 2),
+            "C": MockCollectionUsage("C", 3),
+            "D": MockCollectionUsage("D", 4),
+            "E": MockCollectionUsage("E", 5),
+        }
+        rng = random.Random(42)
+
+        # Request only 3 collections
+        chosen = _select_collections_from_group(available, 3, "lru", usage_map, rng)
+
+        # Should get oldest 3: A(1), B(2), C(3)
+        assert chosen == ["A", "B", "C"]


### PR DESCRIPTION
## Feature: Add Weighted and LRU rotation strategies

Adds two new rotation strategies to give users more control over how collections are selected during rotations:
1. **Weighted Strategy** - Prioritize groups by weight (group-level)
2. **LRU Strategy** - Select least recently used collections (collection-level)

### Background

Previously, HomeScreen Hero only supported random selection with uniform probability. Users wanted more control to:
- Prioritize certain groups over others (e.g., always check seasonal collections first)
- Ensure fair rotation by tracking usage history and favoring neglected collections

### Changes

#### 1. Weighted Strategy (Group-Level Prioritization)

**How it works:**
- Groups are sorted by their `weight` field in descending order
- Higher weight = processed first = higher chance of selection
- Groups with equal weight maintain config order
- Works with existing `weight` field in config (default: 1)

**Example:**
```yaml
groups:
  - name: "Holiday Specials"
    weight: 10  # Highest priority
    max_picks: 2
    collections: [...]
  
  - name: "New Releases"
    weight: 5   # Medium priority
    max_picks: 2
    collections: [...]
  
  - name: "Classic Films"
    weight: 1   # Lowest priority (default)
    max_picks: 1
    collections: [...]
```

With `strategy: weighted` and `max_collections: 5`:
- Holiday Specials gets processed first (up to 2 collections)
- New Releases gets processed second (up to 2 collections)
- Classic Films gets processed last (up to 1 collection)


#### 2. LRU Strategy (Collection-Level Selection)

**How it works:**
- When selecting collections from a group, prioritize least recently used
- Collections never used get highest priority
- Collections are sorted by `last_rotation_id` (ascending)
- Uses existing `CollectionUsage` database table (no schema changes)

**Example rotation history:**
```
Collection A: Never used → Priority 1 (selected first)
Collection B: Last used rotation #5 → Priority 2
Collection C: Last used rotation #12 → Priority 3
Collection D: Last used rotation #15 → Priority 4 (selected last)
```

**Benefits:**
- Ensures fair rotation - all collections get featured eventually
- Prevents same collections appearing repeatedly
- Honors user intent: "I added this collection, I want to see it rotated"


