### PR TITLE
Feature: Add visibility filter tabs to Active Collections

### DIFF
--- a/homescreen-hero-ui/src/components/ActiveCollectionsCard.tsx
+++ b/homescreen-hero-ui/src/components/ActiveCollectionsCard.tsx
@@ -1,9 +1,13 @@
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 export type ActiveCollection = {
     title: string;
     poster_url?: string | null;
     library?: string | null;
+    promoted_to_own_home?: boolean;
+    promoted_to_shared?: boolean;
+    promoted_to_recommended?: boolean;
 };
 
 export default function ActiveCollectionsCard({
@@ -14,6 +18,20 @@ export default function ActiveCollectionsCard({
     loading?: boolean;
 }) {
     const navigate = useNavigate();
+    const [visibilityFilter, setVisibilityFilter] = useState<"all" | "my_home" | "shared" | "recommended">("all");
+
+    const filteredCollections = useMemo(() => {
+        if (visibilityFilter === "all") {
+            return collections;
+        } else if (visibilityFilter === "my_home") {
+            return collections.filter(c => c.promoted_to_own_home);
+        } else if (visibilityFilter === "shared") {
+            return collections.filter(c => c.promoted_to_shared);
+        } else if (visibilityFilter === "recommended") {
+            return collections.filter(c => c.promoted_to_recommended);
+        }
+        return collections;
+    }, [collections, visibilityFilter]);
 
     const handleCollectionClick = (collection: ActiveCollection) => {
         if (collection.library) {
@@ -23,20 +41,61 @@ export default function ActiveCollectionsCard({
         }
     };
     return (
-        <div className="rounded-2xl bg-white border border-slate-200/80 shadow-sm hover:shadow-md p-5 dark:bg-card-dark dark:border-slate-800/80 dark:hover:border-slate-700 transition-all duration-300">
-            <div className="flex items-end justify-between mb-5">
+        <div className="rounded-2xl bg-white border border-slate-200/80 shadow-sm hover:shadow-md px-5 py-4 dark:bg-card-dark dark:border-slate-800/80 dark:hover:border-slate-700 transition-all duration-300">
+            <div className="flex items-center justify-between mb-4">
                 <div>
-                    <div className="flex items-center gap-3">
-                        <h3 className="text-lg font-bold text-slate-900 dark:text-white tracking-tight">Active Collections</h3>
-                        {!loading && collections.length > 0 && (
-                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-semibold bg-primary/10 text-primary border border-primary/20">
-                                {collections.length}
-                            </span>
-                        )}
-                    </div>
+                    <h3 className="text-lg font-bold text-slate-900 dark:text-white tracking-tight">Active Collections</h3>
                     <p className="text-sm text-slate-600 dark:text-slate-400 mt-0.5">
                         Currently featured on your Plex home screen
                     </p>
+                </div>
+
+                {/* Filter Tabs */}
+                <div className="flex gap-2">
+                <button
+                    type="button"
+                    onClick={() => setVisibilityFilter("all")}
+                    className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition ${
+                        visibilityFilter === "all"
+                            ? "bg-primary text-white"
+                            : "bg-slate-200 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700"
+                    }`}
+                >
+                    All {!loading && collections.length > 0 && `(${collections.length})`}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setVisibilityFilter("my_home")}
+                    className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition ${
+                        visibilityFilter === "my_home"
+                            ? "bg-primary text-white"
+                            : "bg-slate-200 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700"
+                    }`}
+                >
+                    My Home {!loading && `(${collections.filter(c => c.promoted_to_own_home).length})`}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setVisibilityFilter("shared")}
+                    className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition ${
+                        visibilityFilter === "shared"
+                            ? "bg-primary text-white"
+                            : "bg-slate-200 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700"
+                    }`}
+                >
+                    Shared Users {!loading && `(${collections.filter(c => c.promoted_to_shared).length})`}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setVisibilityFilter("recommended")}
+                    className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition ${
+                        visibilityFilter === "recommended"
+                            ? "bg-primary text-white"
+                            : "bg-slate-200 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700"
+                    }`}
+                >
+                    Recommended {!loading && `(${collections.filter(c => c.promoted_to_recommended).length})`}
+                </button>
                 </div>
             </div>
 
@@ -49,11 +108,13 @@ export default function ActiveCollectionsCard({
                         </div>
                     ))}
                 </div>
-            ) : collections.length === 0 ? (
-                <div className="text-sm text-slate-600 dark:text-slate-400 py-4">No active collections yet.</div>
+            ) : filteredCollections.length === 0 ? (
+                <div className="text-sm text-slate-600 dark:text-slate-400 py-4">
+                    No active collections {visibilityFilter !== "all" ? "in this category" : "yet"}.
+                </div>
             ) : (
                 <div className="flex gap-4 overflow-x-auto px-2 py-2 -mx-2 -my-2 scrollbar-hover-only">
-                    {collections.map((c, index) => (
+                    {filteredCollections.map((c, index) => (
                         <button
                             key={c.title}
                             onClick={() => handleCollectionClick(c)}

--- a/homescreen_hero/web/routers/collections.py
+++ b/homescreen_hero/web/routers/collections.py
@@ -20,6 +20,9 @@ class ActiveCollectionOut(BaseModel):
     title: str
     library: Optional[str] = None
     poster_url: Optional[str] = None
+    promoted_to_own_home: bool = False
+    promoted_to_shared: bool = False
+    promoted_to_recommended: bool = False
 
 
 class ActiveCollectionsResponse(BaseModel):
@@ -184,8 +187,14 @@ def get_active_collections() -> ActiveCollectionsResponse:
                     # Get the visibility/hub settings for this collection
                     hub = col.visibility()
 
-                    # Check if this collection is visible on the home screen
-                    if getattr(hub, "promotedToOwnHome", False):
+                    # Get all three visibility flags
+                    # Note: The correct attribute name is "promotedToSharedHome" not "promotedToShared"
+                    promoted_own = getattr(hub, "promotedToOwnHome", False)
+                    promoted_shared = getattr(hub, "promotedToSharedHome", False)
+                    promoted_recommended = getattr(hub, "promotedToRecommended", False)
+
+                    # Include if ANY visibility is enabled
+                    if promoted_own or promoted_shared or promoted_recommended:
                         poster_url = None
                         if getattr(col, "thumb", None):
                             try:
@@ -206,6 +215,9 @@ def get_active_collections() -> ActiveCollectionsResponse:
                                 title=col.title,
                                 poster_url=poster_url,
                                 library=section.title,
+                                promoted_to_own_home=promoted_own,
+                                promoted_to_shared=promoted_shared,
+                                promoted_to_recommended=promoted_recommended,
                             )
                         )
                 except Exception as e:


### PR DESCRIPTION
## Summary
- Added visibility filter tabs to the Active Collections card to filter by "All", "My Home", "Shared Users", and "Recommended"
- Extended backend API to include visibility flags (`promoted_to_own_home`, `promoted_to_shared`, `promoted_to_recommended`)
- Collections now display based on any visibility setting (not just "My Home")

## Changes
- **Frontend** ([ActiveCollectionsCard.tsx](homescreen-hero-ui/src/components/ActiveCollectionsCard.tsx)):
  - Added filter tabs with counts for each visibility category
  - Implemented `useMemo` hook to efficiently filter collections based on selected tab
  - Updated layout to accommodate filter tabs in the header
  - Shows contextual empty state message based on active filter

- **Backend** ([collections.py](homescreen_hero/web/routers/collections.py)):
  - Added three new fields to `ActiveCollectionOut`: `promoted_to_own_home`, `promoted_to_shared`, `promoted_to_recommended`
  - Updated collection fetching logic to check all three visibility flags
  - Collections are now included if ANY visibility flag is enabled (not just "promotedToOwnHome")
