### PR TITLE
Fix: Ignore Unraid template placeholder URLs

### DIFF
--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -157,8 +157,9 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             )
 
         # Tautulli base URL override (optional)
+        # Skip placeholder value from Unraid template
         tautulli_base_url = os.getenv("HSH_TAUTULLI_BASE_URL")
-        if tautulli_base_url:
+        if tautulli_base_url and tautulli_base_url != "http://your-tautulli-url:8181":
             logger.info("Using Tautulli base URL from HSH_TAUTULLI_BASE_URL environment variable")
             config.tautulli.base_url = tautulli_base_url
 
@@ -174,8 +175,9 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             )
 
         # Seerr base URL override (optional)
+        # Skip placeholder value from Unraid template
         seerr_base_url = os.getenv("HSH_SEERR_BASE_URL")
-        if seerr_base_url:
+        if seerr_base_url and seerr_base_url != "http://your-seerr-url:5055":
             logger.info("Using Seerr base URL from HSH_SEERR_BASE_URL environment variable")
             config.seerr.base_url = seerr_base_url
 


### PR DESCRIPTION
## Summary
- Fixes issue where Unraid template placeholder URLs override user-configured values
- When users configure Tautulli/Seerr via the UI, the placeholder env vars (`http://your-tautulli-url:8181`, `http://your-seerr-url:5055`) were taking precedence over config.yaml values
- Now these specific placeholder values are ignored, allowing config.yaml values to be used
