### PR TITLE
Fix: Movie GUID matching for MDBList and Trakt sync

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -19,5 +19,6 @@ Review all staged and unstaged changes, then create a well-formatted commit.
 2. Keep things brief, separate items in one commit should be explained in no more than two sentences, but ideally in one.
 3. Use normal human language/tone like "Added ..." or "Fixed ..."
 4. Don't include any reference to the commit being written by Claude, as we want to keep these commit messages short.
+5. For longer commit messages, prioritize important changes. Commit message shouldn't be more than 3-4 points long.
 
 Always ask me for permission before commiting.

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -10,51 +10,9 @@ from plexapi.exceptions import NotFound
 from homescreen_hero.core.db.models import MDBListMissingItem
 from homescreen_hero.core.config.schema import AppConfig, MDBListSource
 from homescreen_hero.core.integrations.mdblist_client import get_mdblist_client
+from homescreen_hero.core.integrations.plex_match import build_guid_map, find_movie
 
 logger = logging.getLogger(__name__)
-
-
-def _find_movie_in_library(
-    library,
-    title: str,
-    year: int | None,
-    imdb_id: str | None,
-    tmdb_id: int | None,
-    trakt_id: int | None,
-):
-    # Try to match by GUID ids (tmdb/imdb/trakt) if possible, otherwise fall back to title/year
-
-    # 1) Try TMDb GUID (most reliable for Plex)
-    if tmdb_id is not None:
-        guid = f"com.plexapp.agents.themoviedb://{tmdb_id}?lang=en"
-        results = library.search(guid=guid)
-        if results:
-            return results[0]
-
-    # 2) Try IMDb GUID
-    if imdb_id:
-        guid = f"com.plexapp.agents.imdb://{imdb_id}?lang=en"
-        results = library.search(guid=guid)
-        if results:
-            return results[0]
-
-    # 3) Try Trakt GUID (less common but available)
-    if trakt_id is not None:
-        guid = f"com.plexapp.agents.trakt://{trakt_id}?lang=en"
-        results = library.search(guid=guid)
-        if results:
-            return results[0]
-
-    # 4) Fallback: title/year search
-    if year:
-        results = library.search(title=title, year=year)
-    else:
-        results = library.search(title=title)
-
-    if results:
-        return results[0]
-
-    return None
 
 
 def sync_single_mdblist_source(
@@ -117,6 +75,10 @@ def sync_single_mdblist_source(
         )
         return 0, 0
 
+    # Build GUID lookup map once for fast matching
+    logger.info("Building Plex library GUID index for '%s'...", source.plex_library)
+    guid_map = build_guid_map(library)
+
     existing_collection_items = []
     try:
         existing_collection_items = library.collection(source.name).items()
@@ -139,7 +101,7 @@ def sync_single_mdblist_source(
         if not title:
             continue
 
-        plex_item = _find_movie_in_library(library, title, year, imdb_id, tmdb_id, trakt_id)
+        plex_item = find_movie(guid_map, library, title, year, imdb_id, tmdb_id)
 
         if plex_item is not None:
             matched_items.append(plex_item)

--- a/homescreen_hero/core/integrations/plex_match.py
+++ b/homescreen_hero/core/integrations/plex_match.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import unicodedata
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Unicode superscript/subscript digit mapping
+_SUPER_SUB_DIGITS = str.maketrans(
+    "⁰¹²³⁴⁵⁶⁷⁸⁹₀₁₂₃₄₅₆₇₈₉",
+    "01234567890123456789",
+)
+
+
+def normalize_title(title: str) -> str:
+    # Normalize Unicode characters that look like ASCII equivalents
+    normalized = unicodedata.normalize("NFKC", title)
+
+    return normalized.translate(_SUPER_SUB_DIGITS)
+
+
+def build_guid_map(library) -> dict:
+    guid_map = {}
+    for item in library.all(includeGuids=1):
+        # Map primary GUID (covers legacy agent format like com.plexapp.agents.themoviedb://...)
+        if item.guid:
+            guid_map[item.guid] = item
+        # Map external GUIDs (imdb://tt1234567, tmdb://12345, tvdb://12345)
+        for guid in getattr(item, "guids", None) or []:
+            guid_id = getattr(guid, "id", None)
+            if guid_id:
+                guid_map[guid_id] = item
+    return guid_map
+
+
+def find_movie(guid_map, library, title, year, imdb_id=None, tmdb_id=None):
+    # Match a movie against the Plex library using GUID map first, then title/year fallback
+
+    if tmdb_id is not None:
+        item = guid_map.get(f"tmdb://{tmdb_id}")
+        if item:
+            return item
+
+    if imdb_id:
+        item = guid_map.get(f"imdb://{imdb_id}")
+        if item:
+            return item
+
+    if tmdb_id is not None:
+        item = guid_map.get(f"com.plexapp.agents.themoviedb://{tmdb_id}?lang=en")
+        if item:
+            return item
+
+    if imdb_id:
+        item = guid_map.get(f"com.plexapp.agents.imdb://{imdb_id}?lang=en")
+        if item:
+            return item
+
+    # Fallback Matching: title/year search with normalized title
+    normalized = normalize_title(title)
+    search_title = normalized if normalized != title else title
+
+    if year:
+        results = library.search(title=search_title, year=year)
+    else:
+        results = library.search(title=search_title)
+
+    if results:
+        return results[0]
+
+    if normalized != title:
+        if year:
+            results = library.search(title=title, year=year)
+        else:
+            results = library.search(title=title)
+        if results:
+            return results[0]
+
+    return None

--- a/homescreen_hero/core/integrations/trakt_sync.py
+++ b/homescreen_hero/core/integrations/trakt_sync.py
@@ -10,44 +10,9 @@ from plexapi.exceptions import NotFound
 from homescreen_hero.core.db.models import TraktMissingItem
 from homescreen_hero.core.config.schema import AppConfig, TraktSource
 from homescreen_hero.core.integrations.trakt_client import get_trakt_client
+from homescreen_hero.core.integrations.plex_match import build_guid_map, find_movie
 
 logger = logging.getLogger(__name__)
-
-
-def _find_movie_in_library(
-    library,
-    title: str,
-    year: int | None,
-    ids: Dict[str, Any],
-):
-    # Try to match by GUID ids (tmdb/imdb) if possible, otherwise fall back to title/year
-    tmdb_id = ids.get("tmdb")
-    imdb_id = ids.get("imdb")
-
-    # 1) Try TMDb GUID
-    if tmdb_id is not None:
-        guid = f"com.plexapp.agents.themoviedb://{tmdb_id}?lang=en"
-        results = library.search(guid=guid)
-        if results:
-            return results[0]
-
-    # 2) Try IMDb GUID
-    if imdb_id:
-        guid = f"com.plexapp.agents.imdb://{imdb_id}?lang=en"
-        results = library.search(guid=guid)
-        if results:
-            return results[0]
-
-    # 3) Fallback: title/year search
-    if year:
-        results = library.search(title=title, year=year)
-    else:
-        results = library.search(title=title)
-
-    if results:
-        return results[0]
-
-    return None
 
 
 def sync_single_trakt_source(
@@ -101,6 +66,10 @@ def sync_single_trakt_source(
 
     items = trakt_client.get_list_items_from_url(source.url)
 
+    # Build GUID lookup map once for fast matching
+    logger.info("Building Plex library GUID index for '%s'...", source.plex_library)
+    guid_map = build_guid_map(library)
+
     existing_collection_items = []
     try:
         existing_collection_items = library.collection(source.name).items()
@@ -124,7 +93,11 @@ def sync_single_trakt_source(
         if not title:
             continue
 
-        plex_item = _find_movie_in_library(library, title, year, ids)
+        plex_item = find_movie(
+            guid_map, library, title, year,
+            imdb_id=ids.get("imdb"),
+            tmdb_id=ids.get("tmdb"),
+        )
 
         if plex_item is not None:
             matched_items.append(plex_item)


### PR DESCRIPTION
### Summary
`library.search(guid=...)` only matches the primary Plex GUID (`plex://movie/...`), not external IDs like `tmdb://` or `imdb://`. This meant GUID matching was silently failing on modern Plex agents, causing movies to be incorrectly reported as missing even when they exist in the library.

### Major Changes
- Replaced broken `library.search(guid=...)` calls with a GUID lookup map built from `library.all()` that indexes all external IDs for O(1) matching
- Added Unicode title normalization for fallback title matching (e.g. superscript `²` → `2`)
- Extracted shared matching logic into `plex_match.py` used by both MDBList and Trakt sync

### Minor Changes
- Removed dead Trakt GUID matching code (Plex never had a `com.plexapp.agents.trakt` agent)