### PR TITLE
Feature: Per-Library Limits, Copy Watch History Tool, User-Requested Changes

### DIFF
--- a/homescreen-hero-ui/package-lock.json
+++ b/homescreen-hero-ui/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@types/react-datepicker": "^6.2.0",
         "class-variance-authority": "^0.7.1",
@@ -2213,6 +2214,68 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/homescreen-hero-ui/package.json
+++ b/homescreen-hero-ui/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@types/react-datepicker": "^6.2.0",
     "class-variance-authority": "^0.7.1",

--- a/homescreen-hero-ui/src/components/ActiveStreamsCard.tsx
+++ b/homescreen-hero-ui/src/components/ActiveStreamsCard.tsx
@@ -17,6 +17,8 @@ type ActiveStream = {
     title: string;
     media_type: string;
     progress_percent: number | null;
+    season_number: number | null;
+    episode_number: number | null;
 };
 
 type CurrentActivity = {
@@ -254,6 +256,11 @@ export default function ActiveStreamsCard({ loading }: { loading?: boolean }) {
                                         <p className="text-sm text-slate-400 mt-1">
                                             {stream.title}
                                         </p>
+                                        {stream.season_number !== null && stream.episode_number !== null && (
+                                            <p className="text-xs text-slate-500 mt-0.5">
+                                                Season {stream.season_number}, Episode {stream.episode_number}
+                                            </p>
+                                        )}
                                     </div>
                                     <div className="flex-shrink-0">
                                         <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-slate-700 text-slate-300 uppercase">

--- a/homescreen-hero-ui/src/components/tools/CopyWatchHistory.tsx
+++ b/homescreen-hero-ui/src/components/tools/CopyWatchHistory.tsx
@@ -25,6 +25,8 @@ import {
     DialogDescription,
     DialogCloseButton,
 } from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 type HomeUser = {
     id: number;
@@ -88,8 +90,21 @@ export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
         errors: string[];
     } | null>(null);
 
+    // Progress state for SSE
+    const [progress, setProgress] = useState<{
+        library: string;
+        libraryIndex: number;
+        totalLibraries: number;
+        processed: number;
+        total: number;
+        itemType: string;
+    } | null>(null);
+
     // Toast
     const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+
+    // Confirm dialog
+    const [showConfirm, setShowConfirm] = useState(false);
 
     // Fetch home users on mount
     useEffect(() => {
@@ -139,14 +154,15 @@ export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
         }
     };
 
-    // Apply changes
+    // Apply changes with SSE streaming for progress
     const handleApply = async () => {
         if (!sourceUser || !targetUser) return;
 
         setStep("applying");
+        setProgress(null);
 
         try {
-            const response = await fetchWithAuth("/api/tools/copy-watch-history/apply", {
+            const response = await fetchWithAuth("/api/tools/copy-watch-history/apply-stream", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -161,9 +177,67 @@ export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
                 throw new Error(error.detail || "Failed to apply changes");
             }
 
-            const data = await response.json();
-            setApplyResult(data);
-            setStep("complete");
+            // Read the SSE stream
+            const reader = response.body?.getReader();
+            if (!reader) throw new Error("No response body");
+
+            const decoder = new TextDecoder();
+            let buffer = "";
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                buffer += decoder.decode(value, { stream: true });
+
+                // Process complete SSE events (each ends with \n\n)
+                const events = buffer.split("\n\n");
+                buffer = events.pop() || ""; // Keep incomplete event in buffer
+
+                for (const event of events) {
+                    if (!event.trim()) continue;
+
+                    // Parse "data: {...}" format
+                    const dataMatch = event.match(/^data: (.+)$/m);
+                    if (!dataMatch) continue;
+
+                    try {
+                        const data = JSON.parse(dataMatch[1]);
+
+                        if (data.type === "library_start") {
+                            setProgress({
+                                library: data.library,
+                                libraryIndex: data.library_index,
+                                totalLibraries: data.total_libraries,
+                                processed: 0,
+                                total: 0,
+                                itemType: "",
+                            });
+                        } else if (data.type === "progress") {
+                            setProgress((prev) => ({
+                                library: data.library,
+                                libraryIndex: prev?.libraryIndex ?? 0,
+                                totalLibraries: prev?.totalLibraries ?? 1,
+                                processed: data.processed,
+                                total: data.total,
+                                itemType: data.item_type,
+                            }));
+                        } else if (data.type === "complete") {
+                            setApplyResult({
+                                success: data.success,
+                                movies_updated: data.movies_updated,
+                                episodes_updated: data.episodes_updated,
+                                errors: data.errors,
+                            });
+                            setStep("complete");
+                        } else if (data.type === "error") {
+                            throw new Error(data.message);
+                        }
+                    } catch (parseError) {
+                        console.error("Failed to parse SSE event:", parseError);
+                    }
+                }
+            }
         } catch (e) {
             setToast({ message: `Apply failed: ${e instanceof Error ? e.message : String(e)}`, type: "error" });
             setStep("preview");
@@ -412,14 +486,6 @@ export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
                                         </div>
                                     )}
 
-                                {/* Shows affected */}
-                                {previewCounts.shows_affected > 0 && (
-                                    <p className="mt-4 text-sm text-slate-400">
-                                        Across {previewCounts.shows_affected} TV show
-                                        {previewCounts.shows_affected !== 1 ? "s" : ""}
-                                    </p>
-                                )}
-
                                 {/* No changes */}
                                 {previewCounts.movies_to_mark_watched === 0 &&
                                     previewCounts.episodes_to_mark_watched === 0 &&
@@ -436,7 +502,32 @@ export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
                         <div className="flex flex-col items-center justify-center py-12">
                             <Loader2 className="h-10 w-10 animate-spin text-primary mb-4" />
                             <p className="text-lg font-medium text-white">Applying changes...</p>
-                            <p className="text-sm text-slate-400 mt-1">This may take a while for large libraries</p>
+
+                            {progress ? (
+                                <div className="w-full max-w-md mt-6 space-y-3">
+                                    {/* Library progress */}
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-slate-300">
+                                            Processing <span className="font-medium text-white">{progress.library}</span>
+                                        </span>
+                                        <span className="text-slate-400">
+                                            Library {progress.libraryIndex + 1} of {progress.totalLibraries}
+                                        </span>
+                                    </div>
+
+                                    {/* Item progress bar */}
+                                    {progress.total > 0 && (
+                                        <>
+                                            <Progress value={(progress.processed / progress.total) * 100} />
+                                            <p className="text-xs text-slate-500 text-center">
+                                                {progress.processed} / {progress.total} {progress.itemType}
+                                            </p>
+                                        </>
+                                    )}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-slate-400 mt-1">Connecting to Plex...</p>
+                            )}
                         </div>
                     ) : step === "complete" && applyResult ? (
                         <div className="space-y-6">
@@ -547,7 +638,7 @@ export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
                                 </button>
                                 <button
                                     type="button"
-                                    onClick={handleApply}
+                                    onClick={() => setShowConfirm(true)}
                                     disabled={
                                         previewCounts?.movies_to_mark_watched === 0 &&
                                         previewCounts?.episodes_to_mark_watched === 0 &&
@@ -577,6 +668,24 @@ export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
                     )}
                 </DialogFooter>
             </DialogContent>
+
+            <ConfirmDialog
+                open={showConfirm}
+                onOpenChange={setShowConfirm}
+                title="Apply Watch History Changes?"
+                description={
+                    conflictMode === "mirror"
+                        ? `This will update ${targetUser?.title}'s watch history to match ${sourceUser?.title}'s. Some items may be marked as unwatched. This cannot be easily undone.`
+                        : `This will copy ${sourceUser?.title}'s watched items to ${targetUser?.title}'s history. This cannot be easily undone.`
+                }
+                confirmLabel="Apply Changes"
+                cancelLabel="Cancel"
+                onConfirm={() => {
+                    setShowConfirm(false);
+                    handleApply();
+                }}
+                variant="warning"
+            />
 
             {toast && (
                 <Toast

--- a/homescreen-hero-ui/src/components/tools/CopyWatchHistory.tsx
+++ b/homescreen-hero-ui/src/components/tools/CopyWatchHistory.tsx
@@ -1,0 +1,590 @@
+import { useState, useEffect } from "react";
+import {
+    Loader2,
+    Check,
+    ChevronDown,
+    Users,
+    ArrowRight,
+    AlertCircle,
+    CheckCircle2,
+    Film,
+    Tv,
+    ArrowLeft,
+    CirclePlus,
+    RefreshCw,
+} from "lucide-react";
+import { Listbox } from "@headlessui/react";
+import { fetchWithAuth } from "../../utils/api";
+import Toast from "../Toast";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogFooter,
+    DialogTitle,
+    DialogDescription,
+    DialogCloseButton,
+} from "@/components/ui/dialog";
+
+type HomeUser = {
+    id: number;
+    username: string;
+    title: string;
+    thumb: string | null;
+    is_admin: boolean;
+};
+
+type ConflictMode = "only_add" | "mirror";
+
+type PreviewCounts = {
+    movies_to_mark_watched: number;
+    movies_to_mark_unwatched: number;
+    episodes_to_mark_watched: number;
+    episodes_to_mark_unwatched: number;
+    shows_affected: number;
+};
+
+type Step = "configure" | "preview" | "applying" | "complete";
+
+type CopyWatchHistoryProps = {
+    onClose: () => void;
+};
+
+const conflictModes: { value: ConflictMode; label: string; description: string; icon: typeof CirclePlus }[] = [
+    {
+        value: "only_add",
+        label: "Add Only",
+        description: "Mark items as watched that the source user has seen. Never removes existing watch history.",
+        icon: CirclePlus,
+    },
+    {
+        value: "mirror",
+        label: "Mirror",
+        description: "Make the target's history identical to the source. Items the source hasn't watched will be marked unwatched.",
+        icon: RefreshCw,
+    },
+];
+
+export default function CopyWatchHistory({ onClose }: CopyWatchHistoryProps) {
+    // Step management
+    const [step, setStep] = useState<Step>("configure");
+
+    // Configuration state
+    const [users, setUsers] = useState<HomeUser[]>([]);
+    const [loadingUsers, setLoadingUsers] = useState(true);
+    const [sourceUser, setSourceUser] = useState<HomeUser | null>(null);
+    const [targetUser, setTargetUser] = useState<HomeUser | null>(null);
+    const [conflictMode, setConflictMode] = useState<ConflictMode>("only_add");
+
+    // Preview state
+    const [previewCounts, setPreviewCounts] = useState<PreviewCounts | null>(null);
+    const [loadingPreview, setLoadingPreview] = useState(false);
+
+    // Apply state
+    const [applyResult, setApplyResult] = useState<{
+        success: boolean;
+        movies_updated: number;
+        episodes_updated: number;
+        errors: string[];
+    } | null>(null);
+
+    // Toast
+    const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+
+    // Fetch home users on mount
+    useEffect(() => {
+        fetchWithAuth("/api/tools/home-users")
+            .then((r) => r.json())
+            .then((data) => {
+                setUsers(data.users || []);
+                // Auto-select first user as source if available
+                if (data.users?.length > 0) {
+                    setSourceUser(data.users[0]);
+                }
+            })
+            .catch((e) => {
+                console.error("Failed to fetch home users:", e);
+                setToast({ message: "Failed to load Plex Home users", type: "error" });
+            })
+            .finally(() => setLoadingUsers(false));
+    }, []);
+
+    // Generate preview
+    const handlePreview = async () => {
+        if (!sourceUser || !targetUser) return;
+
+        setLoadingPreview(true);
+        try {
+            const response = await fetchWithAuth("/api/tools/copy-watch-history/preview", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    source_user: sourceUser.username,
+                    target_user: targetUser.username,
+                }),
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                throw new Error(error.detail || "Failed to generate preview");
+            }
+
+            const data = await response.json();
+            setPreviewCounts(data.counts);
+            setStep("preview");
+        } catch (e) {
+            setToast({ message: `Preview failed: ${e instanceof Error ? e.message : String(e)}`, type: "error" });
+        } finally {
+            setLoadingPreview(false);
+        }
+    };
+
+    // Apply changes
+    const handleApply = async () => {
+        if (!sourceUser || !targetUser) return;
+
+        setStep("applying");
+
+        try {
+            const response = await fetchWithAuth("/api/tools/copy-watch-history/apply", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    source_user: sourceUser.username,
+                    target_user: targetUser.username,
+                    conflict_mode: conflictMode,
+                }),
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                throw new Error(error.detail || "Failed to apply changes");
+            }
+
+            const data = await response.json();
+            setApplyResult(data);
+            setStep("complete");
+        } catch (e) {
+            setToast({ message: `Apply failed: ${e instanceof Error ? e.message : String(e)}`, type: "error" });
+            setStep("preview");
+        }
+    };
+
+    // Validation
+    const canPreview = sourceUser && targetUser && sourceUser.id !== targetUser.id && !loadingPreview;
+
+    // Get available target users (exclude source)
+    const availableTargetUsers = users.filter((u) => u.id !== sourceUser?.id);
+
+    // Render user selector
+    const renderUserSelector = (
+        label: string,
+        value: HomeUser | null,
+        onChange: (user: HomeUser) => void,
+        availableUsers: HomeUser[],
+        disabled: boolean = false,
+        dashed: boolean = false
+    ) => (
+        <div className="space-y-2 w-full min-w-0">
+            <label className="block text-xs font-semibold uppercase tracking-wider text-slate-400">{label}</label>
+            <Listbox value={value ?? undefined} onChange={onChange} disabled={disabled}>
+                <div className="relative">
+                    <Listbox.Button
+                        className={`flex w-full items-center gap-3 rounded-lg border ${dashed && !value ? "border-dashed border-slate-600" : "border-slate-700"} bg-slate-800/60 px-4 py-3 text-left text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-primary/70 transition-colors ${
+                            disabled ? "opacity-50 cursor-not-allowed" : ""
+                        }`}
+                    >
+                        {value ? (
+                            <>
+                                {value.thumb ? (
+                                    <img
+                                        src={value.thumb}
+                                        alt={value.title}
+                                        className="h-8 w-8 rounded-full object-cover"
+                                    />
+                                ) : (
+                                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-700">
+                                        <Users className="h-4 w-4 text-slate-400" />
+                                    </div>
+                                )}
+                                <div className="flex-1 flex items-center">
+                                    <span className="font-medium text-white">{value.title}</span>
+                                    {value.is_admin && (
+                                        <span className="ml-2 text-xs text-primary">(Admin)</span>
+                                    )}
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-700/50">
+                                    <Users className="h-4 w-4 text-slate-500" />
+                                </div>
+                                <div className="flex-1 flex items-center">
+                                    <p className="text-slate-500">Select a user...</p>
+                                </div>
+                            </>
+                        )}
+                        <ChevronDown className="h-4 w-4 text-slate-400" />
+                    </Listbox.Button>
+                    <Listbox.Options className="absolute z-10 mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg focus:outline-none max-h-60 overflow-auto">
+                        {availableUsers.map((user) => (
+                            <Listbox.Option
+                                key={user.id}
+                                value={user}
+                                className="flex cursor-pointer items-center gap-3 px-4 py-2 text-white hover:bg-slate-700 data-[selected]:bg-primary"
+                            >
+                                {({ selected }) => (
+                                    <>
+                                        {user.thumb ? (
+                                            <img
+                                                src={user.thumb}
+                                                alt={user.title}
+                                                className="h-8 w-8 rounded-full object-cover"
+                                            />
+                                        ) : (
+                                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-700">
+                                                <Users className="h-4 w-4 text-slate-400" />
+                                            </div>
+                                        )}
+                                        <div className="flex-1">
+                                            <span className="font-medium text-white">{user.title}</span>
+                                            {user.is_admin && (
+                                                <span className="ml-2 text-xs text-primary">(Admin)</span>
+                                            )}
+                                        </div>
+                                        {selected && <Check className="h-4 w-4 text-white" />}
+                                    </>
+                                )}
+                            </Listbox.Option>
+                        ))}
+                    </Listbox.Options>
+                </div>
+            </Listbox>
+        </div>
+    );
+
+    return (
+        <Dialog open onOpenChange={(open) => !open && onClose()}>
+            <DialogContent className="!max-w-3xl">
+                {/* Header */}
+                <DialogHeader>
+                    <div>
+                        <DialogTitle>Copy Watch History</DialogTitle>
+                        <DialogDescription>
+                            Sync watched status between your home media users.
+                        </DialogDescription>
+                    </div>
+                    <DialogCloseButton />
+                </DialogHeader>
+
+                {/* Content */}
+                <div className="flex-1 overflow-y-auto p-6 scrollbar-hover-only">
+                    {loadingUsers ? (
+                        <div className="flex items-center justify-center py-12 text-slate-400">
+                            <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                            Loading users...
+                        </div>
+                    ) : users.length < 2 ? (
+                        <div className="flex flex-col items-center justify-center py-12 text-slate-400">
+                            <AlertCircle className="h-8 w-8 mb-3 text-amber-400" />
+                            <p className="font-medium text-white">Not enough users</p>
+                            <p className="text-sm text-slate-500 mt-1 text-center">
+                                You need at least 2 Plex Home users to copy watch history.
+                            </p>
+                        </div>
+                    ) : step === "configure" ? (
+                        <div className="space-y-6">
+                            {/* User selectors */}
+                            <div className="flex items-end gap-3">
+                                {renderUserSelector(
+                                    "Copy From (Source)",
+                                    sourceUser,
+                                    (user) => {
+                                        setSourceUser(user);
+                                        // Clear target if it was the same as new source
+                                        if (targetUser?.id === user.id) {
+                                            setTargetUser(null);
+                                        }
+                                    },
+                                    users,
+                                    false,
+                                    false
+                                )}
+                                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-primary mb-2">
+                                    <ArrowRight className="h-4 w-4 text-white" />
+                                </div>
+                                {renderUserSelector(
+                                    "Copy To (Target)",
+                                    targetUser,
+                                    setTargetUser,
+                                    availableTargetUsers,
+                                    !sourceUser,
+                                    true
+                                )}
+                            </div>
+
+                            {/* Conflict mode */}
+                            <div className="space-y-3">
+                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-400">
+                                    Conflict Resolution Strategy
+                                </label>
+                                <div className="grid grid-cols-2 gap-4">
+                                    {conflictModes.map((mode) => {
+                                        const Icon = mode.icon;
+                                        const isSelected = conflictMode === mode.value;
+                                        return (
+                                            <button
+                                                key={mode.value}
+                                                type="button"
+                                                onClick={() => setConflictMode(mode.value)}
+                                                className={`flex flex-col items-start rounded-xl border p-4 text-left transition-all ${
+                                                    isSelected
+                                                        ? "border-primary bg-primary/10"
+                                                        : "border-slate-800/60 bg-slate-900/30 hover:border-slate-700"
+                                                }`}
+                                            >
+                                                <div className={`flex h-8 w-8 items-center justify-center rounded-lg mb-3 ${
+                                                    isSelected ? "bg-primary/20 text-primary" : "bg-slate-800 text-slate-400"
+                                                }`}>
+                                                    <Icon className="h-4 w-4" />
+                                                </div>
+                                                <p className="font-medium text-white text-sm mb-1">{mode.label}</p>
+                                                <p className="text-xs text-slate-400 leading-relaxed">{mode.description}</p>
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        </div>
+                    ) : step === "preview" && previewCounts ? (
+                        <div className="space-y-6">
+                            {/* Preview summary */}
+                            <div className="rounded-xl border border-slate-800/60 bg-slate-900/50 p-6">
+                                <h3 className="text-lg font-semibold text-white mb-4">Preview Summary</h3>
+                                <div className="grid gap-4 sm:grid-cols-2">
+                                    {/* Movies */}
+                                    <div className="flex items-center gap-3 rounded-lg bg-slate-800/40 p-4">
+                                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/20">
+                                            <Film className="h-5 w-5 text-blue-400" />
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-white">
+                                                {previewCounts.movies_to_mark_watched}
+                                            </p>
+                                            <p className="text-sm text-slate-400">Movies to mark watched</p>
+                                        </div>
+                                    </div>
+
+                                    {/* Episodes */}
+                                    <div className="flex items-center gap-3 rounded-lg bg-slate-800/40 p-4">
+                                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-500/20">
+                                            <Tv className="h-5 w-5 text-purple-400" />
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-white">
+                                                {previewCounts.episodes_to_mark_watched}
+                                            </p>
+                                            <p className="text-sm text-slate-400">Episodes to mark watched</p>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* Mirror mode - show items to unwatch */}
+                                {conflictMode === "mirror" &&
+                                    (previewCounts.movies_to_mark_unwatched > 0 ||
+                                        previewCounts.episodes_to_mark_unwatched > 0) && (
+                                        <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+                                            <div className="flex items-start gap-3">
+                                                <AlertCircle className="h-5 w-5 text-amber-400 mt-0.5" />
+                                                <div>
+                                                    <p className="font-medium text-amber-200">
+                                                        Items will be marked unwatched
+                                                    </p>
+                                                    <p className="text-sm text-amber-300/80 mt-1">
+                                                        {previewCounts.movies_to_mark_unwatched} movie
+                                                        {previewCounts.movies_to_mark_unwatched !== 1 ? "s" : ""} and{" "}
+                                                        {previewCounts.episodes_to_mark_unwatched} episode
+                                                        {previewCounts.episodes_to_mark_unwatched !== 1 ? "s" : ""} will
+                                                        be marked as unwatched to mirror the source user.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                {/* Shows affected */}
+                                {previewCounts.shows_affected > 0 && (
+                                    <p className="mt-4 text-sm text-slate-400">
+                                        Across {previewCounts.shows_affected} TV show
+                                        {previewCounts.shows_affected !== 1 ? "s" : ""}
+                                    </p>
+                                )}
+
+                                {/* No changes */}
+                                {previewCounts.movies_to_mark_watched === 0 &&
+                                    previewCounts.episodes_to_mark_watched === 0 &&
+                                    previewCounts.movies_to_mark_unwatched === 0 &&
+                                    previewCounts.episodes_to_mark_unwatched === 0 && (
+                                        <div className="mt-4 flex items-center gap-2 text-slate-400">
+                                            <CheckCircle2 className="h-5 w-5 text-green-400" />
+                                            <span>Watch history is already in sync - no changes needed!</span>
+                                        </div>
+                                    )}
+                            </div>
+                        </div>
+                    ) : step === "applying" ? (
+                        <div className="flex flex-col items-center justify-center py-12">
+                            <Loader2 className="h-10 w-10 animate-spin text-primary mb-4" />
+                            <p className="text-lg font-medium text-white">Applying changes...</p>
+                            <p className="text-sm text-slate-400 mt-1">This may take a while for large libraries</p>
+                        </div>
+                    ) : step === "complete" && applyResult ? (
+                        <div className="space-y-6">
+                            {/* Result summary */}
+                            <div
+                                className={`rounded-xl border p-6 ${
+                                    applyResult.success
+                                        ? "border-green-500/30 bg-green-500/10"
+                                        : "border-amber-500/30 bg-amber-500/10"
+                                }`}
+                            >
+                                <div className="flex items-start gap-4">
+                                    {applyResult.success ? (
+                                        <CheckCircle2 className="h-8 w-8 text-green-400" />
+                                    ) : (
+                                        <AlertCircle className="h-8 w-8 text-amber-400" />
+                                    )}
+                                    <div>
+                                        <h3
+                                            className={`text-lg font-semibold ${
+                                                applyResult.success ? "text-green-200" : "text-amber-200"
+                                            }`}
+                                        >
+                                            {applyResult.success
+                                                ? "Watch history copied successfully!"
+                                                : "Completed with some errors"}
+                                        </h3>
+                                        <p className="text-slate-300 mt-2">
+                                            Updated {applyResult.movies_updated} movie
+                                            {applyResult.movies_updated !== 1 ? "s" : ""} and{" "}
+                                            {applyResult.episodes_updated} episode
+                                            {applyResult.episodes_updated !== 1 ? "s" : ""}.
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {/* Errors list */}
+                            {applyResult.errors.length > 0 && (
+                                <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+                                    <p className="font-medium text-red-200 mb-2">
+                                        {applyResult.errors.length} error
+                                        {applyResult.errors.length !== 1 ? "s" : ""} occurred:
+                                    </p>
+                                    <ul className="text-sm text-red-300/80 space-y-1 max-h-40 overflow-auto">
+                                        {applyResult.errors.map((error, i) => (
+                                            <li key={i}>- {error}</li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+                        </div>
+                    ) : null}
+                </div>
+
+                {/* Footer */}
+                <DialogFooter className="py-4 px-6">
+                    {step === "configure" && (
+                        <>
+                            <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                                <AlertCircle className="h-3.5 w-3.5" />
+                                <span>This action cannot be easily undone.</span>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    type="button"
+                                    onClick={onClose}
+                                    className="px-4 py-2 rounded-lg text-slate-300 hover:text-white hover:bg-slate-800 transition-colors"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handlePreview}
+                                    disabled={!canPreview}
+                                    className="px-4 py-2 rounded-lg bg-primary text-white font-semibold hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+                                >
+                                    {loadingPreview ? (
+                                        <>
+                                            <Loader2 className="h-4 w-4 animate-spin" />
+                                            Loading...
+                                        </>
+                                    ) : (
+                                        <>
+                                            Preview Changes
+                                            <ArrowRight className="h-4 w-4" />
+                                        </>
+                                    )}
+                                </button>
+                            </div>
+                        </>
+                    )}
+
+                    {step === "preview" && (
+                        <>
+                            <div className="flex items-center gap-1.5 text-xs text-slate-500">
+                                <AlertCircle className="h-3.5 w-3.5" />
+                                <span>This action cannot be easily undone.</span>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    type="button"
+                                    onClick={() => setStep("configure")}
+                                    className="px-4 py-2 rounded-lg text-slate-300 hover:text-white hover:bg-slate-800 transition-colors flex items-center gap-2"
+                                >
+                                    <ArrowLeft className="h-4 w-4" />
+                                    Back
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleApply}
+                                    disabled={
+                                        previewCounts?.movies_to_mark_watched === 0 &&
+                                        previewCounts?.episodes_to_mark_watched === 0 &&
+                                        previewCounts?.movies_to_mark_unwatched === 0 &&
+                                        previewCounts?.episodes_to_mark_unwatched === 0
+                                    }
+                                    className="px-4 py-2 rounded-lg bg-primary text-white font-semibold hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+                                >
+                                    <CheckCircle2 className="h-4 w-4" />
+                                    Confirm & Apply
+                                </button>
+                            </div>
+                        </>
+                    )}
+
+                    {step === "complete" && (
+                        <>
+                            <div />
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                className="px-4 py-2 rounded-lg bg-primary text-white font-semibold hover:bg-blue-600 transition-colors"
+                            >
+                                Done
+                            </button>
+                        </>
+                    )}
+                </DialogFooter>
+            </DialogContent>
+
+            {toast && (
+                <Toast
+                    message={toast.message}
+                    type={toast.type}
+                    onClose={() => setToast(null)}
+                />
+            )}
+        </Dialog>
+    );
+}

--- a/homescreen-hero-ui/src/components/ui/progress.tsx
+++ b/homescreen-hero-ui/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+
+import { cn } from "@/lib/utils";
+
+const Progress = React.forwardRef<
+    React.ElementRef<typeof ProgressPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+    <ProgressPrimitive.Root
+        ref={ref}
+        className={cn(
+            "relative h-2 w-full overflow-hidden rounded-full bg-slate-800",
+            className
+        )}
+        {...props}
+    >
+        <ProgressPrimitive.Indicator
+            className="h-full w-full flex-1 bg-primary transition-all duration-300 ease-out"
+            style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+        />
+    </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -783,20 +783,58 @@ export default function GroupDetailPage() {
                                     Previous
                                 </button>
                                 <div className="flex items-center gap-1">
-                                    {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-                                        <button
-                                            key={page}
-                                            type="button"
-                                            onClick={() => setCurrentPage(page)}
-                                            className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition ${
-                                                currentPage === page
-                                                    ? "bg-primary text-white"
-                                                    : "bg-slate-800/60 text-slate-300 hover:bg-slate-700"
-                                            }`}
-                                        >
-                                            {page}
-                                        </button>
-                                    ))}
+                                    {(() => {
+                                        // Build smart page list: 1 ... (current-1) current (current+1) ... totalPages
+                                        const pages: (number | "ellipsis")[] = [];
+                                        const showEllipsisThreshold = 7;
+
+                                        if (totalPages <= showEllipsisThreshold) {
+                                            // Show all pages if there aren't many
+                                            for (let i = 1; i <= totalPages; i++) pages.push(i);
+                                        } else {
+                                            // Always show first page
+                                            pages.push(1);
+
+                                            // Left ellipsis if current page is far from start
+                                            if (currentPage > 3) {
+                                                pages.push("ellipsis");
+                                            }
+
+                                            // Pages around current
+                                            for (let i = Math.max(2, currentPage - 1); i <= Math.min(totalPages - 1, currentPage + 1); i++) {
+                                                pages.push(i);
+                                            }
+
+                                            // Right ellipsis if current page is far from end
+                                            if (currentPage < totalPages - 2) {
+                                                pages.push("ellipsis");
+                                            }
+
+                                            // Always show last page
+                                            if (!pages.includes(totalPages)) {
+                                                pages.push(totalPages);
+                                            }
+                                        }
+
+                                        return pages.map((page, idx) =>
+                                            page === "ellipsis" ? (
+                                                <span key={`ellipsis-${idx}`} className="px-2 text-xs text-slate-500">…</span>
+                                            ) : (
+                                                <button
+                                                    key={page}
+                                                    type="button"
+                                                    onClick={() => setCurrentPage(page)}
+                                                    className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition ${
+                                                        currentPage === page
+                                                            ? "bg-primary text-white"
+                                                            : "bg-slate-800/60 text-slate-300 hover:bg-slate-700"
+                                                    }`}
+                                                >
+                                                    {page}
+                                                </button>
+                                            )
+                                        );
+                                    })()}
                                 </div>
                                 <button
                                     type="button"

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -25,6 +25,7 @@ type RotationSettings = {
     allow_repeats: boolean;
     sync_all_on_rotation: boolean;
     blacklisted_collections: string[];
+    per_library_limits: Record<string, number>;
 };
 type ConfigSaveResponse = { ok: boolean; path: string; message: string; env_override: boolean };
 type HealthComponent = { ok: boolean; error?: string | null };
@@ -118,7 +119,11 @@ export default function SettingsPage() {
         allow_repeats: false,
         sync_all_on_rotation: true,
         blacklisted_collections: [],
+        per_library_limits: {},
     });
+    // Track input values as strings to allow empty fields while editing
+    const [intervalInput, setIntervalInput] = useState("12");
+    const [maxCollectionsInput, setMaxCollectionsInput] = useState("5");
     const [blacklistSearch, setBlacklistSearch] = useState("");
     const [blacklistSourceFilter, setBlacklistSourceFilter] = useState<"all" | "plex" | "trakt" | "letterboxd" | "mdblist">("all");
     const [blacklistPage, setBlacklistPage] = useState(1);
@@ -197,6 +202,8 @@ export default function SettingsPage() {
             .then((data: RotationSettings) => {
                 if (!isMounted) return;
                 setRotationSettings(data);
+                setIntervalInput(String(data.interval_hours));
+                setMaxCollectionsInput(String(data.max_collections));
             })
             .catch((e) => {
                 if (!isMounted) return;
@@ -360,16 +367,43 @@ export default function SettingsPage() {
         }
     }
 
-    const handleRotationNumberChange = (
-        key: "interval_hours" | "max_collections",
-        value: string,
-    ) => {
+    const handleIntervalChange = (value: string) => {
+        setIntervalInput(value);
         const parsed = Number(value);
-        setRotationSettings((prev) => ({
-            ...prev,
-            [key]: Number.isNaN(parsed) ? 0 : parsed,
-        }));
+        if (value !== "" && !Number.isNaN(parsed)) {
+            setRotationSettings((prev) => ({ ...prev, interval_hours: parsed }));
+        }
     };
+
+    const handleMaxCollectionsChange = (value: string) => {
+        setMaxCollectionsInput(value);
+        const parsed = Number(value);
+        if (value !== "" && !Number.isNaN(parsed)) {
+            setRotationSettings((prev) => ({ ...prev, max_collections: parsed }));
+        }
+    };
+
+    const handleLibraryLimitChange = (libraryName: string, value: string) => {
+        const trimmed = value.trim();
+        setRotationSettings((prev) => {
+            const newLimits = { ...prev.per_library_limits };
+            if (trimmed === "" || trimmed === "0") {
+                // Empty or 0 means no limit - remove from map
+                delete newLimits[libraryName];
+            } else {
+                const parsed = Number(trimmed);
+                if (!Number.isNaN(parsed) && parsed > 0) {
+                    newLimits[libraryName] = parsed;
+                }
+            }
+            return { ...prev, per_library_limits: newLimits };
+        });
+    };
+
+    // Get enabled libraries for per-library limits UI
+    const enabledLibraries = useMemo(() => {
+        return plexSettings.libraries.filter((lib) => lib.enabled);
+    }, [plexSettings.libraries]);
 
     const addToBlacklist = (name: string) => {
         const trimmed = name.trim();
@@ -671,7 +705,7 @@ export default function SettingsPage() {
                     </CollapsibleFormSection>
 
                     <CollapsibleFormSection
-                        title="Rotation schedule"
+                        title="Rotation Settings"
                         description="Configure how often the scheduler rotates featured collections."
                         icon={CalendarSync}
                         expanded={rotationExpanded}
@@ -699,8 +733,8 @@ export default function SettingsPage() {
                             <input
                                 type="number"
                                 min={1}
-                                value={rotationSettings.interval_hours}
-                                onChange={(e) => handleRotationNumberChange("interval_hours", e.target.value)}
+                                value={intervalInput}
+                                onChange={(e) => handleIntervalChange(e.target.value)}
                                 disabled={loadingRotation}
                                 className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
                             />
@@ -710,12 +744,39 @@ export default function SettingsPage() {
                             <input
                                 type="number"
                                 min={1}
-                                value={rotationSettings.max_collections}
-                                onChange={(e) => handleRotationNumberChange("max_collections", e.target.value)}
+                                value={maxCollectionsInput}
+                                onChange={(e) => handleMaxCollectionsChange(e.target.value)}
                                 disabled={loadingRotation}
                                 className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
                             />
                         </FieldRow>
+
+                        {enabledLibraries.length >= 2 && (
+                            <FieldRow label="Per-library limits" hint="Optionally limit how many collections can come from each library. Leave empty for no limit.">
+                                <div className="space-y-2">
+                                    {enabledLibraries.map((lib) => (
+                                        <div key={lib.name} className="flex items-center gap-3 rounded-lg border border-slate-700 bg-slate-900/50 px-3 py-2">
+                                            <span className="text-sm text-slate-200 flex-1">{lib.name}</span>
+                                            <div className="flex items-center gap-2">
+                                                <span className="text-xs text-slate-400">Max:</span>
+                                                <input
+                                                    type="number"
+                                                    min={0}
+                                                    placeholder="∞"
+                                                    value={rotationSettings.per_library_limits[lib.name] ?? ""}
+                                                    onChange={(e) => handleLibraryLimitChange(lib.name, e.target.value)}
+                                                    disabled={loadingRotation}
+                                                    className="w-16 rounded-lg border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-slate-100 text-center focus:outline-none focus:ring-2 focus:ring-primary/70 placeholder-slate-500 focus:placeholder-transparent"
+                                                />
+                                            </div>
+                                        </div>
+                                    ))}
+                                    <p className="text-xs text-slate-500 mt-1">
+                                        These limits work alongside the global max. For example: global max=12, Movies max=6, TV max=6 means at most 6 from each library, up to 12 total.
+                                    </p>
+                                </div>
+                            </FieldRow>
+                        )}
 
                         <FieldRow label="Strategy" hint="Choose how groups are prioritized during rotation.">
                             <Listbox

--- a/homescreen-hero-ui/src/pages/ToolsPage.tsx
+++ b/homescreen-hero-ui/src/pages/ToolsPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { Calendar, Wrench, History, FileSearch } from "lucide-react";
+import { Calendar, Wrench, History, FileSearch, Users } from "lucide-react";
 import ToolCard from "../components/tools/ToolCard";
 import DateAddedEditor from "../components/tools/DateAddedEditor";
 import WatchHistoryCleaner from "../components/tools/WatchHistoryCleaner";
 import UnwatchedReport from "../components/tools/UnwatchedReport";
+import CopyWatchHistory from "../components/tools/CopyWatchHistory";
 
 type Tool = {
     id: string;
@@ -30,6 +31,12 @@ const tools: Tool[] = [
         title: "Unwatched Report",
         description: "Find movies and shows that haven't been watched",
         icon: FileSearch,
+    },
+    {
+        id: "copy-watch-history",
+        title: "Copy Watch History",
+        description: "Copy watched status between Plex Home users",
+        icon: Users,
     },
 ];
 
@@ -76,6 +83,9 @@ export default function ToolsPage() {
             )}
             {activeTool === "unwatched-report" && (
                 <UnwatchedReport onClose={() => setActiveTool(null)} />
+            )}
+            {activeTool === "copy-watch-history" && (
+                <CopyWatchHistory onClose={() => setActiveTool(null)} />
             )}
         </div>
     );

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -85,6 +85,10 @@ class RotationSettings(BaseModel):
         default_factory=AutoRotateSettings,
         description="Settings for auto-rotate mode",
     )
+    per_library_limits: Dict[str, int] = Field(
+        default_factory=dict,
+        description="Maximum collections per library during rotation. Keys are library names, values are max counts.",
+    )
 
 
 class CollectionGroupConfig(BaseModel):
@@ -310,6 +314,10 @@ class RotationResult(BaseModel):
     max_global: int
     remaining_global: int
     today: date
+    per_library_counts: Dict[str, int] = Field(
+        default_factory=dict,
+        description="Number of collections selected from each library",
+    )
 
 
 class RotationExecution(BaseModel):

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Set
 
 from plexapi.server import PlexServer
+from plexapi.myplex import MyPlexAccount
 
 from ..config.schema import AppConfig
 
@@ -416,3 +417,76 @@ def reorder_homescreen_collections(
         logger.info("Reordered %d collections on homescreen", len(applied_order))
 
     return applied_order
+
+
+# Home user functions for watch history copying
+
+def get_plex_account(config: AppConfig) -> MyPlexAccount:
+    # Create MyPlexAccount from configured token for home user access
+    # This requires a Plex.tv account token, not a local server token
+    return MyPlexAccount(token=config.plex.token)
+
+
+def get_home_users(config: AppConfig) -> List[Dict[str, Any]]:
+    # Return list of home users with id, username, title, thumb, is_admin
+    # Note: For managed users, username may be empty - use title for switchHomeUser()
+    account = get_plex_account(config)
+    users = []
+
+    # Include the main account owner
+    # Use title as the primary identifier for consistency with managed users
+    users.append({
+        "id": account.id,
+        "username": account.title or account.username,  # Use title as username for consistency
+        "title": account.title or account.username,
+        "thumb": account.thumb,
+        "is_admin": True,
+    })
+
+    # Add managed/home users (filter out friends - only include home users)
+    for user in account.users():
+        if user.home:
+            users.append({
+                "id": user.id,
+                "username": user.title or user.username,  # Use title as username for managed users
+                "title": user.title or user.username,
+                "thumb": user.thumb,
+                "is_admin": False,
+            })
+
+    logger.debug(f"Found {len(users)} home users")
+    return users
+
+
+def get_server_for_user(config: AppConfig, username: str) -> PlexServer:
+    # Get PlexServer authenticated as a specific home user
+    # Uses switchHomeUser to switch context, then connects via resource
+    account = get_plex_account(config)
+
+    # If it's the admin account, just return normal server
+    if username == account.username or username == account.title:
+        return get_plex_server(config)
+
+    # Switch to the home user's context
+    logger.debug(f"Switching to home user: {username}")
+    user_account = account.switchHomeUser(username)
+
+    # Find the server resource and connect
+    # For managed users, we need to go through the resource to get proper auth
+    for resource in user_account.resources():
+        if resource.product == "Plex Media Server":
+            try:
+                # Try to connect - it will use the best available connection
+                logger.debug(f"Connecting to server as {username} via resource")
+                return resource.connect(timeout=30)
+            except Exception as e:
+                logger.warning(f"Failed to connect via resource: {e}")
+                # If that fails, try forcing the configured base_url
+                try:
+                    logger.debug(f"Retrying with configured base_url")
+                    return PlexServer(config.plex.base_url, resource.accessToken)
+                except Exception as e2:
+                    logger.error(f"Failed with configured base_url: {e2}")
+                    raise
+
+    raise ValueError(f"Could not find Plex server for user '{username}'")

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
+from collections import defaultdict
 from datetime import date
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -163,6 +164,7 @@ def run_rotation_with_history(
     usage_map: Dict[str, CollectionUsage],
     last_rotation_collections: Optional[List[str]] = None,
     pinned_names: Optional[Set[str]] = None,
+    collection_library_map: Optional[Dict[str, str]] = None,
     today: Optional[date] = None,
     rng: Optional[random.Random] = None,
 ) -> RotationResult:
@@ -175,10 +177,25 @@ def run_rotation_with_history(
     remaining_global = max_global
     allow_repeats = config.rotation.allow_repeats
     last_rotation_set = set(last_rotation_collections or [])
+    per_library_limits = config.rotation.per_library_limits
+    collection_library_map = collection_library_map or {}
 
     selected: List[str] = []
     selected_set: Set[str] = set()
     group_results: List[GroupSelectionResult] = []
+    library_counts: Dict[str, int] = defaultdict(int)
+
+    # Helper to check if a collection is within its library's max limit
+    def within_library_limit(coll_name: str) -> bool:
+        if not per_library_limits:
+            return True
+        lib = collection_library_map.get(coll_name)
+        if not lib:
+            return True  # Unknown library, allow
+        max_for_lib = per_library_limits.get(lib)
+        if max_for_lib is None:
+            return True  # No limit configured for this library
+        return library_counts[lib] < max_for_lib
 
     # Handle pinned collections - they go first and don't count against max_collections
     pinned_names = pinned_names or set()
@@ -248,6 +265,9 @@ def run_rotation_with_history(
         if not allow_repeats and last_rotation_set:
             available = [c for c in available if c not in last_rotation_set]
 
+        # Filter out collections that would exceed their library's max limit
+        available = [c for c in available if within_library_limit(c)]
+
         result.available_collections = available
 
         if not available:
@@ -283,16 +303,42 @@ def run_rotation_with_history(
             continue
 
         # Select collections based on strategy
-        chosen = _select_collections_from_group(
-            available, k, config.rotation.strategy, usage_map, rng
-        )
+        # When per-library limits are set, use iterative selection to respect limits
+        if per_library_limits:
+            chosen = []
+            remaining_available = list(available)
+            for _ in range(k):
+                # Re-filter by library limit each iteration
+                eligible = [c for c in remaining_available if within_library_limit(c)]
+                if not eligible:
+                    break
+                pick = _select_collections_from_group(
+                    eligible, 1, config.rotation.strategy, usage_map, rng
+                )
+                if not pick:
+                    break
+                coll = pick[0]
+                chosen.append(coll)
+                remaining_available.remove(coll)
+                lib = collection_library_map.get(coll)
+                if lib:
+                    library_counts[lib] += 1
+        else:
+            chosen = _select_collections_from_group(
+                available, k, config.rotation.strategy, usage_map, rng
+            )
+            # Update library counts for selected collections
+            for coll in chosen:
+                lib = collection_library_map.get(coll)
+                if lib:
+                    library_counts[lib] += 1
 
         selected.extend(chosen)
         selected_set.update(chosen)
-        remaining_global -= k
+        remaining_global -= len(chosen)
 
         result.chosen_collections = chosen
-        result.picked_count = k
+        result.picked_count = len(chosen)
 
         group_results.append(result)
 
@@ -308,6 +354,7 @@ def run_rotation_with_history(
         max_global=max_global,
         remaining_global=remaining_global,
         today=today,
+        per_library_counts=dict(library_counts),
     )
 
     logger.info(
@@ -315,6 +362,8 @@ def run_rotation_with_history(
             len(selected),
             remaining_global,
         )
+    if library_counts:
+        logger.info("Per-library counts: %s", dict(library_counts))
     logger.debug("Group selection details: %s", group_results)
 
     return rotation_result
@@ -331,6 +380,8 @@ def run_auto_rotation_with_history(
     max_rotation_id: int,
     usage_map: Dict[str, CollectionUsage],
     pinned_names: Optional[Set[str]] = None,
+    collection_library_map: Optional[Dict[str, str]] = None,
+    per_library_limits: Optional[Dict[str, int]] = None,
     today: Optional[date] = None,
     rng: Optional[random.Random] = None,
 ) -> RotationResult:
@@ -343,6 +394,9 @@ def run_auto_rotation_with_history(
 
     pinned_names = pinned_names or set()
     last_rotation_set = set(last_rotation_collections)
+    collection_library_map = collection_library_map or {}
+    per_library_limits = per_library_limits or {}
+    library_counts: Dict[str, int] = defaultdict(int)
 
     # Handle pinned collections first - they don't count against max_collections
     pinned_selected: List[str] = []
@@ -382,14 +436,52 @@ def run_auto_rotation_with_history(
         ", repeats excluded" if not allow_repeats else "",
     )
 
-    # Select collections using the configured strategy
-    k = min(max_collections, len(available))
-    if k > 0:
-        selected = _select_collections_from_group(
-            available, k, strategy, usage_map, rng
-        )
+    # Helper to check if a collection is within its library's max limit
+    def within_library_limit(coll_name: str) -> bool:
+        if not per_library_limits:
+            return True
+        lib = collection_library_map.get(coll_name)
+        if not lib:
+            return True
+        max_for_lib = per_library_limits.get(lib)
+        if max_for_lib is None:
+            return True
+        return library_counts[lib] < max_for_lib
+
+    # Select collections using the configured strategy, respecting library limits
+    # If per-library limits are set, we need to select iteratively
+    selected: List[str] = []
+    if per_library_limits:
+        # Iterative selection to respect library limits
+        remaining_available = list(available)
+        while len(selected) < max_collections and remaining_available:
+            # Filter by library limit
+            eligible = [c for c in remaining_available if within_library_limit(c)]
+            if not eligible:
+                break
+            # Select one collection
+            chosen = _select_collections_from_group(eligible, 1, strategy, usage_map, rng)
+            if not chosen:
+                break
+            coll = chosen[0]
+            selected.append(coll)
+            remaining_available.remove(coll)
+            # Update library count
+            lib = collection_library_map.get(coll)
+            if lib:
+                library_counts[lib] += 1
     else:
-        selected = []
+        # Simple selection without library limits
+        k = min(max_collections, len(available))
+        if k > 0:
+            selected = _select_collections_from_group(
+                available, k, strategy, usage_map, rng
+            )
+            # Track library counts for the result
+            for coll in selected:
+                lib = collection_library_map.get(coll)
+                if lib:
+                    library_counts[lib] += 1
 
     # Create a virtual group result for reporting
     group_result = GroupSelectionResult(
@@ -412,6 +504,7 @@ def run_auto_rotation_with_history(
         max_global=max_collections,
         remaining_global=max_collections - len(selected),
         today=today,
+        per_library_counts=dict(library_counts),
     )
 
     logger.info(

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -30,6 +30,22 @@ from .db import (
 
 logger = logging.getLogger(__name__)
 
+
+def _build_collection_library_map(server, config: AppConfig) -> Dict[str, str]:
+    # Build a mapping from collection name to library name.
+    # Used to enforce per-library limits during rotation.
+    coll_to_lib: Dict[str, str] = {}
+    for lib_config in config.plex.libraries:
+        if lib_config.enabled:
+            try:
+                collections_map = get_library_collections(server, lib_config.name)
+                for coll_name in collections_map.keys():
+                    coll_to_lib[coll_name] = lib_config.name
+            except Exception as e:
+                logger.warning("Failed to get collections from library '%s': %s", lib_config.name, e)
+    return coll_to_lib
+
+
 def _run_auto_rotation(
     server,
     config: AppConfig,
@@ -37,6 +53,7 @@ def _run_auto_rotation(
     usage_map: Dict,
     pinned_names: set,
     last_rotation_collections: List[str],
+    collection_library_map: Optional[Dict[str, str]] = None,
 ) -> RotationResult:
     # Run auto-rotation mode: rotate through collections from selected libraries
     auto_rotate = config.rotation.auto_rotate
@@ -85,6 +102,8 @@ def _run_auto_rotation(
         max_rotation_id=max_rotation_id,
         usage_map=usage_map,
         pinned_names=pinned_names,
+        collection_library_map=collection_library_map,
+        per_library_limits=config.rotation.per_library_limits,
     )
 
 
@@ -152,6 +171,9 @@ def run_rotation_once(
     # Connect to Plex
     server = get_plex_server(config)
 
+    # Build collection→library map for per-library limits
+    collection_library_map = _build_collection_library_map(server, config)
+
     # DISABLED: Auto-cleanup was too aggressive and deleting user's collections
     # TODO: Redesign cleanup to only delete collections that HSH created (not native Plex collections)
     # cleanup_result = cleanup_deleted_integration_sources(server, config)
@@ -177,7 +199,8 @@ def run_rotation_once(
 
         if use_auto_rotate:
             rotation_result = _run_auto_rotation(
-                server, config, max_rotation_id, usage_map, pinned_names, last_rotation_collections
+                server, config, max_rotation_id, usage_map, pinned_names, last_rotation_collections,
+                collection_library_map=collection_library_map,
             )
         else:
             rotation_result = run_rotation_with_history(
@@ -186,6 +209,7 @@ def run_rotation_once(
                 usage_map=usage_map,
                 last_rotation_collections=last_rotation_collections,
                 pinned_names=pinned_names,
+                collection_library_map=collection_library_map,
             )
 
         # Now sync only the selected collections
@@ -199,7 +223,8 @@ def run_rotation_once(
 
         if use_auto_rotate:
             rotation_result = _run_auto_rotation(
-                server, config, max_rotation_id, usage_map, pinned_names, last_rotation_collections
+                server, config, max_rotation_id, usage_map, pinned_names, last_rotation_collections,
+                collection_library_map=collection_library_map,
             )
         else:
             rotation_result = run_rotation_with_history(
@@ -208,6 +233,7 @@ def run_rotation_once(
                 usage_map=usage_map,
                 last_rotation_collections=last_rotation_collections,
                 pinned_names=pinned_names,
+                collection_library_map=collection_library_map,
             )
 
     # Build visibility map from group settings (or use auto-rotate config)
@@ -297,12 +323,14 @@ def simulate_rotation_once(
     logger.info("Simulating next rotation (no Plex write, no history write)")
 
     pinned_names = get_pinned_collection_names()
+    server = get_plex_server(config)
+    collection_library_map = _build_collection_library_map(server, config)
 
     # Check if auto-rotate mode is enabled
     if config.rotation.auto_rotate.enabled:
-        server = get_plex_server(config)
         rotation_result = _run_auto_rotation(
-            server, config, max_rotation_id, usage_map, pinned_names, last_rotation_collections
+            server, config, max_rotation_id, usage_map, pinned_names, last_rotation_collections,
+            collection_library_map=collection_library_map,
         )
     else:
         rotation_result = run_rotation_with_history(
@@ -311,6 +339,7 @@ def simulate_rotation_once(
             usage_map=usage_map,
             last_rotation_collections=last_rotation_collections,
             pinned_names=pinned_names,
+            collection_library_map=collection_library_map,
         )
 
     simulation_id = create_simulation(rotation_result)

--- a/homescreen_hero/web/routers/analytics.py
+++ b/homescreen_hero/web/routers/analytics.py
@@ -81,6 +81,8 @@ class ActiveStreamOut(BaseModel):
     title: str
     media_type: str  # movie, episode, etc
     progress_percent: Optional[int] = None
+    season_number: Optional[int] = None
+    episode_number: Optional[int] = None
 
 
 class CurrentActivityOut(BaseModel):
@@ -462,13 +464,18 @@ def get_current_activity(
             # Get title
             title = getattr(session, 'title', 'Unknown')
 
-            # Determine media type
+            # Determine media type and extract season/episode info
             media_type = getattr(session, 'type', 'unknown')
+            season_number = None
+            episode_number = None
             if media_type == "episode":
                 # For TV shows, include show name
                 grandparent_title = getattr(session, 'grandparentTitle', '')
                 if grandparent_title:
                     title = f"{grandparent_title} - {title}"
+                # Extract season and episode numbers
+                season_number = getattr(session, 'parentIndex', None)
+                episode_number = getattr(session, 'index', None)
 
             # Calculate progress percentage
             progress_percent = None
@@ -489,6 +496,8 @@ def get_current_activity(
                     title=title,
                     media_type=media_type,
                     progress_percent=progress_percent,
+                    season_number=season_number,
+                    episode_number=episode_number,
                 )
             )
 

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -446,6 +446,7 @@ def save_rotation_settings(
             sync_all_on_rotation=payload.sync_all_on_rotation,
             blacklisted_collections=payload.blacklisted_collections,
             auto_rotate=payload.auto_rotate.model_dump(),
+            per_library_limits=payload.per_library_limits,
         )
 
         data["rotation"] = rotation_section

--- a/homescreen_hero/web/routers/tools.py
+++ b/homescreen_hero/web/routers/tools.py
@@ -5,9 +5,11 @@ from typing import List, Optional, Literal
 import logging
 import csv
 import io
+import json
 import math
 
-from fastapi import APIRouter, HTTPException, Depends, Response
+from fastapi import APIRouter, HTTPException, Depends, Response, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from homescreen_hero.core.config.loader import load_config
@@ -947,4 +949,125 @@ def apply_copy_watch_history(
         movies_updated=movies_updated,
         episodes_updated=episodes_updated,
         errors=errors,
+    )
+
+
+@router.post("/copy-watch-history/apply-stream")
+async def apply_copy_watch_history_stream(
+    request: CopyWatchHistoryApplyRequest,
+    req: Request,
+    current_user: str = Depends(get_current_user),
+):
+    # SSE streaming version of apply - sends progress updates
+    config = load_config()
+
+    def generate_events():
+        try:
+            source_server = get_server_for_user(config, request.source_user)
+            target_server = get_server_for_user(config, request.target_user)
+        except Exception as e:
+            yield f"data: {json.dumps({'type': 'error', 'message': f'Failed to connect to Plex: {str(e)}'})}\n\n"
+            return
+
+        enabled_libraries = [lib.name for lib in config.plex.libraries if lib.enabled]
+
+        movies_updated = 0
+        episodes_updated = 0
+        errors: List[str] = []
+
+        for lib_idx, lib_name in enumerate(enabled_libraries):
+            # Send library start event
+            yield f"data: {json.dumps({'type': 'library_start', 'library': lib_name, 'library_index': lib_idx, 'total_libraries': len(enabled_libraries)})}\n\n"
+
+            try:
+                source_section = source_server.library.section(lib_name)
+                target_section = target_server.library.section(lib_name)
+
+                if source_section.type == "movie":
+                    source_movies = {m.guid: m for m in source_section.all()}
+                    target_movies = {m.guid: m for m in target_section.all()}
+                    total_items = len(source_movies)
+                    processed = 0
+
+                    for guid, source_movie in source_movies.items():
+                        processed += 1
+
+                        # Send progress every 10 items or on last item
+                        if processed % 10 == 0 or processed == total_items:
+                            yield f"data: {json.dumps({'type': 'progress', 'library': lib_name, 'processed': processed, 'total': total_items, 'item_type': 'movies'})}\n\n"
+
+                        if guid not in target_movies:
+                            continue
+
+                        target_movie = target_movies[guid]
+                        source_watched = getattr(source_movie, "isWatched", False)
+                        target_watched = getattr(target_movie, "isWatched", False)
+
+                        try:
+                            if source_watched and not target_watched:
+                                target_movie.markPlayed()
+                                movies_updated += 1
+                            elif not source_watched and target_watched:
+                                if request.conflict_mode == "mirror":
+                                    target_movie.markUnplayed()
+                                    movies_updated += 1
+                        except Exception as e:
+                            errors.append(f"Failed to update '{source_movie.title}': {str(e)}")
+
+                elif source_section.type == "show":
+                    source_shows = list(source_section.all())
+                    target_shows = {s.guid: s for s in target_section.all()}
+                    total_shows = len(source_shows)
+
+                    for show_idx, source_show in enumerate(source_shows):
+                        # Send show-level progress
+                        if (show_idx + 1) % 5 == 0 or show_idx == total_shows - 1:
+                            yield f"data: {json.dumps({'type': 'progress', 'library': lib_name, 'processed': show_idx + 1, 'total': total_shows, 'item_type': 'shows'})}\n\n"
+
+                        if source_show.guid not in target_shows:
+                            continue
+
+                        target_show = target_shows[source_show.guid]
+
+                        source_episodes = {e.guid: e for e in source_show.episodes()}
+                        target_episodes = {e.guid: e for e in target_show.episodes()}
+
+                        for ep_guid, source_ep in source_episodes.items():
+                            if ep_guid not in target_episodes:
+                                continue
+
+                            target_ep = target_episodes[ep_guid]
+                            source_watched = getattr(source_ep, "isWatched", False)
+                            target_watched = getattr(target_ep, "isWatched", False)
+
+                            try:
+                                if source_watched and not target_watched:
+                                    target_ep.markPlayed()
+                                    episodes_updated += 1
+                                elif not source_watched and target_watched:
+                                    if request.conflict_mode == "mirror":
+                                        target_ep.markUnplayed()
+                                        episodes_updated += 1
+                            except Exception as e:
+                                errors.append(
+                                    f"Failed to update '{source_show.title}' - {source_ep.title}: {str(e)}"
+                                )
+
+            except Exception as e:
+                errors.append(f"Failed to process library '{lib_name}': {str(e)}")
+
+        # Send completion event
+        logger.info(
+            f"Copy watch history complete: {movies_updated} movies, {episodes_updated} episodes updated, {len(errors)} errors"
+        )
+
+        yield f"data: {json.dumps({'type': 'complete', 'success': len(errors) == 0, 'movies_updated': movies_updated, 'episodes_updated': episodes_updated, 'errors': errors})}\n\n"
+
+    return StreamingResponse(
+        generate_events(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
     )

--- a/homescreen_hero/web/routers/tools.py
+++ b/homescreen_hero/web/routers/tools.py
@@ -11,7 +11,11 @@ from fastapi import APIRouter, HTTPException, Depends, Response
 from pydantic import BaseModel
 
 from homescreen_hero.core.config.loader import load_config
-from homescreen_hero.core.integrations.plex_client import get_plex_server
+from homescreen_hero.core.integrations.plex_client import (
+    get_plex_server,
+    get_home_users,
+    get_server_for_user,
+)
 from homescreen_hero.core.integrations.tautulli_client import get_tautulli_client
 from homescreen_hero.core.auth import get_current_user
 
@@ -114,6 +118,55 @@ class UnwatchedReportResponse(BaseModel):
     page_size: int
     total_pages: int
     time_period_description: str
+
+
+# Copy Watch History models
+class HomeUser(BaseModel):
+    id: int
+    username: str
+    title: str
+    thumb: Optional[str] = None
+    is_admin: bool = False
+
+
+class HomeUsersResponse(BaseModel):
+    users: List[HomeUser]
+
+
+class CopyWatchHistoryPreviewRequest(BaseModel):
+    source_user: str  # username
+    target_user: str  # username
+
+
+class WatchHistoryPreviewCounts(BaseModel):
+    movies_to_mark_watched: int = 0
+    movies_to_mark_unwatched: int = 0
+    episodes_to_mark_watched: int = 0
+    episodes_to_mark_unwatched: int = 0
+    shows_affected: int = 0
+
+
+class CopyWatchHistoryPreviewResponse(BaseModel):
+    source_user: str
+    target_user: str
+    counts: WatchHistoryPreviewCounts
+    libraries_processed: List[str]
+
+
+ConflictMode = Literal["only_add", "mirror"]
+
+
+class CopyWatchHistoryApplyRequest(BaseModel):
+    source_user: str  # username
+    target_user: str  # username
+    conflict_mode: ConflictMode
+
+
+class CopyWatchHistoryApplyResponse(BaseModel):
+    success: bool
+    movies_updated: int
+    episodes_updated: int
+    errors: List[str]
 
 
 @router.get("/recent-media", response_model=SearchMediaResponse)
@@ -688,4 +741,210 @@ def export_unwatched_report(
         content=csv_content,
         media_type="text/csv",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+# Copy Watch History endpoints
+
+@router.get("/home-users", response_model=HomeUsersResponse)
+def get_home_users_endpoint(
+    current_user: str = Depends(get_current_user),
+) -> HomeUsersResponse:
+    # Get list of Plex Home users available for watch history operations
+    config = load_config()
+    try:
+        users = get_home_users(config)
+        return HomeUsersResponse(users=[HomeUser(**u) for u in users])
+    except Exception as e:
+        logger.error(f"Failed to get home users: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to get Plex Home users. Ensure your Plex token has account access: {str(e)}"
+        )
+
+
+@router.post("/copy-watch-history/preview", response_model=CopyWatchHistoryPreviewResponse)
+def preview_copy_watch_history(
+    request: CopyWatchHistoryPreviewRequest,
+    current_user: str = Depends(get_current_user),
+) -> CopyWatchHistoryPreviewResponse:
+    # Preview what would be changed when copying watch history
+    config = load_config()
+
+    try:
+        source_server = get_server_for_user(config, request.source_user)
+        target_server = get_server_for_user(config, request.target_user)
+    except Exception as e:
+        logger.error(f"Failed to connect to servers: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to connect to Plex: {str(e)}")
+
+    # Get enabled libraries
+    enabled_libraries = [lib.name for lib in config.plex.libraries if lib.enabled]
+
+    counts = WatchHistoryPreviewCounts()
+    shows_affected = set()
+
+    for lib_name in enabled_libraries:
+        try:
+            source_section = source_server.library.section(lib_name)
+            target_section = target_server.library.section(lib_name)
+
+            if source_section.type == "movie":
+                # Compare movie watch status by GUID
+                source_movies = {m.guid: m for m in source_section.all()}
+                target_movies = {m.guid: m for m in target_section.all()}
+
+                for guid, source_movie in source_movies.items():
+                    if guid in target_movies:
+                        target_movie = target_movies[guid]
+                        source_watched = getattr(source_movie, "isWatched", False)
+                        target_watched = getattr(target_movie, "isWatched", False)
+
+                        if source_watched and not target_watched:
+                            counts.movies_to_mark_watched += 1
+                        elif not source_watched and target_watched:
+                            counts.movies_to_mark_unwatched += 1
+
+            elif source_section.type == "show":
+                # Compare at episode level
+                source_shows = {s.guid: s for s in source_section.all()}
+                target_shows = {s.guid: s for s in target_section.all()}
+
+                for guid, source_show in source_shows.items():
+                    if guid not in target_shows:
+                        continue
+
+                    target_show = target_shows[guid]
+                    show_has_changes = False
+
+                    # Get episodes and match by guid
+                    source_episodes = {e.guid: e for e in source_show.episodes()}
+                    target_episodes = {e.guid: e for e in target_show.episodes()}
+
+                    for ep_guid, source_ep in source_episodes.items():
+                        if ep_guid in target_episodes:
+                            target_ep = target_episodes[ep_guid]
+                            source_watched = getattr(source_ep, "isWatched", False)
+                            target_watched = getattr(target_ep, "isWatched", False)
+
+                            if source_watched and not target_watched:
+                                counts.episodes_to_mark_watched += 1
+                                show_has_changes = True
+                            elif not source_watched and target_watched:
+                                counts.episodes_to_mark_unwatched += 1
+                                show_has_changes = True
+
+                    if show_has_changes:
+                        shows_affected.add(source_show.title)
+
+        except Exception as e:
+            logger.warning(f"Error processing library {lib_name}: {e}")
+            continue
+
+    counts.shows_affected = len(shows_affected)
+
+    return CopyWatchHistoryPreviewResponse(
+        source_user=request.source_user,
+        target_user=request.target_user,
+        counts=counts,
+        libraries_processed=enabled_libraries,
+    )
+
+
+@router.post("/copy-watch-history/apply", response_model=CopyWatchHistoryApplyResponse)
+def apply_copy_watch_history(
+    request: CopyWatchHistoryApplyRequest,
+    current_user: str = Depends(get_current_user),
+) -> CopyWatchHistoryApplyResponse:
+    # Apply watch history copy from source to target user
+    config = load_config()
+
+    try:
+        source_server = get_server_for_user(config, request.source_user)
+        target_server = get_server_for_user(config, request.target_user)
+    except Exception as e:
+        logger.error(f"Failed to connect to servers: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to connect to Plex: {str(e)}")
+
+    enabled_libraries = [lib.name for lib in config.plex.libraries if lib.enabled]
+
+    movies_updated = 0
+    episodes_updated = 0
+    errors: List[str] = []
+
+    for lib_name in enabled_libraries:
+        try:
+            source_section = source_server.library.section(lib_name)
+            target_section = target_server.library.section(lib_name)
+
+            if source_section.type == "movie":
+                source_movies = {m.guid: m for m in source_section.all()}
+                target_movies = {m.guid: m for m in target_section.all()}
+
+                for guid, source_movie in source_movies.items():
+                    if guid not in target_movies:
+                        continue
+
+                    target_movie = target_movies[guid]
+                    source_watched = getattr(source_movie, "isWatched", False)
+                    target_watched = getattr(target_movie, "isWatched", False)
+
+                    try:
+                        if source_watched and not target_watched:
+                            target_movie.markPlayed()
+                            movies_updated += 1
+                        elif not source_watched and target_watched:
+                            # Only mark unwatched in mirror mode
+                            if request.conflict_mode == "mirror":
+                                target_movie.markUnplayed()
+                                movies_updated += 1
+                    except Exception as e:
+                        errors.append(f"Failed to update '{source_movie.title}': {str(e)}")
+
+            elif source_section.type == "show":
+                source_shows = {s.guid: s for s in source_section.all()}
+                target_shows = {s.guid: s for s in target_section.all()}
+
+                for guid, source_show in source_shows.items():
+                    if guid not in target_shows:
+                        continue
+
+                    target_show = target_shows[guid]
+
+                    source_episodes = {e.guid: e for e in source_show.episodes()}
+                    target_episodes = {e.guid: e for e in target_show.episodes()}
+
+                    for ep_guid, source_ep in source_episodes.items():
+                        if ep_guid not in target_episodes:
+                            continue
+
+                        target_ep = target_episodes[ep_guid]
+                        source_watched = getattr(source_ep, "isWatched", False)
+                        target_watched = getattr(target_ep, "isWatched", False)
+
+                        try:
+                            if source_watched and not target_watched:
+                                target_ep.markPlayed()
+                                episodes_updated += 1
+                            elif not source_watched and target_watched:
+                                if request.conflict_mode == "mirror":
+                                    target_ep.markUnplayed()
+                                    episodes_updated += 1
+                        except Exception as e:
+                            errors.append(
+                                f"Failed to update '{source_show.title}' - {source_ep.title}: {str(e)}"
+                            )
+
+        except Exception as e:
+            errors.append(f"Failed to process library '{lib_name}': {str(e)}")
+
+    logger.info(
+        f"Copy watch history complete: {movies_updated} movies, {episodes_updated} episodes updated, {len(errors)} errors"
+    )
+
+    return CopyWatchHistoryApplyResponse(
+        success=len(errors) == 0,
+        movies_updated=movies_updated,
+        episodes_updated=episodes_updated,
+        errors=errors,
     )

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -12,8 +12,17 @@ from homescreen_hero.core.rotation import (
     _is_blacklisted,
     _get_ordered_groups,
     _select_collections_from_group,
+    run_rotation_with_history,
+    run_auto_rotation_with_history,
 )
-from homescreen_hero.core.config.schema import CollectionGroupConfig, DateRange
+from homescreen_hero.core.config.schema import (
+    AppConfig,
+    CollectionGroupConfig,
+    DateRange,
+    PlexSettings,
+    PlexLibraryConfig,
+    RotationSettings,
+)
 
 
 # Mock CollectionUsage for testing
@@ -420,3 +429,395 @@ class TestSelectCollectionsFromGroup:
 
         # Should get oldest 3: A(1), B(2), C(3)
         assert chosen == ["A", "B", "C"]
+
+
+# Helper to create minimal AppConfig for testing
+def _make_test_config(
+    groups: list,
+    max_collections: int = 10,
+    per_library_limits: dict = None,
+    strategy: str = "random",
+    allow_repeats: bool = True,
+    blacklisted_collections: list = None,
+) -> AppConfig:
+    return AppConfig(
+        plex=PlexSettings(
+            base_url="http://localhost:32400",
+            token="test-token",
+            libraries=[
+                PlexLibraryConfig(name="Movies", enabled=True),
+                PlexLibraryConfig(name="TV Shows", enabled=True),
+            ],
+        ),
+        groups=groups,
+        rotation=RotationSettings(
+            enabled=True,
+            max_collections=max_collections,
+            strategy=strategy,
+            allow_repeats=allow_repeats,
+            blacklisted_collections=blacklisted_collections or [],
+            per_library_limits=per_library_limits or {},
+        ),
+    )
+
+
+class TestPerLibraryLimits:
+    """Tests for per-library collection limits in rotation"""
+
+    def test_library_limit_enforced_within_group(self):
+        """Library limit should restrict selections even when group has more collections"""
+        groups = [
+            CollectionGroupConfig(
+                name="Movies Group",
+                enabled=True,
+                min_picks=5,
+                max_picks=5,
+                collections=["Movie A", "Movie B", "Movie C", "Movie D", "Movie E"],
+            ),
+        ]
+        config = _make_test_config(
+            groups=groups,
+            max_collections=10,
+            per_library_limits={"Movies": 2},  # Only allow 2 from Movies
+        )
+        # All collections are from Movies library
+        collection_library_map = {
+            "Movie A": "Movies",
+            "Movie B": "Movies",
+            "Movie C": "Movies",
+            "Movie D": "Movies",
+            "Movie E": "Movies",
+        }
+
+        result = run_rotation_with_history(
+            config,
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            rng=random.Random(42),
+        )
+
+        # Should only select 2 despite group wanting 5
+        assert len(result.selected_collections) == 2
+        assert result.per_library_counts["Movies"] == 2
+
+    def test_library_limits_across_multiple_groups(self):
+        """Library limits should be enforced across multiple groups"""
+        groups = [
+            CollectionGroupConfig(
+                name="Group 1",
+                enabled=True,
+                min_picks=2,
+                max_picks=2,
+                collections=["Movie A", "Movie B"],
+            ),
+            CollectionGroupConfig(
+                name="Group 2",
+                enabled=True,
+                min_picks=2,
+                max_picks=2,
+                collections=["Movie C", "Movie D"],
+            ),
+        ]
+        config = _make_test_config(
+            groups=groups,
+            max_collections=10,
+            per_library_limits={"Movies": 3},  # Only allow 3 total from Movies
+        )
+        collection_library_map = {
+            "Movie A": "Movies",
+            "Movie B": "Movies",
+            "Movie C": "Movies",
+            "Movie D": "Movies",
+        }
+
+        result = run_rotation_with_history(
+            config,
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            rng=random.Random(42),
+        )
+
+        # Should select 3 total (2 from first group, 1 from second)
+        assert len(result.selected_collections) == 3
+        assert result.per_library_counts["Movies"] == 3
+
+    def test_no_limit_for_library_allows_unlimited(self):
+        """Collections from a library with no limit should be unrestricted"""
+        groups = [
+            CollectionGroupConfig(
+                name="Mixed Group",
+                enabled=True,
+                min_picks=5,
+                max_picks=5,
+                collections=["Movie A", "Movie B", "TV A", "TV B", "TV C"],
+            ),
+        ]
+        config = _make_test_config(
+            groups=groups,
+            max_collections=10,
+            per_library_limits={"Movies": 1},  # Only limit Movies, not TV Shows
+        )
+        collection_library_map = {
+            "Movie A": "Movies",
+            "Movie B": "Movies",
+            "TV A": "TV Shows",
+            "TV B": "TV Shows",
+            "TV C": "TV Shows",
+        }
+
+        result = run_rotation_with_history(
+            config,
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            rng=random.Random(42),
+        )
+
+        # 1 Movie (limited) + 3 TV Shows (all available, no limit) = 4 total
+        assert len(result.selected_collections) == 4
+        assert result.per_library_counts["Movies"] == 1
+        assert result.per_library_counts["TV Shows"] == 3
+
+    def test_unknown_library_collections_allowed(self):
+        """Collections not in the library map should be allowed"""
+        groups = [
+            CollectionGroupConfig(
+                name="Mixed Group",
+                enabled=True,
+                min_picks=3,
+                max_picks=3,
+                collections=["Known Movie", "Unknown Collection", "Another Unknown"],
+            ),
+        ]
+        config = _make_test_config(
+            groups=groups,
+            max_collections=10,
+            per_library_limits={"Movies": 1},
+        )
+        # Only one collection has a known library
+        collection_library_map = {
+            "Known Movie": "Movies",
+            # "Unknown Collection" and "Another Unknown" not in map
+        }
+
+        result = run_rotation_with_history(
+            config,
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            rng=random.Random(42),
+        )
+
+        # Should select all 3 (1 Movie limited, 2 unknown allowed)
+        assert len(result.selected_collections) == 3
+        assert result.per_library_counts.get("Movies", 0) <= 1
+
+    def test_empty_per_library_limits_allows_all(self):
+        """Empty per_library_limits should not restrict any selections"""
+        groups = [
+            CollectionGroupConfig(
+                name="Big Group",
+                enabled=True,
+                min_picks=5,
+                max_picks=5,
+                collections=["A", "B", "C", "D", "E"],
+            ),
+        ]
+        config = _make_test_config(
+            groups=groups,
+            max_collections=10,
+            per_library_limits={},  # No limits
+        )
+        collection_library_map = {
+            "A": "Movies",
+            "B": "Movies",
+            "C": "Movies",
+            "D": "Movies",
+            "E": "Movies",
+        }
+
+        result = run_rotation_with_history(
+            config,
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            rng=random.Random(42),
+        )
+
+        # Should select all 5 with no limits
+        assert len(result.selected_collections) == 5
+
+    def test_library_limit_zero_blocks_all(self):
+        """A library limit of 0 should block all collections from that library"""
+        groups = [
+            CollectionGroupConfig(
+                name="Movies Group",
+                enabled=True,
+                min_picks=3,
+                max_picks=3,
+                collections=["Movie A", "Movie B", "Movie C"],
+            ),
+        ]
+        config = _make_test_config(
+            groups=groups,
+            max_collections=10,
+            per_library_limits={"Movies": 0},  # Block all Movies
+        )
+        collection_library_map = {
+            "Movie A": "Movies",
+            "Movie B": "Movies",
+            "Movie C": "Movies",
+        }
+
+        result = run_rotation_with_history(
+            config,
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            rng=random.Random(42),
+        )
+
+        # No collections should be selected
+        assert len(result.selected_collections) == 0
+        assert result.per_library_counts.get("Movies", 0) == 0
+
+    def test_per_library_counts_tracked_in_result(self):
+        """RotationResult should include per_library_counts"""
+        groups = [
+            CollectionGroupConfig(
+                name="Mixed",
+                enabled=True,
+                min_picks=4,
+                max_picks=4,
+                collections=["Movie A", "Movie B", "TV A", "TV B"],
+            ),
+        ]
+        config = _make_test_config(
+            groups=groups,
+            max_collections=10,
+        )
+        collection_library_map = {
+            "Movie A": "Movies",
+            "Movie B": "Movies",
+            "TV A": "TV Shows",
+            "TV B": "TV Shows",
+        }
+
+        result = run_rotation_with_history(
+            config,
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            rng=random.Random(42),
+        )
+
+        # Result should track counts per library
+        assert "Movies" in result.per_library_counts or "TV Shows" in result.per_library_counts
+        total_tracked = sum(result.per_library_counts.values())
+        assert total_tracked == 4
+
+
+class TestAutoRotationPerLibraryLimits:
+    """Tests for per-library limits in auto-rotation mode"""
+
+    def test_auto_rotation_library_limit_enforced(self):
+        """Auto-rotation should respect per-library limits"""
+        all_collections = ["Movie A", "Movie B", "Movie C", "TV A", "TV B"]
+        collection_library_map = {
+            "Movie A": "Movies",
+            "Movie B": "Movies",
+            "Movie C": "Movies",
+            "TV A": "TV Shows",
+            "TV B": "TV Shows",
+        }
+
+        result = run_auto_rotation_with_history(
+            all_collections,
+            max_collections=5,
+            strategy="random",
+            blacklisted_collections=[],
+            allow_repeats=True,
+            last_rotation_collections=[],
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            per_library_limits={"Movies": 2, "TV Shows": 1},
+            rng=random.Random(42),
+        )
+
+        # Should respect limits: max 2 Movies + max 1 TV Show = 3 total
+        assert len(result.selected_collections) == 3
+        assert result.per_library_counts.get("Movies", 0) <= 2
+        assert result.per_library_counts.get("TV Shows", 0) <= 1
+
+    def test_auto_rotation_no_limits(self):
+        """Auto-rotation without limits should select up to max_collections"""
+        all_collections = ["A", "B", "C", "D", "E"]
+        collection_library_map = {c: "Movies" for c in all_collections}
+
+        result = run_auto_rotation_with_history(
+            all_collections,
+            max_collections=5,
+            strategy="random",
+            blacklisted_collections=[],
+            allow_repeats=True,
+            last_rotation_collections=[],
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            per_library_limits={},  # No limits
+            rng=random.Random(42),
+        )
+
+        assert len(result.selected_collections) == 5
+
+    def test_auto_rotation_iterative_selection(self):
+        """Auto-rotation with limits should use iterative selection"""
+        all_collections = ["M1", "M2", "M3", "M4", "T1", "T2"]
+        collection_library_map = {
+            "M1": "Movies", "M2": "Movies", "M3": "Movies", "M4": "Movies",
+            "T1": "TV Shows", "T2": "TV Shows",
+        }
+
+        result = run_auto_rotation_with_history(
+            all_collections,
+            max_collections=4,
+            strategy="random",
+            blacklisted_collections=[],
+            allow_repeats=True,
+            last_rotation_collections=[],
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            per_library_limits={"Movies": 2, "TV Shows": 2},
+            rng=random.Random(42),
+        )
+
+        # Should select 4 total, respecting both limits
+        assert len(result.selected_collections) == 4
+        assert result.per_library_counts.get("Movies", 0) <= 2
+        assert result.per_library_counts.get("TV Shows", 0) <= 2
+
+    def test_auto_rotation_unknown_collections_allowed(self):
+        """Auto-rotation should allow collections not in library map"""
+        all_collections = ["Known", "Unknown1", "Unknown2"]
+        collection_library_map = {"Known": "Movies"}
+
+        result = run_auto_rotation_with_history(
+            all_collections,
+            max_collections=3,
+            strategy="random",
+            blacklisted_collections=[],
+            allow_repeats=True,
+            last_rotation_collections=[],
+            max_rotation_id=0,
+            usage_map={},
+            collection_library_map=collection_library_map,
+            per_library_limits={"Movies": 1},
+            rng=random.Random(42),
+        )
+
+        # Should select all 3 (1 from Movies, 2 unknown)
+        assert len(result.selected_collections) == 3


### PR DESCRIPTION
## Feature: Per-Library Limits, Copy Watch History Tool, User-Requested Changes

### Summary
A collection of smaller features and fixes that have been requested by users. The biggest additions are a new "Copy Watch History" tool for syncing watched status between Plex Home users, and per-library collection limits for finer control over rotation.

### Major Changes
- Added a new "Copy Watch History" tool that lets you sync watched status between Plex Home users. Supports two modes: "Add Only" (only mark things watched) and "Mirror" (make watch history identical). Includes a preview step and real-time progress bar during the apply phase.
- Added per-library collection limits to rotation settings. You can now cap how many collections come from each library (e.g., max 6 from Movies, max 6 from TV Shows). This works alongside the global max and is useful for balancing content across libraries.

### Minor Changes
- Added season/episode numbers (S00, E00 format) to the Active Plex Streams modal so you can see exactly what episode someone is watching.
- Fixed pagination overflow on group detail page - now shows ellipsis (`...`) instead of rendering 50+ page buttons when you have lots of content sources.
- Added `@radix-ui/react-progress` component for the progress bar UI.