### PR TITLE
Feature: Config backup/restore and collections list view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 
 # --- Local config (DO NOT COMMIT THIS) ---
 config.yaml
+config.yaml.bak
 .env
 
 # --- SQLite database & logs ---

--- a/homescreen-hero-ui/src/pages/CollectionsPage.tsx
+++ b/homescreen-hero-ui/src/pages/CollectionsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchWithAuth } from "../utils/api";
-import { RefreshCw, Plus, Search, Trash2, Check, ChevronDown, ArrowUpAZ, ArrowDownAZ, Edit, Image, Pin, Home, Users, Star } from "lucide-react";
+import { RefreshCw, Plus, Search, Trash2, Check, ChevronDown, ArrowUpAZ, ArrowDownAZ, Edit, Image, Pin, Home, Users, Star, LayoutGrid, List } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "../components/ui/popover";
 import { Listbox } from "@headlessui/react";
 import Toast from "../components/Toast";
@@ -53,27 +53,19 @@ type VisibilityOptions = {
     recommended: boolean;
 };
 
-// Collection card component with pin popover
-function CollectionCard({
-    collection,
-    index,
+type ViewMode = "cards" | "list";
+
+// Shared pin popover used by both card and list views
+function PinPopover({
     isPinned,
     isPinning,
     onPinWithVisibility,
     onUnpin,
-    onClick,
-    onEdit,
-    onDelete,
 }: {
-    collection: Collection;
-    index: number;
     isPinned: boolean;
     isPinning: boolean;
     onPinWithVisibility: (visibility: VisibilityOptions) => void;
     onUnpin: () => void;
-    onClick: () => void;
-    onEdit: (e: React.MouseEvent) => void;
-    onDelete: (e: React.MouseEvent) => void;
 }) {
     const [popoverOpen, setPopoverOpen] = useState(false);
     const [visibility, setVisibility] = useState<VisibilityOptions>({
@@ -99,6 +91,117 @@ function CollectionCard({
         setPopoverOpen(open);
     };
 
+    return (
+        <Popover open={popoverOpen} onOpenChange={handleOpenChange}>
+            <PopoverTrigger asChild>
+                <button
+                    disabled={isPinning}
+                    className={`p-2 rounded-lg transition-colors ${
+                        isPinned
+                            ? "bg-primary/80 hover:bg-primary text-white"
+                            : "bg-slate-800/70 hover:bg-slate-700/90 text-slate-300"
+                    } disabled:opacity-50`}
+                    title={isPinned ? "Edit pin settings" : "Pin to home"}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <Pin size={16} className={isPinned ? "fill-current" : ""} />
+                </button>
+            </PopoverTrigger>
+            <PopoverContent
+                align="end"
+                className="w-44 p-2.5 bg-slate-900/90 backdrop-blur-md border-slate-700/50"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="space-y-1.5">
+                    <label className="flex items-center gap-2 px-1.5 py-1 rounded-md cursor-pointer hover:bg-white/5 transition-colors">
+                        <input
+                            type="checkbox"
+                            checked={visibility.home}
+                            onChange={(e) => setVisibility(v => ({ ...v, home: e.target.checked }))}
+                            className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-800/50 text-primary focus:ring-1 focus:ring-primary/50 focus:ring-offset-0"
+                        />
+                        <Home size={12} className="text-slate-500" />
+                        <span className="text-xs text-slate-300">My Home</span>
+                    </label>
+
+                    <label className="flex items-center gap-2 px-1.5 py-1 rounded-md cursor-pointer hover:bg-white/5 transition-colors">
+                        <input
+                            type="checkbox"
+                            checked={visibility.shared}
+                            onChange={(e) => setVisibility(v => ({ ...v, shared: e.target.checked }))}
+                            className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-800/50 text-primary focus:ring-1 focus:ring-primary/50 focus:ring-offset-0"
+                        />
+                        <Users size={12} className="text-slate-500" />
+                        <span className="text-xs text-slate-300">Shared</span>
+                    </label>
+
+                    <label className="flex items-center gap-2 px-1.5 py-1 rounded-md cursor-pointer hover:bg-white/5 transition-colors">
+                        <input
+                            type="checkbox"
+                            checked={visibility.recommended}
+                            onChange={(e) => setVisibility(v => ({ ...v, recommended: e.target.checked }))}
+                            className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-800/50 text-primary focus:ring-1 focus:ring-primary/50 focus:ring-offset-0"
+                        />
+                        <Star size={12} className="text-slate-500" />
+                        <span className="text-xs text-slate-300">Recommended</span>
+                    </label>
+
+                    <div className="pt-1.5 flex gap-1.5">
+                        {isPinned ? (
+                            <>
+                                <button
+                                    onClick={handleUnpin}
+                                    disabled={isPinning}
+                                    className="flex-1 px-2 py-1 text-[10px] font-medium rounded-md border border-slate-600/50 text-slate-400 hover:bg-slate-800/50 hover:text-white transition-colors disabled:opacity-50"
+                                >
+                                    Unpin
+                                </button>
+                                <button
+                                    onClick={handlePin}
+                                    disabled={isPinning || (!visibility.home && !visibility.shared && !visibility.recommended)}
+                                    className="flex-1 px-2 py-1 text-[10px] font-medium rounded-md bg-primary/90 hover:bg-primary text-white transition-colors disabled:opacity-50"
+                                >
+                                    Update
+                                </button>
+                            </>
+                        ) : (
+                            <button
+                                onClick={handlePin}
+                                disabled={isPinning || (!visibility.home && !visibility.shared && !visibility.recommended)}
+                                className="w-full px-2 py-1 text-[10px] font-medium rounded-md bg-primary/90 hover:bg-primary text-white transition-colors disabled:opacity-50"
+                            >
+                                Pin
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </PopoverContent>
+        </Popover>
+    );
+}
+
+// Collection card component for grid view
+function CollectionCard({
+    collection,
+    index,
+    isPinned,
+    isPinning,
+    onPinWithVisibility,
+    onUnpin,
+    onClick,
+    onEdit,
+    onDelete,
+}: {
+    collection: Collection;
+    index: number;
+    isPinned: boolean;
+    isPinning: boolean;
+    onPinWithVisibility: (visibility: VisibilityOptions) => void;
+    onUnpin: () => void;
+    onClick: () => void;
+    onEdit: (e: React.MouseEvent) => void;
+    onDelete: (e: React.MouseEvent) => void;
+}) {
     return (
         <div
             key={`${collection.library}-${collection.title}`}
@@ -152,95 +255,12 @@ function CollectionCard({
 
             {/* Action Buttons (shown on hover, top-right) */}
             <div className="absolute top-2 right-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
-                {/* Pin Button with Popover */}
-                <Popover open={popoverOpen} onOpenChange={handleOpenChange}>
-                    <PopoverTrigger asChild>
-                        <button
-                            disabled={isPinning}
-                            className={`p-2 rounded-lg transition-colors ${
-                                isPinned
-                                    ? "bg-primary/80 hover:bg-primary text-white"
-                                    : "bg-slate-800/70 hover:bg-slate-700/90 text-slate-300"
-                            } disabled:opacity-50`}
-                            title={isPinned ? "Edit pin settings" : "Pin to home"}
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            <Pin size={16} className={isPinned ? "fill-current" : ""} />
-                        </button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                        align="end"
-                        className="w-44 p-2.5 bg-slate-900/90 backdrop-blur-md border-slate-700/50"
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <div className="space-y-1.5">
-                            {/* My Home checkbox */}
-                            <label className="flex items-center gap-2 px-1.5 py-1 rounded-md cursor-pointer hover:bg-white/5 transition-colors">
-                                <input
-                                    type="checkbox"
-                                    checked={visibility.home}
-                                    onChange={(e) => setVisibility(v => ({ ...v, home: e.target.checked }))}
-                                    className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-800/50 text-primary focus:ring-1 focus:ring-primary/50 focus:ring-offset-0"
-                                />
-                                <Home size={12} className="text-slate-500" />
-                                <span className="text-xs text-slate-300">My Home</span>
-                            </label>
-
-                            {/* Shared checkbox */}
-                            <label className="flex items-center gap-2 px-1.5 py-1 rounded-md cursor-pointer hover:bg-white/5 transition-colors">
-                                <input
-                                    type="checkbox"
-                                    checked={visibility.shared}
-                                    onChange={(e) => setVisibility(v => ({ ...v, shared: e.target.checked }))}
-                                    className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-800/50 text-primary focus:ring-1 focus:ring-primary/50 focus:ring-offset-0"
-                                />
-                                <Users size={12} className="text-slate-500" />
-                                <span className="text-xs text-slate-300">Shared</span>
-                            </label>
-
-                            {/* Recommended checkbox */}
-                            <label className="flex items-center gap-2 px-1.5 py-1 rounded-md cursor-pointer hover:bg-white/5 transition-colors">
-                                <input
-                                    type="checkbox"
-                                    checked={visibility.recommended}
-                                    onChange={(e) => setVisibility(v => ({ ...v, recommended: e.target.checked }))}
-                                    className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-800/50 text-primary focus:ring-1 focus:ring-primary/50 focus:ring-offset-0"
-                                />
-                                <Star size={12} className="text-slate-500" />
-                                <span className="text-xs text-slate-300">Recommended</span>
-                            </label>
-
-                            <div className="pt-1.5 flex gap-1.5">
-                                {isPinned ? (
-                                    <>
-                                        <button
-                                            onClick={handleUnpin}
-                                            disabled={isPinning}
-                                            className="flex-1 px-2 py-1 text-[10px] font-medium rounded-md border border-slate-600/50 text-slate-400 hover:bg-slate-800/50 hover:text-white transition-colors disabled:opacity-50"
-                                        >
-                                            Unpin
-                                        </button>
-                                        <button
-                                            onClick={handlePin}
-                                            disabled={isPinning || (!visibility.home && !visibility.shared && !visibility.recommended)}
-                                            className="flex-1 px-2 py-1 text-[10px] font-medium rounded-md bg-primary/90 hover:bg-primary text-white transition-colors disabled:opacity-50"
-                                        >
-                                            Update
-                                        </button>
-                                    </>
-                                ) : (
-                                    <button
-                                        onClick={handlePin}
-                                        disabled={isPinning || (!visibility.home && !visibility.shared && !visibility.recommended)}
-                                        className="w-full px-2 py-1 text-[10px] font-medium rounded-md bg-primary/90 hover:bg-primary text-white transition-colors disabled:opacity-50"
-                                    >
-                                        Pin
-                                    </button>
-                                )}
-                            </div>
-                        </div>
-                    </PopoverContent>
-                </Popover>
+                <PinPopover
+                    isPinned={isPinned}
+                    isPinning={isPinning}
+                    onPinWithVisibility={onPinWithVisibility}
+                    onUnpin={onUnpin}
+                />
 
                 {/* Delete Button */}
                 <button
@@ -273,6 +293,9 @@ export default function CollectionsPage() {
     const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
     const [selectedLibraryFilter, setSelectedLibraryFilter] = useState<string>("all");
     const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+    const [viewMode, setViewMode] = useState<ViewMode>(
+        () => (localStorage.getItem("collectionsViewMode") as ViewMode) || "cards"
+    );
     const [lastCacheCheck, setLastCacheCheck] = useState<number | null>(null);
     const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
 
@@ -526,6 +549,11 @@ export default function CollectionsPage() {
         loadCollections(true);
     };
 
+    const handleViewModeChange = (mode: ViewMode) => {
+        setViewMode(mode);
+        localStorage.setItem("collectionsViewMode", mode);
+    };
+
     const searchMovies = async (query: string, libraryName?: string) => {
         // Use provided library name or fall back to state
         const library = libraryName || newCollectionLibrary;
@@ -702,7 +730,7 @@ export default function CollectionsPage() {
         // Fetch full collection details to get summary
         try {
             const response = await fetchWithAuth(
-                `/api/collections/${encodeURIComponent(collection.library)}/${encodeURIComponent(collection.title)}`
+                `/api/collections/${encodeURIComponent(collection.library)}/${encodeURIComponent(collection.title)}/details`
             );
             const data = await response.json();
             setQuickEditSummary(data.summary || "");
@@ -843,19 +871,30 @@ export default function CollectionsPage() {
                             <div className="h-4 w-28 bg-slate-800/60 rounded animate-pulse"></div>
                         </div>
                     </div>
-                    <div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-                        {Array.from({ length: 18 }).map((_, i) => (
-                            <div key={i} className="rounded-xl overflow-hidden border border-slate-800/60 bg-slate-900/50 animate-pulse">
-                                {/* Poster skeleton */}
-                                <div className="aspect-[2/3] bg-slate-800/60"></div>
-                                {/* Info skeleton */}
-                                <div className="p-3 space-y-2">
-                                    <div className="h-4 bg-slate-800/60 rounded w-3/4 mx-auto"></div>
-                                    <div className="h-3 bg-slate-800/60 rounded w-1/2 mx-auto"></div>
+                    {viewMode === "list" ? (
+                        <div className="flex flex-col gap-1.5">
+                            {Array.from({ length: 12 }).map((_, i) => (
+                                <div key={i} className="flex items-center gap-4 rounded-xl border border-slate-800/60 bg-slate-900/50 px-4 py-2.5 animate-pulse">
+                                    <div className="h-10 w-10 rounded-lg bg-slate-800/60 shrink-0" />
+                                    <div className="h-4 bg-slate-800/60 rounded flex-1 max-w-[200px]" />
+                                    <div className="h-4 bg-slate-800/60 rounded w-16 hidden sm:block" />
+                                    <div className="h-4 bg-slate-800/60 rounded w-12" />
                                 </div>
-                            </div>
-                        ))}
-                    </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+                            {Array.from({ length: 18 }).map((_, i) => (
+                                <div key={i} className="rounded-xl overflow-hidden border border-slate-800/60 bg-slate-900/50 animate-pulse">
+                                    <div className="aspect-[2/3] bg-slate-800/60"></div>
+                                    <div className="p-3 space-y-2">
+                                        <div className="h-4 bg-slate-800/60 rounded w-3/4 mx-auto"></div>
+                                        <div className="h-3 bg-slate-800/60 rounded w-1/2 mx-auto"></div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
                 </div>
             </div>
         );
@@ -976,9 +1015,37 @@ export default function CollectionsPage() {
                         <ArrowDownAZ className="h-5 w-5" />
                     )}
                 </button>
+
+                {/* View Mode Toggle */}
+                <div className="inline-flex rounded-lg border border-slate-700 bg-slate-900 p-0.5">
+                    <button
+                        type="button"
+                        onClick={() => handleViewModeChange("cards")}
+                        className={`inline-flex items-center justify-center rounded-md p-1.5 transition-all duration-200 ${
+                            viewMode === "cards"
+                                ? "bg-primary/20 text-primary"
+                                : "text-slate-400 hover:text-slate-200"
+                        }`}
+                        title="Card view"
+                    >
+                        <LayoutGrid className="h-4 w-4" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => handleViewModeChange("list")}
+                        className={`inline-flex items-center justify-center rounded-md p-1.5 transition-all duration-200 ${
+                            viewMode === "list"
+                                ? "bg-primary/20 text-primary"
+                                : "text-slate-400 hover:text-slate-200"
+                        }`}
+                        title="List view"
+                    >
+                        <List className="h-4 w-4" />
+                    </button>
+                </div>
             </div>
 
-            {/* Collections Grid */}
+            {/* Collections */}
             <div>
                 <div className="flex items-center justify-between mb-4">
                     <div>
@@ -1000,6 +1067,81 @@ export default function CollectionsPage() {
                         >
                             Create your first collection
                         </button>
+                    </div>
+                ) : viewMode === "list" ? (
+                    <div className="flex flex-col gap-1.5">
+                        {filteredCollections.map((collection) => (
+                            <div
+                                key={`${collection.library}-${collection.title}`}
+                                role="button"
+                                tabIndex={0}
+                                onClick={() => handleCollectionClick(collection)}
+                                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleCollectionClick(collection); } }}
+                                className="group flex items-center gap-4 rounded-xl border border-slate-800/60 bg-slate-900/50 px-4 py-2.5 hover:border-slate-700 hover:bg-slate-900/80 transition-all duration-200 cursor-pointer"
+                            >
+                                {/* Square Thumbnail */}
+                                <div className="h-10 w-10 rounded-lg overflow-hidden bg-slate-800 shrink-0">
+                                    {collection.poster_url ? (
+                                        <img
+                                            src={collection.poster_url}
+                                            alt={collection.title}
+                                            className="w-full h-full object-cover"
+                                            loading="lazy"
+                                        />
+                                    ) : (
+                                        <div className="w-full h-full flex items-center justify-center text-slate-600">
+                                            <Image size={16} />
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* Title + Active Indicator */}
+                                <div className="flex items-center gap-2 flex-1 min-w-0">
+                                    <span className="text-sm font-semibold text-white truncate">
+                                        {collection.title}
+                                    </span>
+                                    {collection.is_active && (
+                                        <span className="h-2 w-2 rounded-full bg-emerald-400 shrink-0" title="Active" />
+                                    )}
+                                </div>
+
+                                {/* Library Badge */}
+                                <span className="hidden sm:inline-flex rounded-full bg-slate-800 px-2.5 py-0.5 text-xs text-slate-400 border border-slate-700/50 shrink-0">
+                                    {collection.library}
+                                </span>
+
+                                {/* Item Count */}
+                                <span className="text-xs text-slate-500 shrink-0">
+                                    {collection.item_count} items
+                                </span>
+
+                                {/* Action Buttons */}
+                                <div className="flex items-center gap-1.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" onClick={(e) => e.stopPropagation()}>
+                                    <button
+                                        onClick={(e) => openQuickEditModal(collection, e)}
+                                        className="p-1.5 rounded-lg bg-slate-800/70 hover:bg-slate-700 text-slate-400 hover:text-white transition-colors"
+                                        title="Edit collection"
+                                    >
+                                        <Edit size={14} />
+                                    </button>
+
+                                    <PinPopover
+                                        isPinned={pinnedCollections.has(collection.title)}
+                                        isPinning={pinningCollection === collection.title}
+                                        onPinWithVisibility={(visibility) => handlePinWithVisibility(collection, visibility)}
+                                        onUnpin={() => handleUnpin(collection)}
+                                    />
+
+                                    <button
+                                        onClick={(e) => handleDeleteCollection(collection.library, collection.title, e)}
+                                        className="p-1.5 rounded-lg bg-red-600/50 hover:bg-red-600/70 text-red-200 hover:text-white transition-colors"
+                                        title="Delete collection"
+                                    >
+                                        <Trash2 size={14} />
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
                     </div>
                 ) : (
                     <div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { fetchWithAuth } from "../utils/api";
-import { SlidersHorizontal, Check, ChevronDown, FileText, Copy, Download, Pause, Play, RefreshCw, Search, Server, CalendarSync, Ban } from "lucide-react";
+import { SlidersHorizontal, Check, ChevronDown, FileText, Copy, Download, Pause, Play, RefreshCw, Search, Server, CalendarSync, Ban, Archive, Upload, HardDriveDownload, HardDriveUpload, Undo2 } from "lucide-react";
 import { Switch, Listbox } from "@headlessui/react";
 import FieldRow from "../components/FieldRow";
 import CollapsibleFormSection from "../components/CollapsibleFormSection";
 import TestConnectionCta from "../components/TestConnectionCta";
+import Toast from "../components/Toast";
 
 const tabs = [
     { id: "general", label: "General", icon: SlidersHorizontal },
     { id: "logs", label: "Logs", icon: FileText },
+    { id: "backup", label: "Backup", icon: Archive },
 ] as const;
 
 type TabId = (typeof tabs)[number]["id"];
@@ -155,12 +157,25 @@ export default function SettingsPage() {
     const [follow, setFollow] = useState(true);
     const scrollerRef = useRef<HTMLDivElement | null>(null);
 
+    // Backup/Restore state
+    const [exporting, setExporting] = useState(false);
+    const [importing, setImporting] = useState(false);
+    const [validating, setValidating] = useState(false);
+    const [reverting, setReverting] = useState(false);
+    const [backupStatus, setBackupStatus] = useState<{ exists: boolean; modified_at: string | null } | null>(null);
+    const [backupToast, setBackupToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+    const [selectedFile, setSelectedFile] = useState<File | null>(null);
+    const [validationResult, setValidationResult] = useState<{ ok: boolean; message: string } | null>(null);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+
     const tabDescription = useMemo(() => {
         switch (activeTab) {
             case "general":
                 return "Control the basics without directly editing the YAML config.";
             case "logs":
                 return "View and search application logs in real-time.";
+            case "backup":
+                return "Export or import your configuration file.";
             default:
                 return "";
         }
@@ -533,6 +548,125 @@ export default function SettingsPage() {
             setLogsError(e?.message ?? "Failed to download logs");
         }
     }
+
+    // Backup functions
+    async function handleExport() {
+        setExporting(true);
+        setBackupToast(null);
+        try {
+            const res = await fetchWithAuth("/api/admin/config/export");
+            if (!res.ok) throw new Error(await res.text());
+            const blob = await res.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            const disposition = res.headers.get("Content-Disposition");
+            const filenameMatch = disposition?.match(/filename="?([^"]+)"?/);
+            a.download = filenameMatch?.[1] || "config_backup.yaml";
+            a.click();
+            URL.revokeObjectURL(url);
+            setBackupToast({ message: "Configuration exported successfully.", type: "success" });
+        } catch (e: any) {
+            setBackupToast({ message: e?.message ?? "Failed to export configuration.", type: "error" });
+        } finally {
+            setExporting(false);
+        }
+    }
+
+    async function handleValidate() {
+        if (!selectedFile) return;
+        setValidating(true);
+        setBackupToast(null);
+        setValidationResult(null);
+        try {
+            const formData = new FormData();
+            formData.append("file", selectedFile);
+            const res = await fetchWithAuth("/api/admin/config/import?validate_only=true", {
+                method: "POST",
+                body: formData,
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                setValidationResult({ ok: false, message: data.detail || "Validation failed." });
+            } else {
+                setValidationResult({ ok: true, message: data.message });
+            }
+        } catch (e: any) {
+            setBackupToast({ message: e?.message ?? "Validation request failed.", type: "error" });
+        } finally {
+            setValidating(false);
+        }
+    }
+
+    async function handleImport() {
+        if (!selectedFile) return;
+        setImporting(true);
+        setBackupToast(null);
+        try {
+            const formData = new FormData();
+            formData.append("file", selectedFile);
+            const res = await fetchWithAuth("/api/admin/config/import", {
+                method: "POST",
+                body: formData,
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(data.detail || "Import failed.");
+            }
+            setBackupToast({ message: data.message, type: "success" });
+            setSelectedFile(null);
+            setValidationResult(null);
+            if (fileInputRef.current) fileInputRef.current.value = "";
+        } catch (e: any) {
+            setBackupToast({ message: e?.message ?? "Failed to import configuration.", type: "error" });
+        } finally {
+            setImporting(false);
+        }
+    }
+
+    async function fetchBackupStatus() {
+        try {
+            const res = await fetchWithAuth("/api/admin/config/backup-status");
+            if (res.ok) {
+                const data = await res.json();
+                setBackupStatus(data);
+            }
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    async function handleRevert() {
+        setReverting(true);
+        setBackupToast(null);
+        try {
+            const res = await fetchWithAuth("/api/admin/config/revert", { method: "POST" });
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(data.detail || "Revert failed.");
+            }
+            setBackupToast({ message: data.message, type: "success" });
+            fetchBackupStatus();
+        } catch (e: any) {
+            setBackupToast({ message: e?.message ?? "Failed to revert configuration.", type: "error" });
+        } finally {
+            setReverting(false);
+        }
+    }
+
+    // Fetch backup status when switching to backup tab
+    useEffect(() => {
+        if (activeTab === "backup") {
+            fetchBackupStatus();
+        }
+    }, [activeTab]);
+
+    // Refresh backup status after import
+    useEffect(() => {
+        if (backupToast?.type === "success" && activeTab === "backup") {
+            fetchBackupStatus();
+        }
+    }, [backupToast]);
 
     // Logs effects
     useEffect(() => {
@@ -1251,6 +1385,185 @@ export default function SettingsPage() {
                     </div>
                 </div>
             ) : null}
+
+            {activeTab === "backup" ? (
+                <div className="space-y-6">
+                    <CollapsibleFormSection
+                        title="Export Configuration"
+                        description="Download your current config.yaml as a backup file."
+                        icon={HardDriveDownload}
+                        defaultExpanded
+                    >
+                        <div className="space-y-4">
+                            <p className="text-sm text-slate-400">
+                                Export your current configuration to a YAML file. This includes all settings, groups, integration sources, and rotation rules.
+                            </p>
+                            <p className="text-xs text-amber-400/80">
+                                Note: Sensitive values like API keys and tokens stored in config.yaml will be included in the export. Values from environment variables are not included.
+                            </p>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    type="button"
+                                    onClick={handleExport}
+                                    disabled={exporting}
+                                    className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {exporting ? (
+                                        <>
+                                            <span className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                                            Exporting...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Download className="h-4 w-4" />
+                                            Export Config
+                                        </>
+                                    )}
+                                </button>
+                            </div>
+                        </div>
+                    </CollapsibleFormSection>
+
+                    <CollapsibleFormSection
+                        title="Import Configuration"
+                        description="Upload a config.yaml file to replace your current configuration."
+                        icon={HardDriveUpload}
+                        defaultExpanded
+                    >
+                        <div className="space-y-4">
+                            <p className="text-sm text-slate-400">
+                                Import a previously exported configuration file. Your current config will be automatically backed up before being replaced.
+                            </p>
+
+                            <div className="space-y-2">
+                                <label className="block text-xs font-medium text-slate-400 uppercase tracking-wider">
+                                    Select File
+                                </label>
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    accept=".yaml,.yml"
+                                    onChange={(e) => {
+                                        const file = e.target.files?.[0] || null;
+                                        setSelectedFile(file);
+                                        setValidationResult(null);
+                                        setBackupToast(null);
+                                    }}
+                                    className="block w-full text-sm text-slate-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border file:border-slate-700 file:text-sm file:font-semibold file:bg-slate-800 file:text-slate-100 hover:file:bg-slate-700 file:transition file:cursor-pointer"
+                                />
+                            </div>
+
+                            {validationResult && (
+                                <div className={`rounded-lg border px-3 py-2 text-xs ${
+                                    validationResult.ok
+                                        ? "border-emerald-700 bg-emerald-900/50 text-emerald-100"
+                                        : "border-rose-700 bg-rose-950/60 text-rose-100"
+                                }`}>
+                                    {validationResult.message}
+                                </div>
+                            )}
+
+                            <div className="flex items-center gap-3">
+                                <button
+                                    type="button"
+                                    onClick={handleValidate}
+                                    disabled={!selectedFile || validating}
+                                    className="flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-700 text-sm font-semibold text-slate-100 transition hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {validating ? (
+                                        <>
+                                            <span className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                                            Validating...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Check className="h-4 w-4" />
+                                            Validate
+                                        </>
+                                    )}
+                                </button>
+
+                                <button
+                                    type="button"
+                                    onClick={handleImport}
+                                    disabled={!selectedFile || importing || validating || (validationResult !== null && !validationResult.ok)}
+                                    className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {importing ? (
+                                        <>
+                                            <span className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                                            Importing...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Upload className="h-4 w-4" />
+                                            Import Config
+                                        </>
+                                    )}
+                                </button>
+                            </div>
+                        </div>
+                    </CollapsibleFormSection>
+
+                    <CollapsibleFormSection
+                        title="Revert Configuration"
+                        description="Revert to the previous configuration that was replaced during import."
+                        icon={Undo2}
+                        defaultExpanded
+                    >
+                        <div className="space-y-4">
+                            {backupStatus === null ? (
+                                <p className="text-sm text-slate-500">Checking for backup...</p>
+                            ) : !backupStatus.exists ? (
+                                <p className="text-sm text-slate-400">
+                                    No backup available. A backup is automatically created each time you import a configuration.
+                                </p>
+                            ) : (
+                                <>
+                                    <p className="text-sm text-slate-400">
+                                        A backup of your previous configuration exists from{" "}
+                                        <span className="text-slate-200 font-medium">
+                                            {backupStatus.modified_at
+                                                ? new Date(backupStatus.modified_at).toLocaleString()
+                                                : "unknown date"}
+                                        </span>.
+                                        Reverting will swap your current config with this backup, so you can always revert again if needed.
+                                    </p>
+                                    <div className="flex items-center gap-3">
+                                        <button
+                                            type="button"
+                                            onClick={handleRevert}
+                                            disabled={reverting}
+                                            className="flex items-center gap-2 px-4 py-2 rounded-lg border border-amber-600 text-amber-400 text-sm font-semibold transition hover:bg-amber-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                                        >
+                                            {reverting ? (
+                                                <>
+                                                    <span className="h-4 w-4 border-2 border-amber-400/30 border-t-amber-400 rounded-full animate-spin" />
+                                                    Reverting...
+                                                </>
+                                            ) : (
+                                                <>
+                                                    <Undo2 className="h-4 w-4" />
+                                                    Revert to Previous Config
+                                                </>
+                                            )}
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </CollapsibleFormSection>
+
+                </div>
+            ) : null}
+
+            {backupToast && (
+                <Toast
+                    message={backupToast.message}
+                    type={backupToast.type}
+                    onClose={() => setBackupToast(null)}
+                />
+            )}
         </div>
     );
 }

--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -295,3 +295,11 @@ def load_config(path: Optional[Path | str] = None, force_reload: bool = False) -
 def reload_config(path: Optional[Path | str] = None) -> AppConfig:
     logger.info("Forcing config reload")
     return load_config(path, force_reload=True)
+
+
+# Validate config YAML content without writing to disk
+def validate_config_text(content: str) -> AppConfig:
+    data = yaml.safe_load(content)
+    if data is None or not isinstance(data, dict):
+        raise ValueError("Config content must be a YAML mapping at the top level")
+    return _validate_config_dict(data)

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -297,3 +297,20 @@ class QuickStartRequest(BaseModel):
     rotation_max_collections: int = 5
     rotation_strategy: str = "random"
     rotation_allow_repeats: bool = False
+
+
+class ConfigValidateResponse(BaseModel):
+    ok: bool
+    message: str
+
+
+class ConfigImportResponse(BaseModel):
+    ok: bool
+    message: str
+    backup_path: Optional[str] = None
+    env_override: bool
+
+
+class BackupStatusResponse(BaseModel):
+    exists: bool
+    modified_at: Optional[str] = None

--- a/homescreen_hero/web/routers/config/setup.py
+++ b/homescreen_hero/web/routers/config/setup.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
+from datetime import datetime
 
 import yaml
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, UploadFile, File, Query
+from fastapi.responses import Response
 
 from homescreen_hero.core.auth import get_current_user
 from homescreen_hero.core.config.loader import (
@@ -13,6 +16,7 @@ from homescreen_hero.core.config.loader import (
     load_config,
     load_config_text,
     save_config_text,
+    validate_config_text,
 )
 from homescreen_hero.core.integrations.trakt_client import TraktClient, TraktConfig
 from homescreen_hero.core.integrations.mdblist_client import MDBListClient, MDBListConfig
@@ -25,6 +29,9 @@ from .schemas import (
     ConfigSaveResponse,
     ConfigUpdateRequest,
     ConfigExistsResponse,
+    ConfigValidateResponse,
+    ConfigImportResponse,
+    BackupStatusResponse,
     EnvVarsResponse,
     TraktTestRequest,
     MDBListTestRequest,
@@ -78,6 +85,169 @@ def save_config(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ========================================================================
+# CONFIG BACKUP / RESTORE
+# ========================================================================
+
+@router.get("/export")
+def export_config(
+    current_user: str = Depends(get_current_user),
+) -> Response:
+    # Download the current config.yaml as a file attachment
+    try:
+        content = load_config_text()
+        timestamp = datetime.now().strftime("%Y_%m_%d")
+        filename = f"config_backup_{timestamp}.yaml"
+
+        return Response(
+            content=content,
+            media_type="application/x-yaml",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/import")
+def import_config(
+    file: UploadFile = File(...),
+    validate_only: bool = Query(False),
+    current_user: str = Depends(get_current_user),
+):
+    # Import a config.yaml file, optionally just validating without applying
+    MAX_CONFIG_SIZE = 1_048_576  # 1 MB
+    try:
+        raw = file.file.read(MAX_CONFIG_SIZE + 1)
+        if len(raw) > MAX_CONFIG_SIZE:
+            raise HTTPException(
+                status_code=413, detail="Config file exceeds 1 MB size limit."
+            )
+        content = raw.decode("utf-8")
+    except HTTPException:
+        raise
+    except UnicodeDecodeError as exc:
+        raise HTTPException(
+            status_code=400, detail="File must be valid UTF-8 text."
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Failed to read file: {exc}"
+        ) from exc
+
+    # Validate the uploaded YAML (schema + env overrides)
+    try:
+        validate_config_text(content)
+    except (yaml.YAMLError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Validation failed: {exc}"
+        ) from exc
+
+    if validate_only:
+        return ConfigValidateResponse(
+            ok=True,
+            message="Configuration is valid and can be imported.",
+        )
+
+    # Backup current config before overwriting
+    config_path = get_config_path()
+    backup_path_str = None
+
+    if config_path.exists():
+        backup_path = config_path.with_suffix(".yaml.bak")
+        try:
+            shutil.copy2(config_path, backup_path)
+            backup_path_str = str(backup_path)
+            logger.info(f"Backed up current config to {backup_path}")
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to create backup before import: {exc}",
+            ) from exc
+
+    # Apply the new config
+    try:
+        save_config_text(content)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Update rotation schedule with new config
+    try:
+        updated_config = load_config()
+        update_rotation_schedule(config=updated_config)
+    except Exception as exc:
+        logger.warning(f"Failed to update rotation schedule after import: {exc}")
+
+    return ConfigImportResponse(
+        ok=True,
+        message="Configuration imported successfully.",
+        backup_path=backup_path_str,
+        env_override=CONFIG_ENV_VAR in os.environ,
+    )
+
+
+@router.get("/backup-status", response_model=BackupStatusResponse)
+def get_backup_status(
+    current_user: str = Depends(get_current_user),
+) -> BackupStatusResponse:
+    # Check if a .bak backup file exists and when it was last modified
+    backup_path = get_config_path().with_suffix(".yaml.bak")
+    if not backup_path.exists():
+        return BackupStatusResponse(exists=False)
+
+    modified_ts = backup_path.stat().st_mtime
+    modified_at = datetime.fromtimestamp(modified_ts).isoformat()
+    return BackupStatusResponse(exists=True, modified_at=modified_at)
+
+
+@router.post("/revert", response_model=ConfigImportResponse)
+def revert_config(
+    current_user: str = Depends(get_current_user),
+) -> ConfigImportResponse:
+    # Revert to the most recent .bak backup, backing up the current config first
+    config_path = get_config_path()
+    backup_path = config_path.with_suffix(".yaml.bak")
+
+    if not backup_path.exists():
+        raise HTTPException(status_code=404, detail="No backup file found to revert to.")
+
+    # Read and validate the backup before applying
+    backup_content = backup_path.read_text(encoding="utf-8")
+    try:
+        validate_config_text(backup_content)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Backup file is not valid: {exc}"
+        ) from exc
+
+    # Swap: current -> .bak, backup -> current
+    # Save current config to .bak so the user can revert the revert
+    try:
+        current_content = config_path.read_text(encoding="utf-8")
+        save_config_text(backup_content)
+        backup_path.write_text(current_content, encoding="utf-8")
+        logger.info("Reverted config and swapped backup")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Update rotation schedule
+    try:
+        updated_config = load_config()
+        update_rotation_schedule(config=updated_config)
+    except Exception as exc:
+        logger.warning(f"Failed to update rotation schedule after revert: {exc}")
+
+    return ConfigImportResponse(
+        ok=True,
+        message="Configuration reverted successfully.",
+        backup_path=str(backup_path),
+        env_override=CONFIG_ENV_VAR in os.environ,
+    )
 
 
 # ========================================================================


### PR DESCRIPTION
## Feature: Config backup/restore and collections list view

### Summary
A couple of quality-of-life additions before the next release. Adds a full config backup and restore system so users can export, import, validate, and revert their `config.yaml` from the Settings page. Also adds a compact list view option to the Collections page as an alternative to the card grid (not 100% sold on the layout of the new list few, so any feedback is much appreciated)

### Major Changes
- Added a new **Backup** tab to Settings page with config export, import (with validation), and revert functionality. Imports automatically back up the current config so you can always undo.
- Added a list view toggle to the Collections page - cards or compact rows, persisted to `localStorage`.

### Minor Changes
- Extracted the pin popover into a shared `PinPopover` component so both card and list views can reuse it.
- Added `config.yaml.bak` to `.gitignore`. This is the automated backup created when you import a config
- Added `validate_config_text` helper to the config loader for validating YAML without writing to disk.

**Note:** As I said above, I haven't fully settled on the Collections list layout. Looks a little bare to me, so please feel free to provide feedback on Discord :)