### PR TITLE
Feature: Add file size/sorting to Unwatched Report tool

### DIFF
--- a/homescreen-hero-ui/src/components/tools/UnwatchedReport.tsx
+++ b/homescreen-hero-ui/src/components/tools/UnwatchedReport.tsx
@@ -42,6 +42,7 @@ type UnwatchedItem = {
     added_at: string | null;
     last_watched_at: string | null;
     total_plays: number;
+    file_size: number | null;
 };
 
 type Library = {
@@ -51,6 +52,7 @@ type Library = {
 
 type UnwatchedMode = "never_watched" | "not_watched_since";
 type TimePeriod = "30d" | "90d" | "6m" | "1y" | "all" | "custom";
+type SortBy = "title" | "size_desc" | "size_asc" | "added_desc" | "added_asc";
 
 type UnwatchedReportProps = {
     onClose: () => void;
@@ -69,6 +71,7 @@ export default function UnwatchedReport({ onClose }: UnwatchedReportProps) {
     });
     const [calendarOpen, setCalendarOpen] = useState(false);
     const [calendarMonth, setCalendarMonth] = useState<Date>(customDate);
+    const [sortBy, setSortBy] = useState<SortBy>("title");
 
     // Report state
     const [items, setItems] = useState<UnwatchedItem[]>([]);
@@ -229,6 +232,38 @@ export default function UnwatchedReport({ onClose }: UnwatchedReportProps) {
         }
     };
 
+    // Format file size for display
+    const formatFileSize = (sizeBytes: number | null): string => {
+        if (!sizeBytes) return "Unknown";
+        const sizeGB = sizeBytes / (1024 ** 3);
+        if (sizeGB >= 1000) {
+            const sizeTB = sizeGB / 1024;
+            return `${sizeTB.toFixed(2)} TB`;
+        }
+        return `${sizeGB.toFixed(2)} GB`;
+    };
+
+    // Sort items based on selected sort option
+    const sortedItems = [...items].sort((a, b) => {
+        switch (sortBy) {
+            case "size_desc":
+                return (b.file_size || 0) - (a.file_size || 0);
+            case "size_asc":
+                return (a.file_size || 0) - (b.file_size || 0);
+            case "added_desc":
+                if (!a.added_at) return 1;
+                if (!b.added_at) return -1;
+                return new Date(b.added_at).getTime() - new Date(a.added_at).getTime();
+            case "added_asc":
+                if (!a.added_at) return 1;
+                if (!b.added_at) return -1;
+                return new Date(a.added_at).getTime() - new Date(b.added_at).getTime();
+            case "title":
+            default:
+                return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+        }
+    });
+
     const timePeriods = [
         { value: "30d", label: "30 days" },
         { value: "90d", label: "90 days" },
@@ -236,6 +271,14 @@ export default function UnwatchedReport({ onClose }: UnwatchedReportProps) {
         { value: "1y", label: "1 year" },
         { value: "all", label: "All time" },
         { value: "custom", label: "Custom" },
+    ];
+
+    const sortOptions = [
+        { value: "title", label: "Title (A-Z)" },
+        { value: "size_desc", label: "Size (Largest First)" },
+        { value: "size_asc", label: "Size (Smallest First)" },
+        { value: "added_desc", label: "Date Added (Newest)" },
+        { value: "added_asc", label: "Date Added (Oldest)" },
     ];
 
     return (
@@ -406,18 +449,48 @@ export default function UnwatchedReport({ onClose }: UnwatchedReportProps) {
                 <div className="flex-1 overflow-y-auto px-6 py-4 scrollbar-hover-only min-h-[300px]">
                     {hasGenerated && items.length > 0 ? (
                         <div className={`space-y-3 transition-opacity duration-150 ${loading ? "opacity-50" : ""}`}>
-                            {/* Summary */}
-                            <div className="flex items-center justify-between">
-                                <p className="text-sm text-slate-400">
-                                    Found <span className="text-white font-medium">{totalCount}</span> unwatched item{totalCount !== 1 ? "s" : ""}
-                                    {loading && <Loader2 className="inline h-3 w-3 animate-spin ml-2" />}
-                                </p>
+                            {/* Summary and Sort */}
+                            <div className="flex items-center justify-between gap-4">
+                                <div className="flex items-center gap-4">
+                                    <p className="text-sm text-slate-400">
+                                        Found <span className="text-white font-medium">{totalCount}</span> unwatched item{totalCount !== 1 ? "s" : ""}
+                                        {loading && <Loader2 className="inline h-3 w-3 animate-spin ml-2" />}
+                                    </p>
+
+                                    {/* Sort Dropdown */}
+                                    <Listbox value={sortBy} onChange={setSortBy}>
+                                        <div className="relative">
+                                            <Listbox.Button className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-1.5 text-xs text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-primary/70 transition-colors">
+                                                <span>
+                                                    Sort: {sortOptions.find(opt => opt.value === sortBy)?.label}
+                                                </span>
+                                                <ChevronDown className="h-3 w-3 text-slate-400" />
+                                            </Listbox.Button>
+                                            <Listbox.Options className="absolute left-0 z-10 mt-1 w-48 rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg focus:outline-none">
+                                                {sortOptions.map((opt) => (
+                                                    <Listbox.Option
+                                                        key={opt.value}
+                                                        value={opt.value}
+                                                        className="cursor-pointer px-3 py-2 text-xs text-white hover:bg-slate-700 data-[selected]:bg-primary data-[selected]:font-semibold flex items-center justify-between"
+                                                    >
+                                                        {({ selected }) => (
+                                                            <>
+                                                                <span>{opt.label}</span>
+                                                                {selected && <Check className="h-3 w-3 text-white" />}
+                                                            </>
+                                                        )}
+                                                    </Listbox.Option>
+                                                ))}
+                                            </Listbox.Options>
+                                        </div>
+                                    </Listbox>
+                                </div>
                                 <p className="text-xs text-slate-500">{timeDescription}</p>
                             </div>
 
                             {/* Results Grid */}
                             <div className="grid gap-2">
-                                {items.map((item) => (
+                                {sortedItems.map((item) => (
                                     <div
                                         key={item.rating_key}
                                         className="flex items-center gap-3 p-2.5 rounded-lg border border-slate-800/60 bg-slate-900/50"
@@ -448,6 +521,12 @@ export default function UnwatchedReport({ onClose }: UnwatchedReportProps) {
                                             <p className="text-xs text-slate-500">
                                                 {item.library} · {item.type}
                                             </p>
+                                        </div>
+
+                                        {/* File size */}
+                                        <div className="text-right flex-shrink-0 min-w-[80px]">
+                                            <p className="text-xs text-slate-500 uppercase tracking-wide">Size</p>
+                                            <p className="text-sm text-slate-300">{formatFileSize(item.file_size)}</p>
                                         </div>
 
                                         {/* Added date */}

--- a/homescreen_hero/web/routers/tools.py
+++ b/homescreen_hero/web/routers/tools.py
@@ -111,6 +111,7 @@ class UnwatchedItem(BaseModel):
     added_at: Optional[str] = None
     last_watched_at: Optional[str] = None
     total_plays: int = 0
+    file_size: Optional[int] = None  # Size in bytes
 
 
 class UnwatchedReportResponse(BaseModel):
@@ -495,6 +496,36 @@ def _get_time_period_description(
     return descriptions.get(time_period or "all", "Items not watched")
 
 
+def _get_item_file_size(item) -> Optional[int]:
+    # Calculate total file size in bytes for a Plex item
+    # For movies: sum all media parts
+    # For TV shows: sum all episode media parts
+    try:
+        if item.type == "movie":
+            total_size = 0
+            for media in item.media:
+                for part in media.parts:
+                    if hasattr(part, "size") and part.size:
+                        total_size += part.size
+            return total_size if total_size > 0 else None
+
+        elif item.type == "show":
+            # For shows, we need to sum up all episodes
+            total_size = 0
+            episodes = item.episodes()
+            for episode in episodes:
+                for media in episode.media:
+                    for part in media.parts:
+                        if hasattr(part, "size") and part.size:
+                            total_size += part.size
+            return total_size if total_size > 0 else None
+
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to get file size for '{item.title}': {e}")
+        return None
+
+
 def _get_unwatched_items(
     config,
     library_name: str,
@@ -624,6 +655,9 @@ def _get_unwatched_items(
                 last_watched.strftime("%Y-%m-%d") if last_watched else None
             )
 
+            # Get file size
+            file_size = _get_item_file_size(item)
+
             unwatched_items.append(
                 {
                     "rating_key": rating_key,
@@ -635,6 +669,7 @@ def _get_unwatched_items(
                     "added_at": added_at_str,
                     "last_watched_at": last_watched_str,
                     "total_plays": total_plays,
+                    "file_size": file_size,
                 }
             )
 
@@ -709,13 +744,25 @@ def export_unwatched_report(
         config, request.library, request.unwatched_mode, cutoff_date
     )
 
+    # Helper to format file size
+    def format_file_size(size_bytes: Optional[int]) -> str:
+        if not size_bytes:
+            return "Unknown"
+        # Convert to GB
+        size_gb = size_bytes / (1024 ** 3)
+        if size_gb >= 1000:
+            # Use TB for very large sizes
+            size_tb = size_gb / 1024
+            return f"{size_tb:.2f} TB"
+        return f"{size_gb:.2f} GB"
+
     # Build CSV content
     output = io.StringIO()
     writer = csv.writer(output)
 
     # Header row
     writer.writerow(
-        ["Title", "Year", "Type", "Library", "Added Date", "Last Watched", "Total Plays"]
+        ["Title", "Year", "Type", "Library", "Added Date", "Last Watched", "Total Plays", "File Size"]
     )
 
     # Data rows
@@ -729,6 +776,7 @@ def export_unwatched_report(
                 item["added_at"] or "",
                 item["last_watched_at"] or "Never",
                 item["total_plays"],
+                format_file_size(item.get("file_size")),
             ]
         )
 

--- a/tests/test_tautulli_client.py
+++ b/tests/test_tautulli_client.py
@@ -112,7 +112,7 @@ class TestTautulliClient:
         success, error = tautulli_client.ping()
 
         assert success is False
-        assert "timeout" in error.lower()
+        assert "timed out" in error.lower()
 
     @patch('homescreen_hero.core.integrations.tautulli_client.requests.Session.get')
     def test_ping_unauthorized(self, mock_get, tautulli_client):
@@ -326,7 +326,7 @@ class TestTautulliClient:
         success, error = tautulli_client.ping()
 
         assert success is False
-        assert "error" in error.lower()
+        assert "connection" in error.lower() or "refused" in error.lower()
 
 
 def _make_config(tautulli=None):

--- a/tests/test_trakt_client.py
+++ b/tests/test_trakt_client.py
@@ -72,7 +72,7 @@ class TestTraktClient:
         success, error = trakt_client.ping()
 
         assert success is False
-        assert "timeout" in error.lower()
+        assert "timed out" in error.lower()
 
     @patch('homescreen_hero.core.integrations.trakt_client.requests.Session.request')
     def test_ping_http_error(self, mock_request, trakt_client):


### PR DESCRIPTION
## Feature: Add file size/sorting to Unwatched Report tool

### Summary
Added file size display and sorting to the unwatched report, making it easy to find large unwatched content taking up storage space.

### Major Changes
- Shows file sizes for movies and TV shows (uses Plex API, no Sonarr/Radarr needed)
- Added sort dropdown with options: Size (Largest/Smallest), Date Added (Newest/Oldest), Title
- File sizes display in GB/TB format in both UI and CSV export

### Minor Changes
- Fixed 3 test assertions to match actual error messages

### Notes
TV show reports may be slower since we fetch all episodes to calculate total size.