### PR TITLE
Feature: AniList Integration MVP

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -145,6 +145,7 @@ def get_collections():
 | MDBList | `core/integrations/mdblist_client.py` | Third-party list sync |
 | Tautulli | `core/integrations/tautulli_client.py` | Analytics & streaming metrics |
 | Letterboxd | `core/integrations/letterboxd_scraper.py` | List scraping |
+| AniList | `core/integrations/anilist_client.py` | Anime list sync |
 
 ## API Documentation
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -70,6 +70,21 @@ letterboxd:
     url: "LINK_TO_LETTERBOXD_LIST"  # e.g., https://letterboxd.com/username/list/listname/
     plex_library: "YOUR_PLEX_LIBRARY_NAME" # e.g., "Movies"
 
+# Optional: AniList integration (no credentials needed)
+# Supports user lists and public browse lists
+anilist:
+  sources:
+  - name: "My Anime Watchlist"  # This is the name that will show up in Plex
+    url: "https://anilist.co/user/username/animelist"  # Fetches all default lists (Watching, Completed, etc.)
+    plex_library: "Anime"
+# - name: "Completed Anime"
+#   url: "https://anilist.co/user/username/animelist/completed"  # A specific user list
+#   plex_library: "Anime"
+# - name: "Trending Anime"
+#   url: "anilist://browse/trending"  # Currently trending anime
+#   plex_library: "Anime"
+#   max_items: 50  # Limit items for browse lists (default: 100, range: 10-500)
+
 # Optional: MDBList integration
 mdblist:
   enabled: false

--- a/homescreen-hero-ui/src/components/Toast.tsx
+++ b/homescreen-hero-ui/src/components/Toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { CheckCircle, XCircle, X } from "lucide-react";
 
 type ToastProps = {
@@ -9,10 +9,13 @@ type ToastProps = {
 };
 
 export default function Toast({ message, type, onClose, duration = 3000 }: ToastProps) {
+    const onCloseRef = useRef(onClose);
+    onCloseRef.current = onClose;
+
     useEffect(() => {
-        const timer = setTimeout(onClose, duration);
+        const timer = setTimeout(() => onCloseRef.current(), duration);
         return () => clearTimeout(timer);
-    }, [duration, onClose]);
+    }, [duration]);
 
     return (
         <div className="fixed bottom-4 right-4 z-[100] animate-in slide-in-from-bottom-5">

--- a/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
@@ -1,0 +1,254 @@
+import { useState, useCallback, useRef } from "react";
+import { SourceList } from "./shared/SourceListManager";
+import { LibrarySelect } from "./shared/LibrarySelect";
+import { ListTypeSelect } from "./shared/ListTypeSelect";
+import type { ListTypeOption } from "./shared/ListTypeSelect";
+import { useListIntegration } from "../../hooks/integrations/useListIntegration";
+import { usePlexLibraries } from "../../hooks/integrations/usePlexLibraries";
+import { fetchWithAuth } from "../../utils/api";
+import type { AniListMissingItem } from "../../types/integrations";
+
+const emptySettings = {};
+
+function formatDate(dateString: string | null): string {
+    if (!dateString) return "Never";
+    return new Date(dateString).toLocaleString();
+}
+
+const FORMAT_LABELS: Record<string, string> = {
+    TV: "TV",
+    TV_SHORT: "Short",
+    MOVIE: "Movie",
+    SPECIAL: "Special",
+    OVA: "OVA",
+    ONA: "ONA",
+};
+
+// Capitalize first letter for auto-generated collection name
+function capitalize(s: string): string {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export function AniListIntegration() {
+    const { enabledLibraries } = usePlexLibraries();
+
+    const integration = useListIntegration<typeof emptySettings, AniListMissingItem>({
+        integrationName: "anilist",
+        initialSettings: emptySettings,
+        hasSettings: false,
+    });
+
+    // Custom form state (username + list type instead of raw URL)
+    const [username, setUsername] = useState("");
+    const [listType, setListType] = useState("");
+    const [collectionName, setCollectionName] = useState("");
+    const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
+    const [plexLibrary, setPlexLibrary] = useState("");
+
+    // Dynamic list options fetched from AniList
+    const [fetchedLists, setFetchedLists] = useState<ListTypeOption[] | undefined>(undefined);
+    const [fetchingLists, setFetchingLists] = useState(false);
+    const lastFetchedUsername = useRef("");
+
+    const fetchUserLists = useCallback(async (name: string) => {
+        const trimmed = name.trim();
+        if (!trimmed || trimmed === lastFetchedUsername.current) return;
+
+        lastFetchedUsername.current = trimmed;
+        setFetchingLists(true);
+        try {
+            const r = await fetchWithAuth(
+                `/api/admin/config/anilist/user-lists?username=${encodeURIComponent(trimmed)}`
+            );
+            if (r.ok) {
+                const data = await r.json();
+                setFetchedLists(data.lists || []);
+            } else {
+                // On error, clear dynamic lists (falls back to defaults)
+                setFetchedLists(undefined);
+            }
+        } catch {
+            setFetchedLists(undefined);
+        } finally {
+            setFetchingLists(false);
+        }
+    }, []);
+
+    const handleUsernameBlur = useCallback(() => {
+        fetchUserLists(username);
+    }, [username, fetchUserLists]);
+
+    const handleListTypeChange = useCallback(
+        (value: string) => {
+            setListType(value);
+            // Auto-fill collection name from the selected label
+            if (!nameManuallyEdited) {
+                if (!value) {
+                    setCollectionName("");
+                } else {
+                    // Find the label from fetched or default options
+                    const option = fetchedLists?.find((o) => o.value === value);
+                    setCollectionName(option ? option.label : capitalize(value));
+                }
+            }
+        },
+        [nameManuallyEdited, fetchedLists]
+    );
+
+    const handleNameChange = useCallback((value: string) => {
+        setCollectionName(value);
+        setNameManuallyEdited(true);
+    }, []);
+
+    const canAdd = username.trim() && collectionName.trim() && plexLibrary;
+
+    const handleAdd = useCallback(async () => {
+        if (!canAdd) return;
+
+        const trimmedUsername = username.trim();
+        const url = listType
+            ? `https://anilist.co/user/${trimmedUsername}/animelist/${encodeURIComponent(listType)}`
+            : `https://anilist.co/user/${trimmedUsername}/animelist`;
+
+        await integration.addSource({
+            name: collectionName.trim(),
+            url,
+            plex_library: plexLibrary,
+        });
+
+        // Reset form on success
+        setUsername("");
+        setListType("");
+        setCollectionName("");
+        setNameManuallyEdited(false);
+        setPlexLibrary("");
+        setFetchedLists(undefined);
+        lastFetchedUsername.current = "";
+    }, [canAdd, username, listType, collectionName, plexLibrary, integration]);
+
+    return (
+        <div className="space-y-4">
+            {/* Add form */}
+            <div className="flex gap-2 items-center flex-wrap">
+                <input
+                    type="text"
+                    placeholder="Username"
+                    className="w-46 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    onBlur={handleUsernameBlur}
+                    disabled={integration.savingSource || integration.loadingSources}
+                />
+                <ListTypeSelect
+                    value={listType}
+                    onChange={handleListTypeChange}
+                    disabled={integration.savingSource || integration.loadingSources}
+                    options={fetchedLists}
+                    loading={fetchingLists}
+                />
+                <LibrarySelect
+                    value={plexLibrary}
+                    onChange={setPlexLibrary}
+                    libraries={enabledLibraries}
+                    disabled={integration.savingSource || integration.loadingSources}
+                />
+                <input
+                    type="text"
+                    placeholder="Collection name"
+                    className="w-80 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                    value={collectionName}
+                    onChange={(e) => handleNameChange(e.target.value)}
+                    disabled={integration.savingSource || integration.loadingSources}
+                />
+                <button
+                    type="button"
+                    onClick={handleAdd}
+                    disabled={integration.savingSource || integration.loadingSources || !canAdd}
+                    className="shrink-0 cursor-pointer rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                    {integration.savingSource ? "Adding\u2026" : "Add List"}
+                </button>
+            </div>
+
+            {/* Info note */}
+            <div className="rounded-lg border border-blue-700/50 bg-blue-900/20 px-4 py-3">
+                <p className="text-xs text-blue-200">
+                    <strong>Note:</strong> AniList items are matched to Plex using the{" "}
+                    <a
+                        href="https://github.com/Fribb/anime-lists"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-blue-100"
+                    >
+                        anime-lists
+                    </a>{" "}
+                    ID mapping database, with a fallback to title/year matching. Point your
+                    source at a show library for anime series, or a movie library for anime
+                    films.
+                </p>
+            </div>
+
+            {/* Messages */}
+            {integration.sourcesMessage && (
+                <div className="rounded-lg border border-emerald-700 bg-emerald-900/50 px-3 py-2 text-xs text-emerald-100">
+                    {integration.sourcesMessage}
+                </div>
+            )}
+            {integration.sourcesError && (
+                <div className="rounded-lg border border-rose-700 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
+                    {integration.sourcesError}
+                </div>
+            )}
+
+            {/* Source list */}
+            <SourceList<AniListMissingItem>
+                sources={integration.sources}
+                statuses={integration.statuses}
+                onSyncSource={integration.syncSource}
+                onRemoveSource={integration.removeSource}
+                loadingSources={integration.loadingSources}
+                syncingSource={integration.syncingSource}
+                deletingSource={integration.deletingSource}
+                missingItems={integration.missingItems}
+                expandedMissing={integration.expandedMissing}
+                missingPages={integration.missingPages}
+                loadingMissing={integration.loadingMissing}
+                onToggleMissing={integration.toggleMissingItems}
+                onSetMissingPage={integration.setMissingPage}
+                renderMissingItem={(item, i) => (
+                    <div
+                        key={i}
+                        className="flex items-start justify-between gap-3 rounded-md border border-slate-800/40 bg-slate-950/40 px-3 py-2"
+                    >
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                                <p className="text-xs font-medium text-slate-200 truncate">
+                                    {item.title}
+                                    {item.year ? ` (${item.year})` : ""}
+                                </p>
+                                {item.media_format && (
+                                    <span className="shrink-0 rounded bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-400">
+                                        {FORMAT_LABELS[item.media_format] ?? item.media_format}
+                                    </span>
+                                )}
+                            </div>
+                            {item.anilist_id && (
+                                <a
+                                    href={`https://anilist.co/anime/${item.anilist_id}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs text-primary hover:underline"
+                                >
+                                    View on AniList
+                                </a>
+                            )}
+                        </div>
+                        <div className="text-xs text-slate-500 whitespace-nowrap">
+                            {formatDate(item.last_seen)}
+                        </div>
+                    </div>
+                )}
+            />
+        </div>
+    );
+}

--- a/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from "react";
+import { Minus, Plus } from "lucide-react";
 import { SourceList } from "./shared/SourceListManager";
 import { LibrarySelect } from "./shared/LibrarySelect";
 import { ListTypeSelect } from "./shared/ListTypeSelect";
@@ -29,6 +30,15 @@ function capitalize(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+const BROWSE_LIST_OPTIONS: ListTypeOption[] = [
+    { value: "trending", label: "Trending" },
+    { value: "popular", label: "Popular" },
+    { value: "top-100", label: "Top 100" },
+    { value: "most-favorited", label: "Most Favorited" },
+    { value: "this-season", label: "This Season" },
+    { value: "next-season", label: "Next Season" },
+];
+
 export function AniListIntegration() {
     const { enabledLibraries } = usePlexLibraries();
 
@@ -38,7 +48,10 @@ export function AniListIntegration() {
         hasSettings: false,
     });
 
-    // Custom form state (username + list type instead of raw URL)
+    // Mode toggle: user lists vs browse lists
+    const [mode, setMode] = useState<"user" | "browse">("user");
+
+    // User list form state
     const [username, setUsername] = useState("");
     const [listType, setListType] = useState("");
     const [collectionName, setCollectionName] = useState("");
@@ -49,6 +62,13 @@ export function AniListIntegration() {
     const [fetchedLists, setFetchedLists] = useState<ListTypeOption[] | undefined>(undefined);
     const [fetchingLists, setFetchingLists] = useState(false);
     const lastFetchedUsername = useRef("");
+
+    // Browse list form state
+    const [browseSort, setBrowseSort] = useState("");
+    const [browseCollectionName, setBrowseCollectionName] = useState("");
+    const [browseNameManuallyEdited, setBrowseNameManuallyEdited] = useState(false);
+    const [browsePlexLibrary, setBrowsePlexLibrary] = useState("");
+    const [browseMaxItems, setBrowseMaxItems] = useState(100);
 
     const fetchUserLists = useCallback(async (name: string) => {
         const trimmed = name.trim();
@@ -126,49 +146,181 @@ export function AniListIntegration() {
         lastFetchedUsername.current = "";
     }, [canAdd, username, listType, collectionName, plexLibrary, integration]);
 
+    // Browse list handlers
+    const handleBrowseSortChange = useCallback(
+        (value: string) => {
+            setBrowseSort(value);
+            if (!browseNameManuallyEdited) {
+                const option = BROWSE_LIST_OPTIONS.find((o) => o.value === value);
+                setBrowseCollectionName(option ? `AniList ${option.label}` : "");
+            }
+        },
+        [browseNameManuallyEdited]
+    );
+
+    const canAddBrowse = browseSort && browseCollectionName.trim() && browsePlexLibrary;
+
+    const handleAddBrowse = useCallback(async () => {
+        if (!canAddBrowse) return;
+
+        const url = `anilist://browse/${browseSort}`;
+        await integration.addSource({
+            name: browseCollectionName.trim(),
+            url,
+            plex_library: browsePlexLibrary,
+            max_items: browseMaxItems,
+        });
+
+        // Reset form
+        setBrowseSort("");
+        setBrowseCollectionName("");
+        setBrowseNameManuallyEdited(false);
+        setBrowsePlexLibrary("");
+        setBrowseMaxItems(100);
+    }, [canAddBrowse, browseSort, browseCollectionName, browsePlexLibrary, browseMaxItems, integration]);
+
+    const formDisabled = integration.savingSource || integration.loadingSources;
+
     return (
         <div className="space-y-4">
-            {/* Add form */}
-            <div className="flex gap-2 items-center flex-wrap">
-                <input
-                    type="text"
-                    placeholder="Username"
-                    className="w-46 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    onBlur={handleUsernameBlur}
-                    disabled={integration.savingSource || integration.loadingSources}
-                />
-                <ListTypeSelect
-                    value={listType}
-                    onChange={handleListTypeChange}
-                    disabled={integration.savingSource || integration.loadingSources}
-                    options={fetchedLists}
-                    loading={fetchingLists}
-                />
-                <LibrarySelect
-                    value={plexLibrary}
-                    onChange={setPlexLibrary}
-                    libraries={enabledLibraries}
-                    disabled={integration.savingSource || integration.loadingSources}
-                />
-                <input
-                    type="text"
-                    placeholder="Collection name"
-                    className="w-80 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
-                    value={collectionName}
-                    onChange={(e) => handleNameChange(e.target.value)}
-                    disabled={integration.savingSource || integration.loadingSources}
-                />
+            {/* Mode toggle */}
+            <div className="flex gap-1 rounded-lg bg-slate-800/50 p-1 w-fit">
                 <button
                     type="button"
-                    onClick={handleAdd}
-                    disabled={integration.savingSource || integration.loadingSources || !canAdd}
-                    className="shrink-0 cursor-pointer rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+                    onClick={() => setMode("user")}
+                    className={`px-3 py-1.5 rounded-md text-xs font-medium transition ${
+                        mode === "user"
+                            ? "bg-primary text-white"
+                            : "text-slate-400 hover:text-slate-200"
+                    }`}
                 >
-                    {integration.savingSource ? "Adding\u2026" : "Add List"}
+                    User Lists
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setMode("browse")}
+                    className={`px-3 py-1.5 rounded-md text-xs font-medium transition ${
+                        mode === "browse"
+                            ? "bg-primary text-white"
+                            : "text-slate-400 hover:text-slate-200"
+                    }`}
+                >
+                    Public Lists
                 </button>
             </div>
+
+            {/* Add form — user lists */}
+            {mode === "user" ? (
+                <div className="flex gap-2 items-center flex-wrap">
+                    <input
+                        type="text"
+                        placeholder="Username"
+                        className="w-46 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        onBlur={handleUsernameBlur}
+                        disabled={formDisabled}
+                    />
+                    <ListTypeSelect
+                        value={listType}
+                        onChange={handleListTypeChange}
+                        disabled={formDisabled}
+                        options={fetchedLists}
+                        loading={fetchingLists}
+                    />
+                    <LibrarySelect
+                        value={plexLibrary}
+                        onChange={setPlexLibrary}
+                        libraries={enabledLibraries}
+                        disabled={formDisabled}
+                    />
+                    <input
+                        type="text"
+                        placeholder="Collection name"
+                        className="w-80 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={collectionName}
+                        onChange={(e) => handleNameChange(e.target.value)}
+                        disabled={formDisabled}
+                    />
+                    <button
+                        type="button"
+                        onClick={handleAdd}
+                        disabled={formDisabled || !canAdd}
+                        className="shrink-0 cursor-pointer rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                        {integration.savingSource ? "Adding\u2026" : "Add List"}
+                    </button>
+                </div>
+            ) : (
+                /* Add form — browse lists */
+                <div className="flex gap-2 items-center flex-wrap">
+                    <ListTypeSelect
+                        value={browseSort}
+                        onChange={handleBrowseSortChange}
+                        disabled={formDisabled}
+                        options={BROWSE_LIST_OPTIONS}
+                        showAllOption={false}
+                    />
+                    <LibrarySelect
+                        value={browsePlexLibrary}
+                        onChange={setBrowsePlexLibrary}
+                        libraries={enabledLibraries}
+                        disabled={formDisabled}
+                    />
+                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-950 overflow-hidden">
+                        <span className="pl-2.5 text-xs text-slate-500 whitespace-nowrap select-none">Max</span>
+                        <button
+                            type="button"
+                            disabled={formDisabled || browseMaxItems <= 10}
+                            onClick={() => setBrowseMaxItems((v) => Math.max(10, v - 10))}
+                            className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                        >
+                            <Minus className="h-3.5 w-3.5" />
+                        </button>
+                        <input
+                            type="number"
+                            min={10}
+                            max={500}
+                            step={10}
+                            value={browseMaxItems}
+                            onChange={(e) => setBrowseMaxItems(Number(e.target.value) || 0)}
+                            onBlur={() => {
+                                setBrowseMaxItems((v) => Math.max(10, Math.min(500, v || 100)));
+                            }}
+                            disabled={formDisabled}
+                            className="w-10 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                            title="Max items"
+                        />
+                        <button
+                            type="button"
+                            disabled={formDisabled || browseMaxItems >= 500}
+                            onClick={() => setBrowseMaxItems((v) => Math.min(500, v + 10))}
+                            className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                        >
+                            <Plus className="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+                    <input
+                        type="text"
+                        placeholder="Collection name"
+                        className="w-80 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={browseCollectionName}
+                        onChange={(e) => {
+                            setBrowseCollectionName(e.target.value);
+                            setBrowseNameManuallyEdited(true);
+                        }}
+                        disabled={formDisabled}
+                    />
+                    <button
+                        type="button"
+                        onClick={handleAddBrowse}
+                        disabled={formDisabled || !canAddBrowse}
+                        className="shrink-0 cursor-pointer rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                        {integration.savingSource ? "Adding\u2026" : "Add List"}
+                    </button>
+                </div>
+            )}
 
             {/* Info note */}
             <div className="rounded-lg border border-blue-700/50 bg-blue-900/20 px-4 py-3">

--- a/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { Minus, Plus } from "lucide-react";
+import Toast from "../Toast";
 import { SourceList } from "./shared/SourceListManager";
 import { LibrarySelect } from "./shared/LibrarySelect";
 import { ListTypeSelect } from "./shared/ListTypeSelect";
@@ -340,18 +341,6 @@ export function AniListIntegration() {
                 </p>
             </div>
 
-            {/* Messages */}
-            {integration.sourcesMessage && (
-                <div className="rounded-lg border border-emerald-700 bg-emerald-900/50 px-3 py-2 text-xs text-emerald-100">
-                    {integration.sourcesMessage}
-                </div>
-            )}
-            {integration.sourcesError && (
-                <div className="rounded-lg border border-rose-700 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
-                    {integration.sourcesError}
-                </div>
-            )}
-
             {/* Source list */}
             <SourceList<AniListMissingItem>
                 sources={integration.sources}
@@ -401,6 +390,14 @@ export function AniListIntegration() {
                     </div>
                 )}
             />
+
+            {integration.toast && (
+                <Toast
+                    message={integration.toast.message}
+                    type={integration.toast.type}
+                    onClose={integration.clearToast}
+                />
+            )}
         </div>
     );
 }

--- a/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
@@ -75,7 +75,6 @@ export function AniListIntegration() {
         const trimmed = name.trim();
         if (!trimmed || trimmed === lastFetchedUsername.current) return;
 
-        lastFetchedUsername.current = trimmed;
         setFetchingLists(true);
         try {
             const r = await fetchWithAuth(
@@ -84,6 +83,7 @@ export function AniListIntegration() {
             if (r.ok) {
                 const data = await r.json();
                 setFetchedLists(data.lists || []);
+                lastFetchedUsername.current = trimmed;
             } else {
                 // On error, clear dynamic lists (falls back to defaults)
                 setFetchedLists(undefined);
@@ -131,20 +131,21 @@ export function AniListIntegration() {
             ? `https://anilist.co/user/${trimmedUsername}/animelist/${encodeURIComponent(listType)}`
             : `https://anilist.co/user/${trimmedUsername}/animelist`;
 
-        await integration.addSource({
+        const ok = await integration.addSource({
             name: collectionName.trim(),
             url,
             plex_library: plexLibrary,
         });
 
-        // Reset form on success
-        setUsername("");
-        setListType("");
-        setCollectionName("");
-        setNameManuallyEdited(false);
-        setPlexLibrary("");
-        setFetchedLists(undefined);
-        lastFetchedUsername.current = "";
+        if (ok) {
+            setUsername("");
+            setListType("");
+            setCollectionName("");
+            setNameManuallyEdited(false);
+            setPlexLibrary("");
+            setFetchedLists(undefined);
+            lastFetchedUsername.current = "";
+        }
     }, [canAdd, username, listType, collectionName, plexLibrary, integration]);
 
     // Browse list handlers
@@ -165,19 +166,20 @@ export function AniListIntegration() {
         if (!canAddBrowse) return;
 
         const url = `anilist://browse/${browseSort}`;
-        await integration.addSource({
+        const ok = await integration.addSource({
             name: browseCollectionName.trim(),
             url,
             plex_library: browsePlexLibrary,
             max_items: browseMaxItems,
         });
 
-        // Reset form
-        setBrowseSort("");
-        setBrowseCollectionName("");
-        setBrowseNameManuallyEdited(false);
-        setBrowsePlexLibrary("");
-        setBrowseMaxItems(100);
+        if (ok) {
+            setBrowseSort("");
+            setBrowseCollectionName("");
+            setBrowseNameManuallyEdited(false);
+            setBrowsePlexLibrary("");
+            setBrowseMaxItems(100);
+        }
     }, [canAddBrowse, browseSort, browseCollectionName, browsePlexLibrary, browseMaxItems, integration]);
 
     const formDisabled = integration.savingSource || integration.loadingSources;

--- a/homescreen-hero-ui/src/components/integrations/AnimeIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/AnimeIntegration.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { ChevronRight, Tv } from "lucide-react";
+import { AniListIntegration } from "./AniListIntegration";
+
+export function AnimeIntegration() {
+    const [isExpanded, setIsExpanded] = useState(true);
+
+    return (
+        <div className="space-y-4">
+            <div className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 overflow-hidden shadow-lg shadow-primary/5">
+                <button
+                    type="button"
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    className="w-full px-6 py-4 flex items-center justify-between hover:bg-slate-800/30 transition"
+                >
+                    <div className="text-left flex items-start gap-3">
+                        <div className="rounded-lg bg-primary/10 p-2 border border-primary/20 mt-0.5">
+                            <Tv className="h-5 w-5 text-primary" />
+                        </div>
+                        <div>
+                            <h3 className="text-lg font-semibold text-slate-100">AniList</h3>
+                            <p className="text-xs text-slate-400 mt-1">
+                                Sync your AniList anime lists to Plex collections.
+                            </p>
+                        </div>
+                    </div>
+                    <ChevronRight
+                        className={`h-5 w-5 text-slate-400 transition-transform duration-200 ${
+                            isExpanded ? "rotate-90" : ""
+                        }`}
+                    />
+                </button>
+
+                <div
+                    className={`grid transition-all duration-300 ease-in-out ${
+                        isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                    }`}
+                >
+                    <div className="overflow-hidden">
+                        <div className="px-6 pb-6 space-y-4 border-t border-slate-800">
+                            <div className="pt-4">
+                                <AniListIntegration />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
@@ -99,8 +99,8 @@ export function LetterboxdIntegration() {
                                 </div>
 
                                 {/* Note */}
-                                <div className="rounded-lg border border-amber-700/50 bg-amber-900/20 px-4 py-3">
-                                    <p className="text-xs text-amber-200">
+                                <div className="rounded-lg border border-blue-700/50 bg-blue-900/20 px-4 py-3">
+                                    <p className="text-xs text-blue-200">
                                         <strong>Note:</strong> Letterboxd integration uses web scraping since their
                                         API requires approval. Movies are matched by title and year, which may be
                                         less accurate than ID-based matching.

--- a/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
+import { ChevronRight, Film } from "lucide-react";
 import Toast from "../Toast";
-import { SourceListManager } from "./shared/SourceListManager";
+import { SourceList } from "./shared/SourceListManager";
+import { LibrarySelect } from "./shared/LibrarySelect";
 import { useListIntegration } from "../../hooks/integrations/useListIntegration";
 import { usePlexLibraries } from "../../hooks/integrations/usePlexLibraries";
 import type { LetterboxdMissingItem } from "../../types/integrations";
@@ -13,6 +16,7 @@ function formatDate(dateString: string | null): string {
 }
 
 export function LetterboxdIntegration() {
+    const [isExpanded, setIsExpanded] = useState(true);
     const { enabledLibraries } = usePlexLibraries();
 
     const integration = useListIntegration<typeof emptySettings, LetterboxdMissingItem>({
@@ -21,66 +25,136 @@ export function LetterboxdIntegration() {
         hasSettings: false,
     });
 
+    const canAdd = integration.newSource.name && integration.newSource.url && integration.newSource.plex_library;
+
     return (
         <>
-        <SourceListManager<LetterboxdMissingItem>
-            title="Letterboxd Lists"
-            description="Add or remove Letterboxd list sources that sync into Plex collections."
-            urlPlaceholder="https://letterboxd.com/username/list/listname/"
-            sources={integration.sources}
-            statuses={integration.statuses}
-            libraries={enabledLibraries}
-            newSource={integration.newSource}
-            onNewSourceChange={integration.setNewSource}
-            onAddSource={integration.addSource}
-            onSyncSource={integration.syncSource}
-            onRemoveSource={integration.removeSource}
-            loadingSources={integration.loadingSources}
-            savingSource={integration.savingSource}
-            syncingSource={integration.syncingSource}
-            deletingSource={integration.deletingSource}
-            missingItems={integration.missingItems}
-            expandedMissing={integration.expandedMissing}
-            missingPages={integration.missingPages}
-            loadingMissing={integration.loadingMissing}
-            onToggleMissing={integration.toggleMissingItems}
-            onSetMissingPage={integration.setMissingPage}
-            note={
-                <div className="rounded-lg border border-amber-700/50 bg-amber-900/20 px-4 py-3">
-                    <p className="text-xs text-amber-200">
-                        <strong>Note:</strong> Letterboxd integration uses web scraping since their
-                        API requires approval. Movies are matched by title and year, which may be
-                        less accurate than ID-based matching.
-                    </p>
-                </div>
-            }
-            renderMissingItem={(item, i) => (
-                <div
-                    key={i}
-                    className="flex items-start justify-between gap-3 rounded-md border border-slate-800/40 bg-slate-950/40 px-3 py-2"
+        <div className="space-y-4">
+            <div className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 overflow-hidden shadow-lg shadow-primary/5">
+                <button
+                    type="button"
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    className="w-full px-6 py-4 flex items-center justify-between hover:bg-slate-800/30 transition"
                 >
-                    <div className="flex-1 min-w-0">
-                        <p className="text-xs font-medium text-slate-200 truncate">
-                            {item.title}
-                            {item.year ? ` (${item.year})` : ""}
-                        </p>
-                        {item.letterboxd_url && (
-                            <a
-                                href={item.letterboxd_url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-xs text-primary hover:underline"
-                            >
-                                View on Letterboxd
-                            </a>
-                        )}
+                    <div className="text-left flex items-start gap-3">
+                        <div className="rounded-lg bg-primary/10 p-2 border border-primary/20 mt-0.5">
+                            <Film className="h-5 w-5 text-primary" />
+                        </div>
+                        <div>
+                            <h3 className="text-lg font-semibold text-slate-100">Letterboxd Lists</h3>
+                            <p className="text-xs text-slate-400 mt-1">
+                                Sync your Letterboxd lists to Plex collections.
+                            </p>
+                        </div>
                     </div>
-                    <div className="text-xs text-slate-500 whitespace-nowrap">
-                        {formatDate(item.last_seen)}
+                    <ChevronRight
+                        className={`h-5 w-5 text-slate-400 transition-transform duration-200 ${
+                            isExpanded ? "rotate-90" : ""
+                        }`}
+                    />
+                </button>
+
+                <div
+                    className={`grid transition-all duration-300 ease-in-out ${
+                        isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                    }`}
+                >
+                    <div className="overflow-hidden">
+                        <div className="px-6 pb-6 space-y-4 border-t border-slate-800">
+                            <div className="pt-4 space-y-4">
+                                {/* Add source form */}
+                                <div className="flex items-start justify-between gap-4">
+                                    <div className="grid gap-3 md:grid-cols-3 flex-1">
+                                        <input
+                                            type="text"
+                                            placeholder="Friendly name"
+                                            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                                            value={integration.newSource.name}
+                                            onChange={(e) => integration.setNewSource({ ...integration.newSource, name: e.target.value })}
+                                            disabled={integration.savingSource || integration.loadingSources}
+                                        />
+                                        <input
+                                            type="url"
+                                            placeholder="https://letterboxd.com/username/list/listname/"
+                                            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                                            value={integration.newSource.url}
+                                            onChange={(e) => integration.setNewSource({ ...integration.newSource, url: e.target.value })}
+                                            disabled={integration.savingSource || integration.loadingSources}
+                                        />
+                                        <LibrarySelect
+                                            value={integration.newSource.plex_library}
+                                            onChange={(value) => integration.setNewSource({ ...integration.newSource, plex_library: value })}
+                                            libraries={enabledLibraries}
+                                            disabled={integration.savingSource || integration.loadingSources}
+                                        />
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={integration.addSource}
+                                        disabled={integration.savingSource || integration.loadingSources || !canAdd}
+                                        className="cursor-pointer rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed whitespace-nowrap"
+                                    >
+                                        {integration.savingSource ? "Adding…" : "Add List"}
+                                    </button>
+                                </div>
+
+                                {/* Note */}
+                                <div className="rounded-lg border border-amber-700/50 bg-amber-900/20 px-4 py-3">
+                                    <p className="text-xs text-amber-200">
+                                        <strong>Note:</strong> Letterboxd integration uses web scraping since their
+                                        API requires approval. Movies are matched by title and year, which may be
+                                        less accurate than ID-based matching.
+                                    </p>
+                                </div>
+
+                                {/* Source list */}
+                                <SourceList<LetterboxdMissingItem>
+                                    sources={integration.sources}
+                                    statuses={integration.statuses}
+                                    onSyncSource={integration.syncSource}
+                                    onRemoveSource={integration.removeSource}
+                                    loadingSources={integration.loadingSources}
+                                    syncingSource={integration.syncingSource}
+                                    deletingSource={integration.deletingSource}
+                                    missingItems={integration.missingItems}
+                                    expandedMissing={integration.expandedMissing}
+                                    missingPages={integration.missingPages}
+                                    loadingMissing={integration.loadingMissing}
+                                    onToggleMissing={integration.toggleMissingItems}
+                                    onSetMissingPage={integration.setMissingPage}
+                                    renderMissingItem={(item, i) => (
+                                        <div
+                                            key={i}
+                                            className="flex items-start justify-between gap-3 rounded-md border border-slate-800/40 bg-slate-950/40 px-3 py-2"
+                                        >
+                                            <div className="flex-1 min-w-0">
+                                                <p className="text-xs font-medium text-slate-200 truncate">
+                                                    {item.title}
+                                                    {item.year ? ` (${item.year})` : ""}
+                                                </p>
+                                                {item.letterboxd_url && (
+                                                    <a
+                                                        href={item.letterboxd_url}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className="text-xs text-primary hover:underline"
+                                                    >
+                                                        View on Letterboxd
+                                                    </a>
+                                                )}
+                                            </div>
+                                            <div className="text-xs text-slate-500 whitespace-nowrap">
+                                                {formatDate(item.last_seen)}
+                                            </div>
+                                        </div>
+                                    )}
+                                />
+                            </div>
+                        </div>
                     </div>
                 </div>
-            )}
-        />
+            </div>
+        </div>
 
         {integration.toast && (
             <Toast

--- a/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
@@ -90,7 +90,7 @@ export function LetterboxdIntegration() {
                                     </div>
                                     <button
                                         type="button"
-                                        onClick={integration.addSource}
+                                        onClick={() => integration.addSource()}
                                         disabled={integration.savingSource || integration.loadingSources || !canAdd}
                                         className="cursor-pointer rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed whitespace-nowrap"
                                     >

--- a/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
@@ -1,3 +1,4 @@
+import Toast from "../Toast";
 import { SourceListManager } from "./shared/SourceListManager";
 import { useListIntegration } from "../../hooks/integrations/useListIntegration";
 import { usePlexLibraries } from "../../hooks/integrations/usePlexLibraries";
@@ -21,6 +22,7 @@ export function LetterboxdIntegration() {
     });
 
     return (
+        <>
         <SourceListManager<LetterboxdMissingItem>
             title="Letterboxd Lists"
             description="Add or remove Letterboxd list sources that sync into Plex collections."
@@ -43,8 +45,6 @@ export function LetterboxdIntegration() {
             loadingMissing={integration.loadingMissing}
             onToggleMissing={integration.toggleMissingItems}
             onSetMissingPage={integration.setMissingPage}
-            error={integration.sourcesError}
-            message={integration.sourcesMessage}
             note={
                 <div className="rounded-lg border border-amber-700/50 bg-amber-900/20 px-4 py-3">
                     <p className="text-xs text-amber-200">
@@ -81,5 +81,14 @@ export function LetterboxdIntegration() {
                 </div>
             )}
         />
+
+        {integration.toast && (
+            <Toast
+                message={integration.toast.message}
+                type={integration.toast.type}
+                onClose={integration.clearToast}
+            />
+        )}
+        </>
     );
 }

--- a/homescreen-hero-ui/src/components/integrations/MDBListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/MDBListIntegration.tsx
@@ -1,6 +1,7 @@
 import { Switch } from "@headlessui/react";
 import { Wifi, WifiOff } from "lucide-react";
 import FieldRow from "../FieldRow";
+import Toast from "../Toast";
 import { ConfigPanel } from "./shared/ConfigPanel";
 import { SourceListManager } from "./shared/SourceListManager";
 import { useListIntegration } from "../../hooks/integrations/useListIntegration";
@@ -96,18 +97,6 @@ export function MDBListIntegration() {
                     />
                 </FieldRow>
 
-                {integration.settingsMessage && (
-                    <div className="rounded-lg border border-emerald-700 bg-emerald-900/50 px-3 py-2 text-xs text-emerald-100">
-                        {integration.settingsMessage}
-                    </div>
-                )}
-
-                {integration.settingsError && (
-                    <div className="rounded-lg border border-rose-700 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
-                        {integration.settingsError}
-                    </div>
-                )}
-
                 {/* Test connection CTA */}
                 <div className="flex items-center justify-between gap-4 rounded-xl border border-slate-800 bg-slate-900/40 px-4 py-3 mt-6">
                     <div className="flex items-center gap-3">
@@ -184,8 +173,6 @@ export function MDBListIntegration() {
                 loadingMissing={integration.loadingMissing}
                 onToggleMissing={integration.toggleMissingItems}
                 onSetMissingPage={integration.setMissingPage}
-                error={integration.sourcesError}
-                message={integration.sourcesMessage}
                 renderMissingItem={(item, i) => (
                     <div
                         key={i}
@@ -208,6 +195,14 @@ export function MDBListIntegration() {
                     </div>
                 )}
             />
+
+            {integration.toast && (
+                <Toast
+                    message={integration.toast.message}
+                    type={integration.toast.type}
+                    onClose={integration.clearToast}
+                />
+            )}
         </div>
     );
 }

--- a/homescreen-hero-ui/src/components/integrations/MDBListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/MDBListIntegration.tsx
@@ -160,7 +160,7 @@ export function MDBListIntegration() {
                 libraries={enabledLibraries}
                 newSource={integration.newSource}
                 onNewSourceChange={integration.setNewSource}
-                onAddSource={integration.addSource}
+                onAddSource={() => integration.addSource()}
                 onSyncSource={integration.syncSource}
                 onRemoveSource={integration.removeSource}
                 loadingSources={integration.loadingSources}

--- a/homescreen-hero-ui/src/components/integrations/TraktIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/TraktIntegration.tsx
@@ -161,7 +161,7 @@ export function TraktIntegration() {
                 libraries={enabledLibraries}
                 newSource={integration.newSource}
                 onNewSourceChange={integration.setNewSource}
-                onAddSource={integration.addSource}
+                onAddSource={() => integration.addSource()}
                 onSyncSource={integration.syncSource}
                 onRemoveSource={integration.removeSource}
                 loadingSources={integration.loadingSources}

--- a/homescreen-hero-ui/src/components/integrations/TraktIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/TraktIntegration.tsx
@@ -1,6 +1,7 @@
 import { Switch } from "@headlessui/react";
 import { Wifi, WifiOff } from "lucide-react";
 import FieldRow from "../FieldRow";
+import Toast from "../Toast";
 import { ConfigPanel } from "./shared/ConfigPanel";
 import { SourceListManager } from "./shared/SourceListManager";
 import { useListIntegration } from "../../hooks/integrations/useListIntegration";
@@ -99,18 +100,6 @@ export function TraktIntegration() {
                     />
                 </FieldRow>
 
-                {integration.settingsMessage && (
-                    <div className="rounded-lg border border-emerald-700 bg-emerald-900/50 px-3 py-2 text-xs text-emerald-100">
-                        {integration.settingsMessage}
-                    </div>
-                )}
-
-                {integration.settingsError && (
-                    <div className="rounded-lg border border-rose-700 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
-                        {integration.settingsError}
-                    </div>
-                )}
-
                 {/* Test connection CTA */}
                 <div className="flex items-center justify-between gap-4 rounded-xl border border-slate-800 bg-slate-900/40 px-4 py-3 mt-6">
                     <div className="flex items-center gap-3">
@@ -185,8 +174,6 @@ export function TraktIntegration() {
                 loadingMissing={integration.loadingMissing}
                 onToggleMissing={integration.toggleMissingItems}
                 onSetMissingPage={integration.setMissingPage}
-                error={integration.sourcesError}
-                message={integration.sourcesMessage}
                 renderMissingItem={(item, i) => (
                     <div
                         key={i}
@@ -208,6 +195,14 @@ export function TraktIntegration() {
                     </div>
                 )}
             />
+
+            {integration.toast && (
+                <Toast
+                    message={integration.toast.message}
+                    type={integration.toast.type}
+                    onClose={integration.clearToast}
+                />
+            )}
         </div>
     );
 }

--- a/homescreen-hero-ui/src/components/integrations/shared/LibrarySelect.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/LibrarySelect.tsx
@@ -12,14 +12,14 @@ interface LibrarySelectProps {
 export function LibrarySelect({ value, onChange, libraries, disabled }: LibrarySelectProps) {
     return (
         <Listbox value={value} onChange={onChange} disabled={disabled}>
-            <div className="relative">
+            <div className="relative w-44">
                 <Listbox.Button className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-left text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 disabled:opacity-60 flex items-center justify-between">
                     <span className={value ? "text-slate-100" : "text-slate-500"}>
                         {value || "Select Plex library"}
                     </span>
                     <ChevronDown className="h-4 w-4 text-slate-400" />
                 </Listbox.Button>
-                <Listbox.Options className="absolute z-10 mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 py-1 shadow-lg focus:outline-none max-h-60 overflow-auto">
+                <Listbox.Options anchor="bottom start" className="z-50 mt-1 w-[var(--button-width)] rounded-lg border border-slate-700 bg-slate-900 py-1 shadow-lg focus:outline-none max-h-60 overflow-auto">
                     {libraries.length === 0 ? (
                         <div className="px-3 py-2 text-xs text-slate-500">
                             No enabled Plex libraries configured.

--- a/homescreen-hero-ui/src/components/integrations/shared/ListTypeSelect.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/ListTypeSelect.tsx
@@ -22,13 +22,15 @@ interface ListTypeSelectProps {
     disabled?: boolean;
     options?: ListTypeOption[];
     loading?: boolean;
+    showAllOption?: boolean;
 }
 
-export function ListTypeSelect({ value, onChange, disabled, options, loading }: ListTypeSelectProps) {
+export function ListTypeSelect({ value, onChange, disabled, options, loading, showAllOption = true }: ListTypeSelectProps) {
     // Use dynamic options if provided, otherwise fall back to defaults
-    // Always prepend "All Lists" option
     const allOption: ListTypeOption = { value: "", label: "All Lists" };
-    const listOptions = options ? [allOption, ...options] : DEFAULT_LIST_TYPES;
+    const listOptions = options
+        ? (showAllOption ? [allOption, ...options] : options)
+        : DEFAULT_LIST_TYPES;
 
     const selected = listOptions.find((t) => t.value === value);
 

--- a/homescreen-hero-ui/src/components/integrations/shared/ListTypeSelect.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/ListTypeSelect.tsx
@@ -1,0 +1,72 @@
+import { Listbox } from "@headlessui/react";
+import { Check, ChevronDown, Loader2 } from "lucide-react";
+
+export interface ListTypeOption {
+    value: string;
+    label: string;
+    is_custom?: boolean;
+}
+
+const DEFAULT_LIST_TYPES: ListTypeOption[] = [
+    { value: "", label: "All Lists" },
+    { value: "watching", label: "Watching" },
+    { value: "completed", label: "Completed" },
+    { value: "planning", label: "Planning" },
+    { value: "paused", label: "Paused" },
+    { value: "dropped", label: "Dropped" },
+];
+
+interface ListTypeSelectProps {
+    value: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+    options?: ListTypeOption[];
+    loading?: boolean;
+}
+
+export function ListTypeSelect({ value, onChange, disabled, options, loading }: ListTypeSelectProps) {
+    // Use dynamic options if provided, otherwise fall back to defaults
+    // Always prepend "All Lists" option
+    const allOption: ListTypeOption = { value: "", label: "All Lists" };
+    const listOptions = options ? [allOption, ...options] : DEFAULT_LIST_TYPES;
+
+    const selected = listOptions.find((t) => t.value === value);
+
+    return (
+        <Listbox value={value} onChange={onChange} disabled={disabled || loading}>
+            <div className="relative w-40">
+                <Listbox.Button className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-left text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 disabled:opacity-60 flex items-center justify-between">
+                    <span className={value !== undefined ? "text-slate-100" : "text-slate-500"}>
+                        {loading ? "Loading…" : (selected?.label ?? "All Lists")}
+                    </span>
+                    {loading ? (
+                        <Loader2 className="h-4 w-4 text-slate-400 animate-spin" />
+                    ) : (
+                        <ChevronDown className="h-4 w-4 text-slate-400" />
+                    )}
+                </Listbox.Button>
+                <Listbox.Options anchor="bottom start" className="z-50 mt-1 w-[var(--button-width)] min-w-max rounded-lg border border-slate-700 bg-slate-900 py-1 shadow-lg focus:outline-none max-h-60 overflow-auto">
+                    {listOptions.map((type) => (
+                        <Listbox.Option
+                            key={type.value}
+                            value={type.value}
+                            className="cursor-pointer px-3 py-2 text-sm text-slate-100 hover:bg-slate-800 data-[selected]:bg-primary/20 data-[selected]:font-semibold flex items-center justify-between gap-3"
+                        >
+                            {({ selected: isSelected }) => (
+                                <>
+                                    <span>
+                                        {type.label}
+                                        {type.is_custom && (
+                                            <span className="ml-1.5 text-[10px] text-slate-500">custom</span>
+                                        )}
+                                    </span>
+                                    {isSelected && <Check className="h-4 w-4 text-primary" />}
+                                </>
+                            )}
+                        </Listbox.Option>
+                    ))}
+                </Listbox.Options>
+            </div>
+        </Listbox>
+    );
+}

--- a/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
@@ -145,10 +145,6 @@ interface SourceListManagerProps<TMissing extends BaseMissingItem> {
     renderMissingItem: (item: TMissing, index: number) => ReactNode;
     itemsPerPage?: number;
 
-    // Messages
-    error: string | null;
-    message: string | null;
-
     // Optional note (like Letterboxd's scraping disclaimer)
     note?: ReactNode;
 }
@@ -180,8 +176,6 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
         onSetMissingPage,
         renderMissingItem,
         itemsPerPage = 10,
-        error,
-        message,
         note,
     } = props;
 
@@ -233,18 +227,6 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
 
             {/* Optional note */}
             {note}
-
-            {/* Messages */}
-            {message && (
-                <div className="rounded-lg border border-emerald-700 bg-emerald-900/50 px-3 py-2 text-xs text-emerald-100">
-                    {message}
-                </div>
-            )}
-            {error && (
-                <div className="rounded-lg border border-rose-700 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
-                    {error}
-                </div>
-            )}
 
             {/* Source list */}
             <SourceList

--- a/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
@@ -315,11 +315,6 @@ function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMi
                                 Last synced: {formatDate(status.last_sync_time)}
                             </p>
                         )}
-                        {status && status.sync_status !== "never_synced" && (
-                            <p className="text-xs text-slate-500">
-                                Matched {status.items_matched} of {status.items_total} items
-                            </p>
-                        )}
                     </div>
 
                     <div className="flex gap-2 flex-wrap">
@@ -357,6 +352,11 @@ function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMi
                             }`}
                         />
                         Missing items
+                        {status && status.sync_status !== "never_synced" && (
+                            <span className="text-slate-500 font-normal">
+                                · {status.items_matched}/{status.items_total} matched
+                            </span>
+                        )}
                     </button>
 
                     {isExpanded && (

--- a/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
@@ -271,7 +271,9 @@ interface SourceCardProps<TMissing> {
 
 function formatDate(dateString: string | null): string {
     if (!dateString) return "Never";
-    return new Date(dateString).toLocaleString();
+    // Backend stores UTC but without a timezone suffix, so append Z
+    const utcString = dateString.endsWith("Z") ? dateString : dateString + "Z";
+    return new Date(utcString).toLocaleString();
 }
 
 function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMissing>) {

--- a/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
@@ -1,8 +1,111 @@
 import type { ReactNode } from "react";
-import { RefreshCw, ChevronRight, ChevronLeft } from "lucide-react";
+import { RefreshCw, ChevronRight, ChevronLeft, ListPlus } from "lucide-react";
 import type { Source, SourceStatus, BaseMissingItem, PlexLibraryConfig } from "../../../types/integrations";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 import { LibrarySelect } from "./LibrarySelect";
+
+// ─── SourceList (reusable source list without the add form) ─────────────────
+
+export interface SourceListProps<TMissing extends BaseMissingItem> {
+    sources: Source[];
+    statuses: Map<number, SourceStatus>;
+    onSyncSource: (index: number) => void;
+    onRemoveSource: (index: number) => void;
+    loadingSources: boolean;
+    syncingSource: number | null;
+    deletingSource: number | null;
+    missingItems: Map<number, TMissing[]>;
+    expandedMissing: Set<number>;
+    missingPages: Map<number, number>;
+    loadingMissing: Set<number>;
+    onToggleMissing: (index: number) => void;
+    onSetMissingPage: (index: number, page: number) => void;
+    renderMissingItem: (item: TMissing, index: number) => ReactNode;
+    itemsPerPage?: number;
+}
+
+export function SourceList<TMissing extends BaseMissingItem>(
+    props: SourceListProps<TMissing>
+) {
+    const {
+        sources,
+        statuses,
+        onSyncSource,
+        onRemoveSource,
+        loadingSources,
+        syncingSource,
+        deletingSource,
+        missingItems,
+        expandedMissing,
+        missingPages,
+        loadingMissing,
+        onToggleMissing,
+        onSetMissingPage,
+        renderMissingItem,
+        itemsPerPage = 10,
+    } = props;
+
+    if (loadingSources) {
+        return <p className="text-xs text-slate-400">Loading sources…</p>;
+    }
+
+    if (sources.length === 0) {
+        return (
+            <div className="rounded-lg border border-dashed border-slate-700 bg-slate-950/30 px-4 py-6 flex items-center gap-4">
+                <div className="space-y-2 flex-1">
+                    <div className="flex items-center gap-2">
+                        <div className="h-4 w-32 rounded bg-slate-800" />
+                        <div className="h-4 w-16 rounded-full bg-slate-800/60" />
+                    </div>
+                    <div className="h-3 w-56 rounded bg-slate-800/40" />
+                    <div className="h-3 w-28 rounded bg-slate-800/40" />
+                </div>
+                <div className="flex flex-col items-center gap-1.5 px-4">
+                    <ListPlus className="h-7 w-7 text-slate-700" />
+                    <p className="text-sm text-slate-400 whitespace-nowrap">No lists added yet</p>
+                </div>
+                <div className="flex gap-2 flex-1 justify-end">
+                    <div className="h-7 w-20 rounded-lg bg-slate-800/40" />
+                    <div className="h-7 w-16 rounded-lg bg-slate-800/40" />
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            {sources.map((source, idx) => {
+                const status = statuses.get(idx);
+                const missing = missingItems.get(idx);
+                const isExpanded = expandedMissing.has(idx);
+                const isLoadingMissing = loadingMissing.has(idx);
+                const currentPage = missingPages.get(idx) || 0;
+
+                return (
+                    <SourceCard
+                        key={`${source.name}-${idx}`}
+                        source={source}
+                        status={status}
+                        onSync={() => onSyncSource(idx)}
+                        onRemove={() => onRemoveSource(idx)}
+                        isSyncing={syncingSource === idx}
+                        isDeleting={deletingSource === idx}
+                        missingItems={missing}
+                        isExpanded={isExpanded}
+                        isLoadingMissing={isLoadingMissing}
+                        currentPage={currentPage}
+                        itemsPerPage={itemsPerPage}
+                        onToggleMissing={() => onToggleMissing(idx)}
+                        onSetPage={(page) => onSetMissingPage(idx, page)}
+                        renderMissingItem={renderMissingItem}
+                    />
+                );
+            })}
+        </div>
+    );
+}
+
+// ─── SourceListManager (add form + SourceList, used by Trakt/Letterboxd/MDBList) ─
 
 interface SourceListManagerProps<TMissing extends BaseMissingItem> {
     // Header
@@ -48,11 +151,6 @@ interface SourceListManagerProps<TMissing extends BaseMissingItem> {
 
     // Optional note (like Letterboxd's scraping disclaimer)
     note?: ReactNode;
-}
-
-function formatDate(dateString: string | null): string {
-    if (!dateString) return "Never";
-    return new Date(dateString).toLocaleString();
 }
 
 export function SourceListManager<TMissing extends BaseMissingItem>(
@@ -101,7 +199,7 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
                     type="button"
                     onClick={onAddSource}
                     disabled={savingSource || loadingSources || !canAdd}
-                    className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-semibold text-slate-100 transition hover:bg-slate-800 disabled:opacity-60"
+                    className="cursor-pointer rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
                 >
                     {savingSource ? "Adding…" : "Add List"}
                 </button>
@@ -149,48 +247,29 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
             )}
 
             {/* Source list */}
-            <div className="space-y-3">
-                {loadingSources ? (
-                    <p className="text-xs text-slate-400">Loading sources…</p>
-                ) : sources.length === 0 ? (
-                    <p className="text-xs text-slate-400">
-                        No lists added yet. Use the form above to add your first list.
-                    </p>
-                ) : (
-                    sources.map((source, idx) => {
-                        const status = statuses.get(idx);
-                        const missing = missingItems.get(idx);
-                        const isExpanded = expandedMissing.has(idx);
-                        const isLoadingMissing = loadingMissing.has(idx);
-                        const currentPage = missingPages.get(idx) || 0;
-
-                        return (
-                            <SourceCard
-                                key={`${source.name}-${idx}`}
-                                source={source}
-                                status={status}
-                                onSync={() => onSyncSource(idx)}
-                                onRemove={() => onRemoveSource(idx)}
-                                isSyncing={syncingSource === idx}
-                                isDeleting={deletingSource === idx}
-                                missingItems={missing}
-                                isExpanded={isExpanded}
-                                isLoadingMissing={isLoadingMissing}
-                                currentPage={currentPage}
-                                itemsPerPage={itemsPerPage}
-                                onToggleMissing={() => onToggleMissing(idx)}
-                                onSetPage={(page) => onSetMissingPage(idx, page)}
-                                renderMissingItem={renderMissingItem}
-                            />
-                        );
-                    })
-                )}
-            </div>
+            <SourceList
+                sources={sources}
+                statuses={statuses}
+                onSyncSource={onSyncSource}
+                onRemoveSource={onRemoveSource}
+                loadingSources={loadingSources}
+                syncingSource={syncingSource}
+                deletingSource={deletingSource}
+                missingItems={missingItems}
+                expandedMissing={expandedMissing}
+                missingPages={missingPages}
+                loadingMissing={loadingMissing}
+                onToggleMissing={onToggleMissing}
+                onSetMissingPage={onSetMissingPage}
+                renderMissingItem={renderMissingItem}
+                itemsPerPage={itemsPerPage}
+            />
         </div>
     );
 }
 
-// Internal SourceCard component
+// ─── SourceCard (internal) ──────────────────────────────────────────────────
+
 interface SourceCardProps<TMissing> {
     source: Source;
     status: SourceStatus | undefined;
@@ -206,6 +285,11 @@ interface SourceCardProps<TMissing> {
     onToggleMissing: () => void;
     onSetPage: (page: number) => void;
     renderMissingItem: (item: TMissing, index: number) => ReactNode;
+}
+
+function formatDate(dateString: string | null): string {
+    if (!dateString) return "Never";
+    return new Date(dateString).toLocaleString();
 }
 
 function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMissing>) {

--- a/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
+++ b/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
@@ -48,7 +48,7 @@ export interface UseListIntegrationReturn<TSettings, TMissing> {
     // Source mutations
     newSource: Source;
     setNewSource: React.Dispatch<React.SetStateAction<Source>>;
-    addSource: () => Promise<void>;
+    addSource: (sourceOverride?: Source) => Promise<void>;
     removeSource: (index: number) => Promise<void>;
     syncSource: (index: number) => Promise<void>;
     savingSource: boolean;
@@ -250,8 +250,9 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         }
     }, [healthEndpoint, integrationName]);
 
-    // Add source
-    const addSource = useCallback(async () => {
+    // Add source (accepts optional override for integrations with custom forms)
+    const addSource = useCallback(async (sourceOverride?: Source) => {
+        const sourceToAdd = sourceOverride || newSource;
         try {
             setSavingSource(true);
             setSourcesError(null);
@@ -260,7 +261,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
             const r = await fetchWithAuth(`${basePath}/sources`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(newSource),
+                body: JSON.stringify(sourceToAdd),
             });
 
             if (!r.ok) throw new Error(await r.text());
@@ -274,7 +275,9 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 setSources(refreshedSources || []);
             }
 
-            setNewSource({ name: "", url: "", plex_library: "" });
+            if (!sourceOverride) {
+                setNewSource({ name: "", url: "", plex_library: "" });
+            }
             setSourcesMessage(data.message);
         } catch (e) {
             setSourcesError(String(e));

--- a/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
+++ b/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
@@ -57,7 +57,7 @@ export interface UseListIntegrationReturn<TSettings, TMissing> {
     // Source mutations
     newSource: Source;
     setNewSource: React.Dispatch<React.SetStateAction<Source>>;
-    addSource: (sourceOverride?: Source) => Promise<void>;
+    addSource: (sourceOverride?: Source) => Promise<boolean>;
     removeSource: (index: number) => Promise<void>;
     syncSource: (index: number) => Promise<void>;
     savingSource: boolean;

--- a/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
+++ b/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
@@ -247,7 +247,8 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
     }, [healthEndpoint, integrationName]);
 
     // Add source (accepts optional override for integrations with custom forms)
-    const addSource = useCallback(async (sourceOverride?: Source) => {
+    // Returns true on success so callers can reset their form only when appropriate
+    const addSource = useCallback(async (sourceOverride?: Source): Promise<boolean> => {
         const sourceToAdd = sourceOverride || newSource;
         try {
             setSavingSource(true);
@@ -273,8 +274,10 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 setNewSource({ name: "", url: "", plex_library: "" });
             }
             setToast({ message: data.message, type: "success" });
+            return true;
         } catch (e) {
             setToast({ message: String(e), type: "error" });
+            return false;
         } finally {
             setSavingSource(false);
         }

--- a/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
+++ b/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
@@ -9,6 +9,17 @@ import type {
     TestStatus,
 } from "../../types/integrations";
 
+// Extract a human-readable message from a failed response.
+// FastAPI returns {"detail": "..."} for HTTPExceptions.
+async function extractError(r: Response): Promise<string> {
+    const text = await r.text();
+    try {
+        const json = JSON.parse(text);
+        if (typeof json.detail === "string") return json.detail;
+    } catch { /* not JSON, fall through */ }
+    return text || `Request failed (${r.status})`;
+}
+
 export interface UseListIntegrationConfig<TSettings> {
     // API endpoint base (e.g., "trakt", "letterboxd", "mdblist")
     integrationName: string;
@@ -29,10 +40,7 @@ export interface UseListIntegrationReturn<TSettings, TMissing> {
     setSettings: React.Dispatch<React.SetStateAction<TSettings>>;
     loadingSettings: boolean;
     savingSettings: boolean;
-    settingsError: string | null;
-    settingsMessage: string | null;
     saveSettings: () => Promise<void>;
-    clearSettingsMessages: () => void;
 
     // Test connection
     testStatus: TestStatus;
@@ -41,9 +49,10 @@ export interface UseListIntegrationReturn<TSettings, TMissing> {
     // Sources
     sources: Source[];
     loadingSources: boolean;
-    sourcesError: string | null;
-    sourcesMessage: string | null;
-    clearSourcesMessages: () => void;
+
+    // Toast notification (replaces inline banners)
+    toast: { message: string; type: "success" | "error" } | null;
+    clearToast: () => void;
 
     // Source mutations
     newSource: Source;
@@ -77,8 +86,6 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
     const [settings, setSettings] = useState<TSettings>(initialSettings);
     const [loadingSettings, setLoadingSettings] = useState(hasSettings);
     const [savingSettings, setSavingSettings] = useState(false);
-    const [settingsError, setSettingsError] = useState<string | null>(null);
-    const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
 
     // Test connection state
     const [testStatus, setTestStatus] = useState<TestStatus>("idle");
@@ -86,8 +93,9 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
     // Sources state
     const [sources, setSources] = useState<Source[]>([]);
     const [loadingSources, setLoadingSources] = useState(true);
-    const [sourcesError, setSourcesError] = useState<string | null>(null);
-    const [sourcesMessage, setSourcesMessage] = useState<string | null>(null);
+
+    // Toast notification (replaces separate settings/sources message/error states)
+    const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
 
     // Source mutation state
     const [newSource, setNewSource] = useState<Source>({
@@ -119,7 +127,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
 
         fetchWithAuth(basePath)
             .then(async (r) => {
-                if (!r.ok) throw new Error(await r.text());
+                if (!r.ok) throw new Error(await extractError(r));
                 return r.json();
             })
             .then((data: TSettings | null) => {
@@ -127,7 +135,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 setSettings(data);
             })
             .catch((e) => {
-                if (isMounted) setSettingsError(String(e));
+                if (isMounted) setToast({ message: String(e), type: "error" });
             })
             .finally(() => {
                 if (isMounted) setLoadingSettings(false);
@@ -144,14 +152,14 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
 
         fetchWithAuth(`${basePath}/sources`)
             .then(async (r) => {
-                if (!r.ok) throw new Error(await r.text());
+                if (!r.ok) throw new Error(await extractError(r));
                 return r.json();
             })
             .then((data: Source[]) => {
                 if (isMounted) setSources(data || []);
             })
             .catch((e) => {
-                if (isMounted) setSourcesError(String(e));
+                if (isMounted) setToast({ message: String(e), type: "error" });
             })
             .finally(() => {
                 if (isMounted) setLoadingSources(false);
@@ -170,7 +178,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
 
         fetchWithAuth(`${basePath}/sources/status`)
             .then(async (r) => {
-                if (!r.ok) throw new Error(await r.text());
+                if (!r.ok) throw new Error(await extractError(r));
                 return r.json();
             })
             .then((data: SourceStatus[]) => {
@@ -188,16 +196,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         };
     }, [basePath, loadingSources, sources.length]);
 
-    // Clear messages helpers
-    const clearSettingsMessages = useCallback(() => {
-        setSettingsError(null);
-        setSettingsMessage(null);
-    }, []);
-
-    const clearSourcesMessages = useCallback(() => {
-        setSourcesError(null);
-        setSourcesMessage(null);
-    }, []);
+    const clearToast = useCallback(() => setToast(null), []);
 
     // Save settings
     const saveSettings = useCallback(async () => {
@@ -205,8 +204,6 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
 
         try {
             setSavingSettings(true);
-            setSettingsError(null);
-            setSettingsMessage(null);
 
             const r = await fetchWithAuth(basePath, {
                 method: "POST",
@@ -214,12 +211,12 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 body: JSON.stringify(settings),
             });
 
-            if (!r.ok) throw new Error(await r.text());
+            if (!r.ok) throw new Error(await extractError(r));
 
             const data: ConfigSaveResponse = await r.json();
-            setSettingsMessage(data.message);
+            setToast({ message: data.message, type: "success" });
         } catch (e) {
-            setSettingsError(String(e));
+            setToast({ message: String(e), type: "error" });
         } finally {
             setSavingSettings(false);
         }
@@ -233,20 +230,19 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
             setTestStatus("testing");
 
             const r = await fetchWithAuth(healthEndpoint);
-            if (!r.ok) throw new Error(await r.text());
+            if (!r.ok) throw new Error(await extractError(r));
 
             const data: HealthComponent = await r.json();
 
             if (data?.ok === true) {
-                setSettingsError(null);
                 setTestStatus("success");
             } else {
                 setTestStatus("error");
-                setSettingsError(data?.error || `${integrationName} API health check failed.`);
+                setToast({ message: data?.error || `${integrationName} API health check failed.`, type: "error" });
             }
         } catch (e) {
             setTestStatus("error");
-            setSettingsError(String(e));
+            setToast({ message: String(e), type: "error" });
         }
     }, [healthEndpoint, integrationName]);
 
@@ -255,8 +251,6 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         const sourceToAdd = sourceOverride || newSource;
         try {
             setSavingSource(true);
-            setSourcesError(null);
-            setSourcesMessage(null);
 
             const r = await fetchWithAuth(`${basePath}/sources`, {
                 method: "POST",
@@ -264,7 +258,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 body: JSON.stringify(sourceToAdd),
             });
 
-            if (!r.ok) throw new Error(await r.text());
+            if (!r.ok) throw new Error(await extractError(r));
 
             const data: ConfigSaveResponse = await r.json();
 
@@ -278,9 +272,9 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
             if (!sourceOverride) {
                 setNewSource({ name: "", url: "", plex_library: "" });
             }
-            setSourcesMessage(data.message);
+            setToast({ message: data.message, type: "success" });
         } catch (e) {
-            setSourcesError(String(e));
+            setToast({ message: String(e), type: "error" });
         } finally {
             setSavingSource(false);
         }
@@ -291,14 +285,12 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         async (index: number) => {
             try {
                 setDeletingSource(index);
-                setSourcesError(null);
-                setSourcesMessage(null);
 
                 const r = await fetchWithAuth(`${basePath}/sources/${index}`, {
                     method: "DELETE",
                 });
 
-                if (!r.ok) throw new Error(await r.text());
+                if (!r.ok) throw new Error(await extractError(r));
 
                 const data: ConfigSaveResponse = await r.json();
 
@@ -315,9 +307,9 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 setMissingPages(new Map());
                 setStatuses(new Map());
 
-                setSourcesMessage(data.message);
+                setToast({ message: data.message, type: "success" });
             } catch (e) {
-                setSourcesError(String(e));
+                setToast({ message: String(e), type: "error" });
             } finally {
                 setDeletingSource(null);
             }
@@ -330,17 +322,15 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         async (index: number) => {
             try {
                 setSyncingSource(index);
-                setSourcesError(null);
-                setSourcesMessage(null);
 
                 const r = await fetchWithAuth(`${basePath}/sources/${index}/sync`, {
                     method: "POST",
                 });
 
-                if (!r.ok) throw new Error(await r.text());
+                if (!r.ok) throw new Error(await extractError(r));
 
                 const data = await r.json();
-                setSourcesMessage(`Synced ${data.items_matched}/${data.items_total} items`);
+                setToast({ message: `Synced ${data.items_matched}/${data.items_total} items`, type: "success" });
 
                 // Refresh statuses
                 const statusR = await fetchWithAuth(`${basePath}/sources/status`);
@@ -358,7 +348,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                     return newMap;
                 });
             } catch (e) {
-                setSourcesError(String(e));
+                setToast({ message: String(e), type: "error" });
             } finally {
                 setSyncingSource(null);
             }
@@ -388,13 +378,13 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 setLoadingMissing((prev) => new Set(prev).add(index));
 
                 const r = await fetchWithAuth(`${basePath}/sources/${index}/missing`);
-                if (!r.ok) throw new Error(await r.text());
+                if (!r.ok) throw new Error(await extractError(r));
 
                 const data: TMissing[] = await r.json();
                 setMissingItems((prev) => new Map(prev).set(index, data));
                 setExpandedMissing((prev) => new Set(prev).add(index));
             } catch (e) {
-                setSourcesError(`Failed to load missing items: ${String(e)}`);
+                setToast({ message: `Failed to load missing items: ${String(e)}`, type: "error" });
             } finally {
                 setLoadingMissing((prev) => {
                     const newSet = new Set(prev);
@@ -417,10 +407,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         setSettings,
         loadingSettings,
         savingSettings,
-        settingsError,
-        settingsMessage,
         saveSettings,
-        clearSettingsMessages,
 
         // Test connection
         testStatus,
@@ -429,9 +416,10 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         // Sources
         sources,
         loadingSources,
-        sourcesError,
-        sourcesMessage,
-        clearSourcesMessages,
+
+        // Toast
+        toast,
+        clearToast,
 
         // Source mutations
         newSource,

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -38,7 +38,7 @@ type CollectionGroup = {
 
 type CollectionSource = {
     name: string;
-    source: "plex" | "trakt" | "letterboxd" | "mdblist";
+    source: "plex" | "trakt" | "letterboxd" | "mdblist" | "anilist";
     detail?: string | null;
 };
 
@@ -47,6 +47,7 @@ type CollectionSourcesResponse = {
     trakt: CollectionSource[];
     letterboxd: CollectionSource[];
     mdblist: CollectionSource[];
+    anilist: CollectionSource[];
 };
 
 type ConfigSaveResponse = { ok: boolean; path: string; message: string; env_override: boolean };
@@ -130,7 +131,7 @@ export default function GroupDetailPage() {
         fetchWithAuth("/api/admin/config/group-sources")
             .then((r) => r.json())
             .then((data: CollectionSourcesResponse) => {
-                const combined = [...(data.plex || []), ...(data.trakt || []), ...(data.letterboxd || []), ...(data.mdblist || [])];
+                const combined = [...(data.plex || []), ...(data.trakt || []), ...(data.letterboxd || []), ...(data.mdblist || []), ...(data.anilist || [])];
                 setSources(combined);
             })
             .catch(() => {

--- a/homescreen-hero-ui/src/pages/IntegrationsPage.tsx
+++ b/homescreen-hero-ui/src/pages/IntegrationsPage.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Tab } from "@headlessui/react";
 import { TraktIntegration } from "../components/integrations/TraktIntegration";
 import { LetterboxdIntegration } from "../components/integrations/LetterboxdIntegration";
@@ -7,15 +9,31 @@ import { TautulliIntegration } from "../components/integrations/TautulliIntegrat
 import { SeerrIntegration } from "../components/integrations/SeerrIntegration";
 
 const tabs = [
-    { name: "Trakt", component: TraktIntegration },
-    { name: "Letterboxd", component: LetterboxdIntegration },
-    { name: "MDBList", component: MDBListIntegration },
-    { name: "Anime", component: AnimeIntegration },
-    { name: "Tautulli", component: TautulliIntegration },
-    { name: "Seerr", component: SeerrIntegration },
+    { name: "Trakt", key: "trakt", component: TraktIntegration },
+    { name: "Letterboxd", key: "letterboxd", component: LetterboxdIntegration },
+    { name: "MDBList", key: "mdblist", component: MDBListIntegration },
+    { name: "Anime", key: "anime", component: AnimeIntegration },
+    { name: "Tautulli", key: "tautulli", component: TautulliIntegration },
+    { name: "Seerr", key: "seerr", component: SeerrIntegration },
 ] as const;
 
 export default function IntegrationsPage() {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const selectedIndex = useMemo(() => {
+        const hash = location.hash.replace("#", "").toLowerCase();
+        const idx = tabs.findIndex((t) => t.key === hash);
+        return idx >= 0 ? idx : 0;
+    }, [location.hash]);
+
+    const handleTabChange = useCallback(
+        (index: number) => {
+            navigate(`#${tabs[index].key}`, { replace: true });
+        },
+        [navigate]
+    );
+
     return (
         <div className="flex flex-col gap-6">
             <div className="flex flex-col gap-2">
@@ -28,7 +46,7 @@ export default function IntegrationsPage() {
                 </p>
             </div>
 
-            <Tab.Group>
+            <Tab.Group selectedIndex={selectedIndex} onChange={handleTabChange}>
                 <Tab.List className="flex gap-2 overflow-x-auto pb-2 border-b border-slate-800">
                     {tabs.map((tab) => (
                         <Tab

--- a/homescreen-hero-ui/src/pages/IntegrationsPage.tsx
+++ b/homescreen-hero-ui/src/pages/IntegrationsPage.tsx
@@ -2,6 +2,7 @@ import { Tab } from "@headlessui/react";
 import { TraktIntegration } from "../components/integrations/TraktIntegration";
 import { LetterboxdIntegration } from "../components/integrations/LetterboxdIntegration";
 import { MDBListIntegration } from "../components/integrations/MDBListIntegration";
+import { AnimeIntegration } from "../components/integrations/AnimeIntegration";
 import { TautulliIntegration } from "../components/integrations/TautulliIntegration";
 import { SeerrIntegration } from "../components/integrations/SeerrIntegration";
 
@@ -9,6 +10,7 @@ const tabs = [
     { name: "Trakt", component: TraktIntegration },
     { name: "Letterboxd", component: LetterboxdIntegration },
     { name: "MDBList", component: MDBListIntegration },
+    { name: "Anime", component: AnimeIntegration },
     { name: "Tautulli", component: TautulliIntegration },
     { name: "Seerr", component: SeerrIntegration },
 ] as const;

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { fetchWithAuth } from "../utils/api";
 import { SlidersHorizontal, Check, ChevronDown, FileText, Copy, Download, Pause, Play, RefreshCw, Search, Server, CalendarSync, Ban, Archive, Upload, HardDriveDownload, HardDriveUpload, Undo2 } from "lucide-react";
 import { Switch, Listbox } from "@headlessui/react";
@@ -101,7 +101,21 @@ function IconButton({
 
 export default function SettingsPage() {
     const [searchParams, setSearchParams] = useSearchParams();
-    const [activeTab, setActiveTab] = useState<TabId>("general");
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const activeTab = useMemo<TabId>(() => {
+        const hash = location.hash.replace("#", "").toLowerCase();
+        const match = tabs.find((t) => t.id === hash);
+        return match ? match.id : "general";
+    }, [location.hash]);
+
+    const setActiveTab = useCallback(
+        (id: TabId) => {
+            navigate(`#${id}`, { replace: true });
+        },
+        [navigate]
+    );
     const [plexTestStatus, setPlexTestStatus] = useState<"idle" | "testing" | "success" | "error">("idle");
 
     // Track which section should be expanded based on URL param

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -35,7 +35,7 @@ type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR" | "ALL";
 
 type CollectionSource = {
     name: string;
-    source: "plex" | "trakt" | "letterboxd" | "mdblist";
+    source: "plex" | "trakt" | "letterboxd" | "mdblist" | "anilist";
     detail?: string | null;
 };
 
@@ -44,6 +44,7 @@ type CollectionSourcesResponse = {
     trakt: CollectionSource[];
     letterboxd: CollectionSource[];
     mdblist: CollectionSource[];
+    anilist: CollectionSource[];
 };
 
 function guessLevel(line: string): Exclude<LogLevel, "ALL"> | null {
@@ -127,7 +128,7 @@ export default function SettingsPage() {
     const [intervalInput, setIntervalInput] = useState("12");
     const [maxCollectionsInput, setMaxCollectionsInput] = useState("5");
     const [blacklistSearch, setBlacklistSearch] = useState("");
-    const [blacklistSourceFilter, setBlacklistSourceFilter] = useState<"all" | "plex" | "trakt" | "letterboxd" | "mdblist">("all");
+    const [blacklistSourceFilter, setBlacklistSourceFilter] = useState<"all" | "plex" | "trakt" | "letterboxd" | "mdblist" | "anilist">("all");
     const [blacklistPage, setBlacklistPage] = useState(1);
     const [collectionSources, setCollectionSources] = useState<CollectionSource[]>([]);
     const blacklistItemsPerPage = 20;
@@ -245,6 +246,7 @@ export default function SettingsPage() {
                     ...(data.trakt || []),
                     ...(data.letterboxd || []),
                     ...(data.mdblist || []),
+                    ...(data.anilist || []),
                 ];
                 setCollectionSources(combined);
             })
@@ -1099,7 +1101,7 @@ export default function SettingsPage() {
                                 />
                             </div>
                             <div className="flex gap-2 flex-wrap">
-                                {(["all", "plex", "trakt", "letterboxd", "mdblist"] as const).map((filter) => (
+                                {(["all", "plex", "trakt", "letterboxd", "mdblist", "anilist"] as const).map((filter) => (
                                     <button
                                         key={filter}
                                         type="button"
@@ -1121,12 +1123,14 @@ export default function SettingsPage() {
                                                               ? "#8b2e82"
                                                               : filter === "letterboxd"
                                                               ? "#00a63d"
+                                                              : filter === "anilist"
+                                                              ? "#2b7de9"
                                                               : "#4284c9",
                                                   }
                                                 : undefined
                                         }
                                     >
-                                        {filter.charAt(0).toUpperCase() + filter.slice(1)}
+                                        {filter === "anilist" ? "AniList" : filter.charAt(0).toUpperCase() + filter.slice(1)}
                                     </button>
                                 ))}
                             </div>

--- a/homescreen-hero-ui/src/types/integrations.ts
+++ b/homescreen-hero-ui/src/types/integrations.ts
@@ -52,6 +52,16 @@ export interface MDBListMissingItem extends BaseMissingItem {
     mdblist_id: string | null;
 }
 
+// AniList-specific missing item
+export interface AniListMissingItem extends BaseMissingItem {
+    media_format: string | null;
+    anilist_id: number | null;
+    mal_id: number | null;
+    tmdb_id: number | null;
+    imdb_id: string | null;
+    tvdb_id: number | null;
+}
+
 // Settings types
 export interface TraktSettings {
     enabled: boolean;

--- a/homescreen-hero-ui/src/types/integrations.ts
+++ b/homescreen-hero-ui/src/types/integrations.ts
@@ -8,6 +8,7 @@ export interface Source {
     name: string;
     url: string;
     plex_library: string;
+    max_items?: number;
 }
 
 // Generic source status (identical for all list-based integrations)

--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -221,13 +221,17 @@ def _validate_collection_references(config: AppConfig) -> None:
         for source in config.mdblist.sources:
             integration_collections.add(source.name)
 
+    if config.anilist and config.anilist.sources:
+        for source in config.anilist.sources:
+            integration_collections.add(source.name)
+
     # Check each group for collections that don't have integration sources
     for group in config.groups:
         for collection_name in group.collections:
             if collection_name not in integration_collections:
                 logger.debug(
                     f"Collection '{collection_name}' in group '{group.name}' has no corresponding "
-                    f"Trakt/Letterboxd/MDBList source. This may be a manually created Plex collection "
+                    f"integration source. This may be a manually created Plex collection "
                     f"or an orphaned reference from a deleted integration source."
                 )
 

--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -213,7 +213,7 @@ def _validate_collection_references(config: AppConfig) -> None:
         for source in config.trakt.sources:
             integration_collections.add(source.name)
 
-    if config.letterboxd and config.letterboxd.enabled and config.letterboxd.sources:
+    if config.letterboxd and config.letterboxd.sources:
         for source in config.letterboxd.sources:
             integration_collections.add(source.name)
 

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -238,6 +238,12 @@ class AniListSource(BaseModel):
     name: str = Field(..., description="Display name for this list (becomes Plex collection name)")
     url: str = Field(..., description="AniList user list URL (e.g., https://anilist.co/user/username/animelist)")
     plex_library: str = Field(..., description="Target Plex library name")
+    max_items: Optional[int] = Field(
+        default=100,
+        ge=10,
+        le=500,
+        description="Maximum number of items to fetch for browse lists (ignored for user lists)",
+    )
 
 
 class AniListSettings(BaseModel):

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -203,10 +203,10 @@ class LetterboxdSource(BaseModel):
 
 
 class LetterboxdSettings(BaseModel):
-    # Letterboxd connection details.
+    # Letterboxd needs no credentials; enabled defaults to True.
     enabled: bool = Field(
-        default=False,
-        description="Whether Letterboxd integration is enabled",
+        default=True,
+        description="Whether Letterboxd integration is enabled (defaults to True — no credentials needed)",
     )
     sources: List[LetterboxdSource] = Field(default_factory=list)
 
@@ -232,6 +232,21 @@ class MDBListSettings(BaseModel):
         description="Base URL for MDBList API",
     )
     sources: List[MDBListSource] = Field(default_factory=list)
+
+
+class AniListSource(BaseModel):
+    name: str = Field(..., description="Display name for this list (becomes Plex collection name)")
+    url: str = Field(..., description="AniList user list URL (e.g., https://anilist.co/user/username/animelist)")
+    plex_library: str = Field(..., description="Target Plex library name")
+
+
+class AniListSettings(BaseModel):
+    # AniList needs no credentials; enabled defaults to True.
+    enabled: bool = Field(
+        default=True,
+        description="Whether AniList integration is enabled (defaults to True — no credentials needed)",
+    )
+    sources: List[AniListSource] = Field(default_factory=list)
 
 
 class TautulliSettings(BaseModel):
@@ -292,6 +307,7 @@ class AppConfig(BaseModel):
     trakt: Optional[TraktSettings] = None
     letterboxd: Optional[LetterboxdSettings] = None
     mdblist: Optional[MDBListSettings] = None
+    anilist: Optional[AniListSettings] = None
     tautulli: Optional[TautulliSettings] = None
     seerr: Optional[SeerrSettings] = None
     logging: LoggingSettings = LoggingSettings()

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -203,11 +203,7 @@ class LetterboxdSource(BaseModel):
 
 
 class LetterboxdSettings(BaseModel):
-    # Letterboxd needs no credentials; enabled defaults to True.
-    enabled: bool = Field(
-        default=True,
-        description="Whether Letterboxd integration is enabled (defaults to True — no credentials needed)",
-    )
+    # Letterboxd needs no credentials — always enabled if sources exist.
     sources: List[LetterboxdSource] = Field(default_factory=list)
 
 
@@ -247,11 +243,7 @@ class AniListSource(BaseModel):
 
 
 class AniListSettings(BaseModel):
-    # AniList needs no credentials; enabled defaults to True.
-    enabled: bool = Field(
-        default=True,
-        description="Whether AniList integration is enabled (defaults to True — no credentials needed)",
-    )
+    # AniList needs no credentials — always enabled if sources exist.
     sources: List[AniListSource] = Field(default_factory=list)
 
 

--- a/homescreen_hero/core/db/__init__.py
+++ b/homescreen_hero/core/db/__init__.py
@@ -25,6 +25,7 @@ from .models import (
     PendingSimulation,
     PinnedCollection,
     RotationRecord,
+    SourceSyncRecord,
 )
 from .simulations import (
     create_simulation,
@@ -36,6 +37,10 @@ from .tools import (
     list_rotations,
     list_usage
     )
+from .sync_status import (
+    get_sync_status,
+    record_sync_result,
+)
 from .pinning import (
     get_display_order,
     get_pinned_collection_names,
@@ -74,6 +79,9 @@ __all__ = (
     "session_scope",
     "CollectionDisplayOrder",
     "PinnedCollection",
+    "SourceSyncRecord",
+    "get_sync_status",
+    "record_sync_result",
     "get_display_order",
     "get_pinned_collection_names",
     "get_pinned_collections",

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -238,6 +238,22 @@ class PinnedCollection(Base):
     visibility_recommended = Column(Boolean, nullable=False, default=False)
 
 
+class SourceSyncRecord(Base):
+    # Tracks the latest sync result for each integration source
+    __tablename__ = "source_sync_records"
+
+    id = Column(Integer, primary_key=True, index=True)
+    integration_type = Column(String, nullable=False, index=True)  # trakt, letterboxd, mdblist, anilist
+    source_name = Column(String, nullable=False, index=True)
+    source_url = Column(String, nullable=False)
+
+    sync_status = Column(String, nullable=False, default="never_synced")  # success, error, never_synced
+    last_sync_time = Column(DateTime, nullable=True)
+    items_total = Column(Integer, nullable=False, default=0)
+    items_matched = Column(Integer, nullable=False, default=0)
+    error_message = Column(Text, nullable=True)
+
+
 class CollectionDisplayOrder(Base):
     # Tracks the display order of active collections on the homescreen
     __tablename__ = "collection_display_order"

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -156,6 +156,43 @@ class MDBListMissingItem(Base):
     times_seen: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
 
 
+class AniListMissingItem(Base):
+    __tablename__ = "anilist_missing_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Which AniList source this came from
+    source_name: Mapped[str] = mapped_column(String, nullable=False)
+    source_url: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Where we expected to find it in Plex
+    plex_library: Mapped[str] = mapped_column(String, nullable=False)
+    plex_collection: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Media identity
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    year: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    media_format: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # AniList / MAL IDs
+    anilist_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    mal_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Mapped IDs (from anime-lists)
+    tmdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    imdb_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    tvdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Tracking
+    first_seen: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
+    last_seen: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
+    times_seen: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+
 class CollectionAnalytics(Base):
     # Analytics snapshots for collection watch statistics from Tautulli
     __tablename__ = "collection_analytics"

--- a/homescreen_hero/core/db/sync_status.py
+++ b/homescreen_hero/core/db/sync_status.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from .base import session_scope
+from .models import SourceSyncRecord
+
+
+def record_sync_result(
+    integration_type: str,
+    source_name: str,
+    source_url: str,
+    items_total: int,
+    items_matched: int,
+    sync_status: str = "success",
+    error_message: Optional[str] = None,
+) -> None:
+    # Upsert the sync result for a source (one record per integration+name)
+    with session_scope() as session:
+        record = session.query(SourceSyncRecord).filter(
+            SourceSyncRecord.integration_type == integration_type,
+            SourceSyncRecord.source_name == source_name,
+        ).first()
+
+        now = datetime.utcnow()
+
+        if record:
+            record.source_url = source_url
+            record.sync_status = sync_status
+            record.last_sync_time = now
+            record.items_total = items_total
+            record.items_matched = items_matched
+            record.error_message = error_message
+        else:
+            record = SourceSyncRecord(
+                integration_type=integration_type,
+                source_name=source_name,
+                source_url=source_url,
+                sync_status=sync_status,
+                last_sync_time=now,
+                items_total=items_total,
+                items_matched=items_matched,
+                error_message=error_message,
+            )
+            session.add(record)
+
+
+def get_sync_status(
+    integration_type: str,
+    source_name: str,
+) -> Optional[SourceSyncRecord]:
+    # Get the latest sync record for a source, or None if never synced
+    with session_scope() as session:
+        return session.query(SourceSyncRecord).filter(
+            SourceSyncRecord.integration_type == integration_type,
+            SourceSyncRecord.source_name == source_name,
+        ).first()

--- a/homescreen_hero/core/integrations/__init__.py
+++ b/homescreen_hero/core/integrations/__init__.py
@@ -3,6 +3,7 @@ from .trakt_client import get_trakt_client
 from .trakt_sync import sync_all_trakt_sources
 from .letterboxd_sync import sync_all_letterboxd_sources
 from .mdblist_sync import sync_all_mdblist_sources
+from .anilist_sync import sync_all_anilist_sources
 
 __all__ = [
     "get_plex_server",
@@ -10,5 +11,6 @@ __all__ = [
     "sync_all_trakt_sources",
     "sync_all_letterboxd_sources",
     "sync_all_mdblist_sources",
+    "sync_all_anilist_sources",
     "apply_home_screen_selection",
 ]

--- a/homescreen_hero/core/integrations/anilist_client.py
+++ b/homescreen_hero/core/integrations/anilist_client.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import unquote
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+ANILIST_GRAPHQL_URL = "https://graphql.anilist.co"
+
+# GraphQL query to fetch a user's full anime list
+USER_LIST_QUERY = """
+query ($userName: String!, $type: MediaType!) {
+  MediaListCollection(userName: $userName, type: $type) {
+    lists {
+      name
+      isCustomList
+      entries {
+        media {
+          id
+          idMal
+          type
+          format
+          title {
+            romaji
+            english
+            native
+          }
+          seasonYear
+          startDate {
+            year
+          }
+          episodes
+          synonyms
+        }
+      }
+    }
+  }
+}
+"""
+
+# Lightweight query to fetch list names only (no entries)
+USER_LISTS_QUERY = """
+query ($userName: String!, $type: MediaType!) {
+  MediaListCollection(userName: $userName, type: $type) {
+    lists {
+      name
+      isCustomList
+    }
+  }
+}
+"""
+
+# Lightweight query for health check
+PING_QUERY = """
+query {
+  Viewer {
+    id
+  }
+}
+"""
+
+# URL pattern: https://anilist.co/user/{username}/animelist or /animelist/{listname}
+_URL_PATTERN = re.compile(
+    r"https?://anilist\.co/user/([^/]+)/animelist(?:/(.+))?",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class AniListConfig:
+    base_url: str = ANILIST_GRAPHQL_URL
+
+
+@dataclass
+class AniListItem:
+    anilist_id: int
+    mal_id: Optional[int]
+    title_english: Optional[str]
+    title_romaji: Optional[str]
+    year: Optional[int]
+    media_format: Optional[str]  # TV, MOVIE, OVA, ONA, SPECIAL, etc.
+    episodes: Optional[int]
+
+
+class AniListClient:
+    def __init__(self, cfg: AniListConfig):
+        self.cfg = cfg
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        })
+
+    def ping(self) -> Tuple[bool, Optional[str]]:
+        # Test the GraphQL endpoint with a simple query
+        # The Viewer query will return null without auth, but a 200 means the API is reachable
+        try:
+            resp = self.session.post(
+                self.cfg.base_url,
+                json={"query": "{ SiteStatistics { anime { nodes { count } } } }"},
+                timeout=10,
+            )
+            if resp.status_code == 429:
+                return False, "AniList API rate limited"
+            resp.raise_for_status()
+            return True, None
+        except requests.ConnectionError:
+            return False, "Could not connect to AniList API"
+        except requests.Timeout:
+            return False, "AniList API request timed out"
+        except requests.HTTPError as exc:
+            return False, f"AniList API returned HTTP {exc.response.status_code}"
+        except Exception as exc:
+            return False, str(exc)
+
+    def get_user_lists(self, username: str) -> List[Dict[str, Any]]:
+        # Fetch just the list names for a user (no entries — fast)
+        resp = self.session.post(
+            self.cfg.base_url,
+            json={
+                "query": USER_LISTS_QUERY,
+                "variables": {"userName": username, "type": "ANIME"},
+            },
+            timeout=15,
+        )
+
+        if resp.status_code == 429:
+            raise RuntimeError("AniList API rate limited — try again later")
+        resp.raise_for_status()
+
+        data = resp.json()
+        if "errors" in data:
+            error_msg = data["errors"][0].get("message", "Unknown GraphQL error")
+            raise RuntimeError(f"AniList API error: {error_msg}")
+
+        collection = data.get("data", {}).get("MediaListCollection")
+        if not collection:
+            return []
+
+        results: List[Dict[str, Any]] = []
+        for lst in collection.get("lists") or []:
+            name = lst.get("name", "")
+            is_custom = lst.get("isCustomList", False)
+            # Default lists use lowercase in the URL; custom lists use the name as-is
+            value = name if is_custom else name.lower()
+            results.append({
+                "value": value,
+                "label": name,
+                "is_custom": is_custom,
+            })
+
+        return results
+
+    def get_user_list(
+        self,
+        username: str,
+        list_name: Optional[str] = None,
+    ) -> List[AniListItem]:
+        # Fetch a user's anime list from AniList
+        resp = self.session.post(
+            self.cfg.base_url,
+            json={
+                "query": USER_LIST_QUERY,
+                "variables": {"userName": username, "type": "ANIME"},
+            },
+            timeout=30,
+        )
+
+        if resp.status_code == 429:
+            raise RuntimeError("AniList API rate limited — try again later")
+        resp.raise_for_status()
+
+        data = resp.json()
+        if "errors" in data:
+            error_msg = data["errors"][0].get("message", "Unknown GraphQL error")
+            raise RuntimeError(f"AniList API error: {error_msg}")
+
+        collection = data.get("data", {}).get("MediaListCollection")
+        if not collection:
+            logger.warning("No anime list found for user '%s'", username)
+            return []
+
+        lists = collection.get("lists") or []
+
+        # Filter to specific list if requested (case-insensitive)
+        if list_name:
+            decoded_name = unquote(list_name).lower()
+            lists = [lst for lst in lists if (lst.get("name") or "").lower() == decoded_name]
+            if not lists:
+                logger.warning(
+                    "List '%s' not found for user '%s'. Available lists: %s",
+                    decoded_name,
+                    username,
+                    [lst.get("name") for lst in collection.get("lists", [])],
+                )
+                return []
+
+        # Flatten entries from all matching lists
+        items: List[AniListItem] = []
+        seen_ids: set[int] = set()
+
+        for lst in lists:
+            for entry in lst.get("entries") or []:
+                media = entry.get("media") or {}
+                anilist_id = media.get("id")
+                if not anilist_id or anilist_id in seen_ids:
+                    continue
+                seen_ids.add(anilist_id)
+
+                title = media.get("title") or {}
+                year = media.get("seasonYear") or (media.get("startDate") or {}).get("year")
+
+                items.append(AniListItem(
+                    anilist_id=anilist_id,
+                    mal_id=media.get("idMal"),
+                    title_english=title.get("english"),
+                    title_romaji=title.get("romaji"),
+                    year=year,
+                    media_format=media.get("format"),
+                    episodes=media.get("episodes"),
+                ))
+
+        logger.info("Fetched %d anime from AniList user '%s'", len(items), username)
+        return items
+
+
+def parse_anilist_url(url: str) -> Tuple[str, Optional[str]]:
+    # Extract username and optional list name from an AniList URL
+    # Returns (username, list_name) where list_name may be None
+    match = _URL_PATTERN.match(url.strip())
+    if not match:
+        raise ValueError(
+            f"Invalid AniList URL: {url}. "
+            "Expected format: https://anilist.co/user/username/animelist or "
+            "https://anilist.co/user/username/animelist/listname"
+        )
+    username = match.group(1)
+    list_name = match.group(2)
+    if list_name:
+        list_name = unquote(list_name)
+    return username, list_name
+
+
+def get_anilist_client(config) -> Optional[AniListClient]:
+    # Factory function: returns None if AniList is not configured
+    if not config.anilist:
+        return None
+    return AniListClient(AniListConfig())

--- a/homescreen_hero/core/integrations/anilist_client.py
+++ b/homescreen_hero/core/integrations/anilist_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import unquote
 
@@ -55,6 +56,35 @@ query ($userName: String!, $type: MediaType!) {
 }
 """
 
+# GraphQL query to browse anime by sort criteria (Trending, Popular, etc.)
+# season, seasonYear, and format_in are optional filters
+BROWSE_QUERY = """
+query ($page: Int!, $perPage: Int!, $type: MediaType!, $sort: [MediaSort]!, $isAdult: Boolean, $season: MediaSeason, $seasonYear: Int, $format_in: [MediaFormat]) {
+  Page(page: $page, perPage: $perPage) {
+    pageInfo {
+      hasNextPage
+    }
+    media(type: $type, sort: $sort, isAdult: $isAdult, season: $season, seasonYear: $seasonYear, format_in: $format_in) {
+      id
+      idMal
+      type
+      format
+      title {
+        romaji
+        english
+        native
+      }
+      seasonYear
+      startDate {
+        year
+      }
+      episodes
+      synonyms
+    }
+  }
+}
+"""
+
 # Lightweight query for health check
 PING_QUERY = """
 query {
@@ -63,6 +93,35 @@ query {
   }
 }
 """
+
+# Browse list options: each key maps to sort + optional season filter
+# "season": "current" / "next" are resolved dynamically at sync time
+BROWSE_OPTIONS: Dict[str, Dict[str, str]] = {
+    "trending":       {"sort": "TRENDING_DESC"},
+    "popular":        {"sort": "POPULARITY_DESC"},
+    "top-100":        {"sort": "SCORE_DESC"},
+    "most-favorited": {"sort": "FAVOURITES_DESC"},
+    "this-season":    {"sort": "POPULARITY_DESC", "season": "current"},
+    "next-season":    {"sort": "POPULARITY_DESC", "season": "next"},
+}
+
+# AniList anime seasons mapped to month ranges
+_SEASONS = ["WINTER", "SPRING", "SUMMER", "FALL"]  # Q1, Q2, Q3, Q4
+
+
+def _resolve_season(which: str) -> Tuple[str, int]:
+    # Returns (season_name, year) for "current" or "next"
+    now = datetime.now()
+    quarter = (now.month - 1) // 3  # 0=winter, 1=spring, 2=summer, 3=fall
+    if which == "next":
+        quarter += 1
+    year = now.year
+    if quarter > 3:
+        quarter = 0
+        year += 1
+    return _SEASONS[quarter], year
+
+_BROWSE_URL_PATTERN = re.compile(r"anilist://browse/([a-z0-9-]+)", re.IGNORECASE)
 
 # URL pattern: https://anilist.co/user/{username}/animelist or /animelist/{listname}
 _URL_PATTERN = re.compile(
@@ -227,6 +286,102 @@ class AniListClient:
 
         logger.info("Fetched %d anime from AniList user '%s'", len(items), username)
         return items
+
+    def get_browse_list(
+        self,
+        sort_key: str,
+        max_items: int = 100,
+        format_in: Optional[List[str]] = None,
+    ) -> List[AniListItem]:
+        # Fetch a curated browse list from AniList (Trending, Popular, Top Rated, etc.)
+        # format_in filters to specific media formats (e.g. ["TV", "OVA"] for show libraries)
+        opts = BROWSE_OPTIONS.get(sort_key)
+        if not opts:
+            raise ValueError(f"Unknown browse sort key: {sort_key}")
+
+        variables: Dict[str, Any] = {
+            "type": "ANIME",
+            "sort": [opts["sort"]],
+            "isAdult": False,
+        }
+
+        if format_in:
+            variables["format_in"] = format_in
+
+        # Resolve seasonal filter if present
+        season_tag = opts.get("season")
+        if season_tag:
+            season_name, season_year = _resolve_season(season_tag)
+            variables["season"] = season_name
+            variables["seasonYear"] = season_year
+
+        items: List[AniListItem] = []
+        seen_ids: set[int] = set()
+        per_page = 50
+        pages_needed = (max_items + per_page - 1) // per_page
+
+        for page_num in range(1, pages_needed + 1):
+            resp = self.session.post(
+                self.cfg.base_url,
+                json={
+                    "query": BROWSE_QUERY,
+                    "variables": {**variables, "page": page_num, "perPage": per_page},
+                },
+                timeout=30,
+            )
+
+            if resp.status_code == 429:
+                raise RuntimeError("AniList API rate limited — try again later")
+            resp.raise_for_status()
+
+            data = resp.json()
+            if "errors" in data:
+                error_msg = data["errors"][0].get("message", "Unknown GraphQL error")
+                raise RuntimeError(f"AniList API error: {error_msg}")
+
+            page_data = data.get("data", {}).get("Page", {})
+            media_list = page_data.get("media") or []
+
+            for media in media_list:
+                anilist_id = media.get("id")
+                if not anilist_id or anilist_id in seen_ids:
+                    continue
+                seen_ids.add(anilist_id)
+
+                title = media.get("title") or {}
+                year = media.get("seasonYear") or (media.get("startDate") or {}).get("year")
+
+                items.append(AniListItem(
+                    anilist_id=anilist_id,
+                    mal_id=media.get("idMal"),
+                    title_english=title.get("english"),
+                    title_romaji=title.get("romaji"),
+                    year=year,
+                    media_format=media.get("format"),
+                    episodes=media.get("episodes"),
+                ))
+
+            if not page_data.get("pageInfo", {}).get("hasNextPage", False):
+                break
+
+        items = items[:max_items]
+        logger.info("Fetched %d anime from AniList browse list '%s'", len(items), sort_key)
+        return items
+
+
+def is_browse_url(url: str) -> bool:
+    return url.strip().startswith("anilist://browse/")
+
+
+def parse_browse_url(url: str) -> str:
+    # Extract the sort key from anilist://browse/{sort_key}
+    match = _BROWSE_URL_PATTERN.match(url.strip())
+    if not match:
+        raise ValueError(f"Invalid AniList browse URL: {url}")
+    sort_key = match.group(1)
+    if sort_key not in BROWSE_OPTIONS:
+        raise ValueError(f"Unknown browse sort: {sort_key}. Valid: {list(BROWSE_OPTIONS.keys())}")
+    return sort_key
 
 
 def parse_anilist_url(url: str) -> Tuple[str, Optional[str]]:

--- a/homescreen_hero/core/integrations/anilist_sync.py
+++ b/homescreen_hero/core/integrations/anilist_sync.py
@@ -14,6 +14,7 @@ from plexapi.server import PlexServer
 
 from homescreen_hero.core.config.schema import AppConfig, AniListSource
 from homescreen_hero.core.db.models import AniListMissingItem
+from homescreen_hero.core.db.sync_status import record_sync_result
 from homescreen_hero.core.integrations.anilist_client import (
     AniListItem,
     get_anilist_client,
@@ -338,9 +339,25 @@ def sync_all_anilist_sources(
 
     for source in config.anilist.sources:
         try:
-            sync_single_anilist_source(server, config, source)
+            total, matched = sync_single_anilist_source(server, config, source)
+            record_sync_result(
+                integration_type="anilist",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=total,
+                items_matched=matched,
+            )
         except Exception as e:
             logger.error("Failed to sync AniList source '%s': %s", source.name, e, exc_info=True)
+            record_sync_result(
+                integration_type="anilist",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=0,
+                items_matched=0,
+                sync_status="error",
+                error_message=str(e),
+            )
 
 
 def record_missing_items_in_db(

--- a/homescreen_hero/core/integrations/anilist_sync.py
+++ b/homescreen_hero/core/integrations/anilist_sync.py
@@ -17,12 +17,12 @@ from homescreen_hero.core.db.models import AniListMissingItem
 from homescreen_hero.core.integrations.anilist_client import (
     AniListItem,
     get_anilist_client,
+    is_browse_url,
     parse_anilist_url,
+    parse_browse_url,
 )
 from homescreen_hero.core.integrations.plex_match import (
     build_guid_map,
-    find_movie,
-    find_show,
     normalize_title,
 )
 
@@ -99,6 +99,14 @@ def load_anime_id_map(data_dir: Optional[Path] = None) -> Dict[int, Dict[str, An
     return id_map
 
 
+def _guid_lookup(guid_map: dict, *keys: str):
+    # Try multiple GUID keys against the map, return first match
+    for key in keys:
+        if key and key in guid_map:
+            return guid_map[key]
+    return None
+
+
 def _match_item(
     item: AniListItem,
     guid_map: dict,
@@ -113,15 +121,28 @@ def _match_item(
     imdb_id = mapped.get("imdb_id")
     tvdb_id = mapped.get("tvdb_id")
 
-    # 2. Try GUID-based matching
+    # 2. Direct GUID map lookup (no title fallback — avoids false positives
+    #    from find_show/find_movie searching Plex with empty/partial titles)
     if is_movie_library:
-        plex_item = find_movie(guid_map, library, "", None, imdb_id=imdb_id, tmdb_id=tmdb_id)
-        if plex_item:
-            return plex_item
+        plex_item = _guid_lookup(
+            guid_map,
+            f"tmdb://{tmdb_id}" if tmdb_id is not None else "",
+            f"imdb://{imdb_id}" if imdb_id else "",
+            f"com.plexapp.agents.themoviedb://{tmdb_id}?lang=en" if tmdb_id is not None else "",
+            f"com.plexapp.agents.imdb://{imdb_id}?lang=en" if imdb_id else "",
+        )
     else:
-        plex_item = find_show(guid_map, library, "", None, tvdb_id=tvdb_id, tmdb_id=tmdb_id, imdb_id=imdb_id)
-        if plex_item:
-            return plex_item
+        plex_item = _guid_lookup(
+            guid_map,
+            f"tvdb://{tvdb_id}" if tvdb_id is not None else "",
+            f"tmdb://{tmdb_id}" if tmdb_id is not None else "",
+            f"imdb://{imdb_id}" if imdb_id else "",
+            f"com.plexapp.agents.thetvdb://{tvdb_id}?lang=en" if tvdb_id is not None else "",
+            f"com.plexapp.agents.themoviedb://{tmdb_id}?lang=en" if tmdb_id is not None else "",
+            f"com.plexapp.agents.imdb://{imdb_id}?lang=en" if imdb_id else "",
+        )
+    if plex_item:
+        return plex_item
 
     # 3. Fallback: title/year search
     title = item.title_english or item.title_romaji
@@ -168,13 +189,6 @@ def sync_single_anilist_source(
         logger.warning("AniList source '%s' has no plex_library set; skipping", source.name)
         return 0, 0
 
-    # Parse URL to extract username and optional list name
-    try:
-        username, list_name = parse_anilist_url(source.url)
-    except ValueError as exc:
-        logger.error("Invalid AniList URL for source '%s': %s", source.name, exc)
-        return 0, 0
-
     # Resolve the Plex library
     try:
         library = server.library.section(source.plex_library)
@@ -198,8 +212,24 @@ def sync_single_anilist_source(
     # Detect library type
     is_movie_library = library.type == "movie"
 
-    # Fetch items from AniList
-    items = client.get_user_list(username, list_name)
+    # Fetch items from AniList (browse list vs user list)
+    if is_browse_url(source.url):
+        try:
+            sort_key = parse_browse_url(source.url)
+        except ValueError as exc:
+            logger.error("Invalid AniList browse URL for source '%s': %s", source.name, exc)
+            return 0, 0
+        # Pre-filter by format at the API level so we get a full page of the right type
+        format_filter = list(MOVIE_FORMATS) if is_movie_library else list(SHOW_FORMATS)
+        max_items = source.max_items or 100
+        items = client.get_browse_list(sort_key, max_items=max_items, format_in=format_filter)
+    else:
+        try:
+            username, list_name = parse_anilist_url(source.url)
+        except ValueError as exc:
+            logger.error("Invalid AniList URL for source '%s': %s", source.name, exc)
+            return 0, 0
+        items = client.get_user_list(username, list_name)
 
     # Filter items by format based on library type
     if is_movie_library:

--- a/homescreen_hero/core/integrations/anilist_sync.py
+++ b/homescreen_hero/core/integrations/anilist_sync.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+from plexapi.exceptions import NotFound
+from plexapi.server import PlexServer
+
+from homescreen_hero.core.config.schema import AppConfig, AniListSource
+from homescreen_hero.core.db.models import AniListMissingItem
+from homescreen_hero.core.integrations.anilist_client import (
+    AniListItem,
+    get_anilist_client,
+    parse_anilist_url,
+)
+from homescreen_hero.core.integrations.plex_match import (
+    build_guid_map,
+    find_movie,
+    find_show,
+    normalize_title,
+)
+
+logger = logging.getLogger(__name__)
+
+ANIME_LIST_URL = (
+    "https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-full.json"
+)
+ANIME_LIST_CACHE_FILE = "anime-list-full.json"
+ANIME_LIST_MAX_AGE_SECONDS = 86400  # 24 hours
+
+# AniList formats that map to Plex show libraries
+SHOW_FORMATS = {"TV", "TV_SHORT", "OVA", "ONA", "SPECIAL"}
+MOVIE_FORMATS = {"MOVIE"}
+
+
+def _get_data_dir() -> Path:
+    # Resolve the data directory for caching files
+    data_dir = Path(os.getenv("HSH_DATA_DIR", "data"))
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir
+
+
+def load_anime_id_map(data_dir: Optional[Path] = None) -> Dict[int, Dict[str, Any]]:
+    # Download (or load from cache) the anime-lists mapping file
+    # Returns {anilist_id: {tmdb_id, imdb_id, tvdb_id, type}}
+    if data_dir is None:
+        data_dir = _get_data_dir()
+
+    cache_path = data_dir / ANIME_LIST_CACHE_FILE
+    needs_download = True
+
+    if cache_path.exists():
+        age = time.time() - cache_path.stat().st_mtime
+        if age < ANIME_LIST_MAX_AGE_SECONDS:
+            needs_download = False
+
+    if needs_download:
+        logger.info("Downloading anime-lists mapping from GitHub...")
+        try:
+            resp = requests.get(ANIME_LIST_URL, timeout=60)
+            resp.raise_for_status()
+            cache_path.write_bytes(resp.content)
+            logger.info("Anime-lists mapping downloaded and cached (%d bytes)", len(resp.content))
+        except Exception as exc:
+            if cache_path.exists():
+                logger.warning(
+                    "Failed to refresh anime-lists mapping: %s. Using cached version.", exc
+                )
+            else:
+                logger.error("Failed to download anime-lists mapping: %s", exc)
+                return {}
+
+    try:
+        raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.error("Failed to parse anime-lists JSON: %s", exc)
+        return {}
+
+    # Build lookup by anilist_id
+    id_map: Dict[int, Dict[str, Any]] = {}
+    for entry in raw:
+        anilist_id = entry.get("anilist_id")
+        if anilist_id is None:
+            continue
+        id_map[anilist_id] = {
+            "tmdb_id": entry.get("themoviedb_id"),
+            "imdb_id": entry.get("imdb_id"),
+            "tvdb_id": entry.get("tvdb_id"),
+            "type": entry.get("type"),
+        }
+
+    logger.info("Loaded anime-lists mapping: %d entries indexed by AniList ID", len(id_map))
+    return id_map
+
+
+def _match_item(
+    item: AniListItem,
+    guid_map: dict,
+    library,
+    anime_id_map: Dict[int, Dict[str, Any]],
+    is_movie_library: bool,
+):
+    # Try to find a Plex item matching an AniList entry
+    # 1. Look up mapped IDs from anime-lists
+    mapped = anime_id_map.get(item.anilist_id, {})
+    tmdb_id = mapped.get("tmdb_id")
+    imdb_id = mapped.get("imdb_id")
+    tvdb_id = mapped.get("tvdb_id")
+
+    # 2. Try GUID-based matching
+    if is_movie_library:
+        plex_item = find_movie(guid_map, library, "", None, imdb_id=imdb_id, tmdb_id=tmdb_id)
+        if plex_item:
+            return plex_item
+    else:
+        plex_item = find_show(guid_map, library, "", None, tvdb_id=tvdb_id, tmdb_id=tmdb_id, imdb_id=imdb_id)
+        if plex_item:
+            return plex_item
+
+    # 3. Fallback: title/year search
+    title = item.title_english or item.title_romaji
+    if not title:
+        return None
+
+    normalized = normalize_title(title)
+    search_title = normalized if normalized != title else title
+
+    if item.year:
+        results = library.search(title=search_title, year=item.year)
+    else:
+        results = library.search(title=search_title)
+
+    if results:
+        return results[0]
+
+    # Try romaji title if English title didn't match
+    if item.title_romaji and item.title_english and item.title_romaji != title:
+        romaji = item.title_romaji
+        if item.year:
+            results = library.search(title=romaji, year=item.year)
+        else:
+            results = library.search(title=romaji)
+        if results:
+            return results[0]
+
+    return None
+
+
+def sync_single_anilist_source(
+    server: PlexServer,
+    config: AppConfig,
+    source: AniListSource,
+) -> Tuple[int, int]:
+    # Returns (total_items, matched_items)
+    # AniList needs no credentials, so create the client directly
+    from homescreen_hero.core.integrations.anilist_client import AniListClient, AniListConfig
+    client = AniListClient(AniListConfig())
+
+    logger.info("Syncing AniList source '%s' from %s", source.name, source.url)
+
+    if not source.plex_library:
+        logger.warning("AniList source '%s' has no plex_library set; skipping", source.name)
+        return 0, 0
+
+    # Parse URL to extract username and optional list name
+    try:
+        username, list_name = parse_anilist_url(source.url)
+    except ValueError as exc:
+        logger.error("Invalid AniList URL for source '%s': %s", source.name, exc)
+        return 0, 0
+
+    # Resolve the Plex library
+    try:
+        library = server.library.section(source.plex_library)
+    except NotFound:
+        try:
+            available = ", ".join(sec.title for sec in server.library.sections())
+        except Exception:
+            available = "unknown (failed to list libraries)"
+        logger.error(
+            "AniList source '%s' references unknown Plex library '%s'. Available: %s. Skipping.",
+            source.name, source.plex_library, available,
+        )
+        return 0, 0
+    except Exception as exc:
+        logger.error(
+            "Unexpected error looking up Plex library '%s' for AniList source '%s': %s. Skipping.",
+            source.plex_library, source.name, exc,
+        )
+        return 0, 0
+
+    # Detect library type
+    is_movie_library = library.type == "movie"
+
+    # Fetch items from AniList
+    items = client.get_user_list(username, list_name)
+
+    # Filter items by format based on library type
+    if is_movie_library:
+        filtered_items = [i for i in items if i.media_format in MOVIE_FORMATS]
+    else:
+        filtered_items = [i for i in items if i.media_format in SHOW_FORMATS]
+
+    if not filtered_items:
+        logger.info(
+            "AniList source '%s': no %s items found (had %d total items)",
+            source.name,
+            "movie" if is_movie_library else "show",
+            len(items),
+        )
+        return len(items), 0
+
+    # Load anime-lists ID mapping
+    anime_id_map = load_anime_id_map()
+
+    # Build Plex GUID map
+    logger.info("Building Plex library GUID index for '%s'...", source.plex_library)
+    guid_map = build_guid_map(library)
+
+    # Get existing collection items for diff
+    existing_collection_items = []
+    try:
+        existing_collection_items = library.collection(source.name).items()
+    except Exception:
+        existing_collection_items = []
+
+    existing_ids = {item.ratingKey for item in existing_collection_items}
+
+    matched_items = []
+    missing_items: List[Dict[str, Any]] = []
+
+    for item in filtered_items:
+        plex_item = _match_item(item, guid_map, library, anime_id_map, is_movie_library)
+
+        if plex_item is not None:
+            matched_items.append(plex_item)
+        else:
+            mapped = anime_id_map.get(item.anilist_id, {})
+            missing_items.append({
+                "title": item.title_english or item.title_romaji or "Unknown",
+                "year": item.year,
+                "anilist_id": item.anilist_id,
+                "mal_id": item.mal_id,
+                "media_format": item.media_format,
+                "tmdb_id": mapped.get("tmdb_id"),
+                "imdb_id": mapped.get("imdb_id"),
+                "tvdb_id": mapped.get("tvdb_id"),
+            })
+
+    # Add matched items to the collection
+    for plex_item in matched_items:
+        plex_item.addCollection(source.name)
+
+    # Only remove items if we successfully fetched from AniList
+    if items:
+        new_keys = {item.ratingKey for item in matched_items}
+        to_remove_keys = existing_ids - new_keys
+
+        for old_item in existing_collection_items:
+            if old_item.ratingKey in to_remove_keys:
+                try:
+                    old_item.removeCollection(source.name)
+                except Exception:
+                    logger.warning(
+                        "Failed to remove %s from collection %s",
+                        old_item.title, source.name,
+                    )
+    else:
+        logger.warning(
+            "AniList source '%s' returned no items — skipping removal to prevent data loss.",
+            source.name,
+        )
+
+    total = len(filtered_items)
+    matched = len(matched_items)
+    missing = len(missing_items)
+
+    logger.info(
+        "AniList source '%s': total %d (%s), matched %d, missing %d",
+        source.name, total, "movies" if is_movie_library else "shows", matched, missing,
+    )
+
+    if missing_items:
+        for m in missing_items:
+            logger.debug(
+                "AniList missing in Plex: %s (%s) anilist_id=%s",
+                m.get("title"), m.get("year"), m.get("anilist_id"),
+            )
+
+    record_missing_items_in_db(source, missing_items)
+
+    return total, matched
+
+
+def sync_all_anilist_sources(
+    server: PlexServer,
+    config: AppConfig,
+) -> None:
+    if not config.anilist or not config.anilist.sources:
+        logger.info("No AniList sources configured; skipping AniList sync")
+        return
+
+    for source in config.anilist.sources:
+        try:
+            sync_single_anilist_source(server, config, source)
+        except Exception as e:
+            logger.error("Failed to sync AniList source '%s': %s", source.name, e, exc_info=True)
+
+
+def record_missing_items_in_db(
+    source: AniListSource,
+    missing_items: List[Dict[str, Any]],
+) -> None:
+    if not missing_items:
+        return
+
+    from homescreen_hero.core.db import get_session
+
+    with get_session() as session:
+        for m in missing_items:
+            anilist_id = m.get("anilist_id")
+            title = m.get("title")
+            year = m.get("year")
+
+            existing = session.query(AniListMissingItem).filter(
+                AniListMissingItem.source_name == source.name,
+                AniListMissingItem.source_url == source.url,
+                AniListMissingItem.title == title,
+                AniListMissingItem.year == year,
+                AniListMissingItem.anilist_id == anilist_id,
+            ).first()
+
+            if existing:
+                existing.last_seen = datetime.utcnow()
+                existing.times_seen += 1
+            else:
+                row = AniListMissingItem(
+                    source_name=source.name,
+                    source_url=source.url,
+                    plex_library=source.plex_library,
+                    plex_collection=source.name,
+                    title=title,
+                    year=year,
+                    media_format=m.get("media_format"),
+                    anilist_id=anilist_id,
+                    mal_id=m.get("mal_id"),
+                    tmdb_id=m.get("tmdb_id"),
+                    imdb_id=m.get("imdb_id"),
+                    tvdb_id=m.get("tvdb_id"),
+                    first_seen=datetime.utcnow(),
+                    last_seen=datetime.utcnow(),
+                    times_seen=1,
+                )
+                session.add(row)
+
+        session.commit()

--- a/homescreen_hero/core/integrations/letterboxd_sync.py
+++ b/homescreen_hero/core/integrations/letterboxd_sync.py
@@ -15,6 +15,7 @@ import logging
 from plexapi.server import PlexServer
 from plexapi.exceptions import NotFound
 from homescreen_hero.core.db.models import LetterboxdMissingItem
+from homescreen_hero.core.db.sync_status import record_sync_result
 from homescreen_hero.core.config.schema import AppConfig, LetterboxdSource
 from homescreen_hero.core.integrations.letterboxd_scraper import get_letterboxd_scraper
 
@@ -221,7 +222,14 @@ def sync_all_letterboxd_sources(
 
     for source in config.letterboxd.sources:
         try:
-            sync_single_letterboxd_source(server, config, source)
+            total, matched = sync_single_letterboxd_source(server, config, source)
+            record_sync_result(
+                integration_type="letterboxd",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=total,
+                items_matched=matched,
+            )
         except Exception as exc:
             logger.error(
                 "Error syncing Letterboxd source '%s' (%s): %s",
@@ -229,6 +237,15 @@ def sync_all_letterboxd_sources(
                 source.url,
                 exc,
                 exc_info=True,
+            )
+            record_sync_result(
+                integration_type="letterboxd",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=0,
+                items_matched=0,
+                sync_status="error",
+                error_message=str(exc),
             )
 
     logger.info("Letterboxd sync complete")

--- a/homescreen_hero/core/integrations/letterboxd_sync.py
+++ b/homescreen_hero/core/integrations/letterboxd_sync.py
@@ -213,11 +213,7 @@ def sync_all_letterboxd_sources(
         server: PlexServer instance
         config: Application configuration
     """
-    if not config.letterboxd or not config.letterboxd.enabled:
-        logger.info("Letterboxd disabled or not configured; skipping Letterboxd sync")
-        return
-
-    if not config.letterboxd.sources:
+    if not config.letterboxd or not config.letterboxd.sources:
         logger.info("No Letterboxd sources configured; skipping Letterboxd sync")
         return
 

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -8,6 +8,7 @@ import logging
 from plexapi.server import PlexServer
 from plexapi.exceptions import NotFound
 from homescreen_hero.core.db.models import MDBListMissingItem
+from homescreen_hero.core.db.sync_status import record_sync_result
 from homescreen_hero.core.config.schema import AppConfig, MDBListSource
 from homescreen_hero.core.integrations.mdblist_client import get_mdblist_client
 from homescreen_hero.core.integrations.plex_match import build_guid_map, find_movie
@@ -188,7 +189,26 @@ def sync_all_mdblist_sources(
         return
 
     for source in config.mdblist.sources:
-        sync_single_mdblist_source(server, config, source)
+        try:
+            total, matched = sync_single_mdblist_source(server, config, source)
+            record_sync_result(
+                integration_type="mdblist",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=total,
+                items_matched=matched,
+            )
+        except Exception as e:
+            logger.error("Failed to sync MDBList source '%s': %s", source.name, e, exc_info=True)
+            record_sync_result(
+                integration_type="mdblist",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=0,
+                items_matched=0,
+                sync_status="error",
+                error_message=str(e),
+            )
 
 
 def record_missing_items_in_db(

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -79,9 +79,15 @@ def get_configured_collection_names(config: AppConfig) -> Set[str]:
         for source in config.mdblist.sources:
             names.add(source.name)
 
+    # Add collections from AniList sources
+    if config.anilist and config.anilist.sources:
+        for source in config.anilist.sources:
+            names.add(source.name)
+
     return names
 
 
+# Currently unused — auto-delete functionality is disabled in service.py
 def cleanup_deleted_integration_sources(
     server: PlexServer,
     config: AppConfig,
@@ -89,7 +95,7 @@ def cleanup_deleted_integration_sources(
     auto_update_config: bool = True,
 ) -> Dict[str, List[str]]:
     """
-    Automatically detect and clean up collections that have been removed from config.
+    This is deletion territory, so gonna try an detail exactly whats going on:
 
     This function:
     1. Identifies collections that were previously rotated but are no longer in:
@@ -131,6 +137,10 @@ def cleanup_deleted_integration_sources(
 
     if config.mdblist and config.mdblist.enabled and config.mdblist.sources:
         for source in config.mdblist.sources:
+            current_integration_sources.add(source.name)
+
+    if config.anilist and config.anilist.sources:
+        for source in config.anilist.sources:
             current_integration_sources.add(source.name)
 
     # Get previously rotated collections from history

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -70,7 +70,7 @@ def get_configured_collection_names(config: AppConfig) -> Set[str]:
             names.add(source.name)
 
     # Add collections from Letterboxd sources
-    if config.letterboxd and config.letterboxd.enabled and config.letterboxd.sources:
+    if config.letterboxd and config.letterboxd.sources:
         for source in config.letterboxd.sources:
             names.add(source.name)
 
@@ -125,7 +125,7 @@ def cleanup_deleted_integration_sources(
         for source in config.trakt.sources:
             current_integration_sources.add(source.name)
 
-    if config.letterboxd and config.letterboxd.enabled and config.letterboxd.sources:
+    if config.letterboxd and config.letterboxd.sources:
         for source in config.letterboxd.sources:
             current_integration_sources.add(source.name)
 

--- a/homescreen_hero/core/integrations/plex_match.py
+++ b/homescreen_hero/core/integrations/plex_match.py
@@ -77,3 +77,60 @@ def find_movie(guid_map, library, title, year, imdb_id=None, tmdb_id=None):
             return results[0]
 
     return None
+
+
+def find_show(guid_map, library, title, year, tvdb_id=None, tmdb_id=None, imdb_id=None):
+    # Match a show against the Plex library using GUID map first, then title/year fallback
+
+    if tvdb_id is not None:
+        item = guid_map.get(f"tvdb://{tvdb_id}")
+        if item:
+            return item
+
+    if tmdb_id is not None:
+        item = guid_map.get(f"tmdb://{tmdb_id}")
+        if item:
+            return item
+
+    if imdb_id:
+        item = guid_map.get(f"imdb://{imdb_id}")
+        if item:
+            return item
+
+    # Legacy agent formats
+    if tvdb_id is not None:
+        item = guid_map.get(f"com.plexapp.agents.thetvdb://{tvdb_id}?lang=en")
+        if item:
+            return item
+
+    if tmdb_id is not None:
+        item = guid_map.get(f"com.plexapp.agents.themoviedb://{tmdb_id}?lang=en")
+        if item:
+            return item
+
+    if imdb_id:
+        item = guid_map.get(f"com.plexapp.agents.imdb://{imdb_id}?lang=en")
+        if item:
+            return item
+
+    # Fallback: title/year search with normalized title
+    normalized = normalize_title(title)
+    search_title = normalized if normalized != title else title
+
+    if year:
+        results = library.search(title=search_title, year=year)
+    else:
+        results = library.search(title=search_title)
+
+    if results:
+        return results[0]
+
+    if normalized != title:
+        if year:
+            results = library.search(title=title, year=year)
+        else:
+            results = library.search(title=title)
+        if results:
+            return results[0]
+
+    return None

--- a/homescreen_hero/core/integrations/trakt_sync.py
+++ b/homescreen_hero/core/integrations/trakt_sync.py
@@ -8,6 +8,7 @@ import logging
 from plexapi.server import PlexServer
 from plexapi.exceptions import NotFound
 from homescreen_hero.core.db.models import TraktMissingItem
+from homescreen_hero.core.db.sync_status import record_sync_result
 from homescreen_hero.core.config.schema import AppConfig, TraktSource
 from homescreen_hero.core.integrations.trakt_client import get_trakt_client
 from homescreen_hero.core.integrations.plex_match import build_guid_map, find_movie
@@ -181,9 +182,25 @@ def sync_all_trakt_sources(
 
     for source in config.trakt.sources:
         try:
-            sync_single_trakt_source(server, config, source)
+            total, matched = sync_single_trakt_source(server, config, source)
+            record_sync_result(
+                integration_type="trakt",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=total,
+                items_matched=matched,
+            )
         except Exception as e:
             logger.error("Failed to sync Trakt source '%s': %s", source.name, e, exc_info=True)
+            record_sync_result(
+                integration_type="trakt",
+                source_name=source.name,
+                source_url=source.url,
+                items_total=0,
+                items_matched=0,
+                sync_status="error",
+                error_message=str(e),
+            )
 
 
 def record_missing_items_in_db(

--- a/homescreen_hero/core/logging_config.py
+++ b/homescreen_hero/core/logging_config.py
@@ -65,6 +65,10 @@ def setup_logging(level: int | str = logging.INFO, reconfigure: bool = False) ->
     for handler in root.handlers:
         handler.setLevel(level)
 
+    # Keep noisy third-party loggers at WARNING even when log level is set to DEBUG
+    for noisy in ("urllib3", "httpcore", "httpx"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
     logging.captureWarnings(True)
     root.debug(
         "Logging configured (level=%s, handlers=%d, log_file=%s)",

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -119,6 +119,7 @@ def _sync_selected_collections(
     from .integrations.letterboxd_sync import sync_single_letterboxd_source
     from .integrations.mdblist_sync import sync_single_mdblist_source
     from .integrations.anilist_sync import sync_single_anilist_source
+    from .db import record_sync_result
 
     # Build a map of collection name -> source for quick lookup
     trakt_sources = {}
@@ -142,20 +143,42 @@ def _sync_selected_collections(
         for source in config.anilist.sources:
             anilist_sources[source.name] = source
 
+    def _sync_and_record(integration_type: str, source, sync_fn):
+        try:
+            total, matched = sync_fn(server, config, source)
+            record_sync_result(
+                integration_type=integration_type,
+                source_name=source.name,
+                source_url=source.url,
+                items_total=total,
+                items_matched=matched,
+            )
+        except Exception as exc:
+            logger.error(f"Error syncing {integration_type} source '{source.name}': {exc}")
+            record_sync_result(
+                integration_type=integration_type,
+                source_name=source.name,
+                source_url=source.url,
+                items_total=0,
+                items_matched=0,
+                sync_status="error",
+                error_message=str(exc),
+            )
+
     # Sync only the selected collections
     for collection_name in selected_collections:
         if collection_name in trakt_sources:
             logger.info(f"Syncing selected Trakt collection: {collection_name}")
-            sync_single_trakt_source(server, config, trakt_sources[collection_name])
+            _sync_and_record("trakt", trakt_sources[collection_name], sync_single_trakt_source)
         elif collection_name in letterboxd_sources:
             logger.info(f"Syncing selected Letterboxd collection: {collection_name}")
-            sync_single_letterboxd_source(server, config, letterboxd_sources[collection_name])
+            _sync_and_record("letterboxd", letterboxd_sources[collection_name], sync_single_letterboxd_source)
         elif collection_name in mdblist_sources:
             logger.info(f"Syncing selected MDBList collection: {collection_name}")
-            sync_single_mdblist_source(server, config, mdblist_sources[collection_name])
+            _sync_and_record("mdblist", mdblist_sources[collection_name], sync_single_mdblist_source)
         elif collection_name in anilist_sources:
             logger.info(f"Syncing selected AniList collection: {collection_name}")
-            sync_single_anilist_source(server, config, anilist_sources[collection_name])
+            _sync_and_record("anilist", anilist_sources[collection_name], sync_single_anilist_source)
         else:
             logger.debug(f"Collection '{collection_name}' is not a synced source, skipping sync")
 

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -10,6 +10,7 @@ from .integrations import (
     sync_all_trakt_sources,
     sync_all_letterboxd_sources,
     sync_all_mdblist_sources,
+    sync_all_anilist_sources,
     apply_home_screen_selection,
 )
 from .integrations.plex_client import get_library_collections
@@ -117,23 +118,29 @@ def _sync_selected_collections(
     from .integrations.trakt_sync import sync_single_trakt_source
     from .integrations.letterboxd_sync import sync_single_letterboxd_source
     from .integrations.mdblist_sync import sync_single_mdblist_source
+    from .integrations.anilist_sync import sync_single_anilist_source
 
     # Build a map of collection name -> source for quick lookup
     trakt_sources = {}
     letterboxd_sources = {}
     mdblist_sources = {}
+    anilist_sources = {}
 
     if config.trakt and config.trakt.enabled:
         for source in config.trakt.sources:
             trakt_sources[source.name] = source
 
-    if config.letterboxd and config.letterboxd.enabled:
+    if config.letterboxd and config.letterboxd.sources:
         for source in config.letterboxd.sources:
             letterboxd_sources[source.name] = source
 
     if config.mdblist and config.mdblist.enabled:
         for source in config.mdblist.sources:
             mdblist_sources[source.name] = source
+
+    if config.anilist and config.anilist.sources:
+        for source in config.anilist.sources:
+            anilist_sources[source.name] = source
 
     # Sync only the selected collections
     for collection_name in selected_collections:
@@ -146,8 +153,11 @@ def _sync_selected_collections(
         elif collection_name in mdblist_sources:
             logger.info(f"Syncing selected MDBList collection: {collection_name}")
             sync_single_mdblist_source(server, config, mdblist_sources[collection_name])
+        elif collection_name in anilist_sources:
+            logger.info(f"Syncing selected AniList collection: {collection_name}")
+            sync_single_anilist_source(server, config, anilist_sources[collection_name])
         else:
-            logger.debug(f"Collection '{collection_name}' is not a Trakt, Letterboxd, or MDBList source, skipping sync")
+            logger.debug(f"Collection '{collection_name}' is not a synced source, skipping sync")
 
 
 def run_rotation_once(
@@ -187,7 +197,7 @@ def run_rotation_once(
     if config.rotation.sync_all_on_rotation:
         # Sync all Trakt, Letterboxd, and MDBList sources
         # Errors are non-fatal: if sync fails, rotation continues with existing Plex collections
-        logger.info("Syncing all Trakt, Letterboxd, and MDBList sources")
+        logger.info("Syncing all integration sources")
         try:
             sync_all_trakt_sources(server, config)
         except Exception as e:
@@ -200,6 +210,10 @@ def run_rotation_once(
             sync_all_mdblist_sources(server, config)
         except Exception as e:
             logger.error("MDBList sync failed, continuing with rotation: %s", e)
+        try:
+            sync_all_anilist_sources(server, config)
+        except Exception as e:
+            logger.error("AniList sync failed, continuing with rotation: %s", e)
     else:
         # First, select collections to determine which ones need syncing
         logger.info("Selective sync mode: will only sync collections selected for rotation")
@@ -394,6 +408,7 @@ def sync_all_sources(config: Optional[AppConfig] = None) -> Dict[str, int]:
     sync_all_trakt_sources(server, config)
     sync_all_letterboxd_sources(server, config)
     sync_all_mdblist_sources(server, config)
+    sync_all_anilist_sources(server, config)
 
     logger.info("Manual sync complete")
 

--- a/homescreen_hero/web/routers/config/groups.py
+++ b/homescreen_hero/web/routers/config/groups.py
@@ -16,6 +16,7 @@ from homescreen_hero.core.config.schema import (
     TraktSettings,
     LetterboxdSettings,
     MDBListSettings,
+    AniListSettings,
 )
 from homescreen_hero.core.integrations.plex_client import get_plex_server
 
@@ -244,9 +245,21 @@ def list_group_sources(current_user: str = Depends(get_current_user)) -> Collect
                     )
                 )
 
+        anilist_sources: list[CollectionSourcesResponse.CollectionSource] = []
+        anilist_cfg: Optional[AniListSettings] = getattr(config, "anilist", None)
+        if anilist_cfg and getattr(anilist_cfg, "sources", None):
+            for src in anilist_cfg.sources:
+                anilist_sources.append(
+                    CollectionSourcesResponse.CollectionSource(
+                        name=src.name,
+                        source="anilist",
+                        detail=src.plex_library or src.url,
+                    )
+                )
+
         # Plex collections created by third-party sync duplicate those sources.
         # Filter them out so the UI only shows the authoritative source.
-        third_party_names = {s.name for s in trakt_sources + letterboxd_sources + mdblist_sources}
+        third_party_names = {s.name for s in trakt_sources + letterboxd_sources + mdblist_sources + anilist_sources}
         plex_sources = [s for s in plex_sources if s.name not in third_party_names]
 
         return CollectionSourcesResponse(
@@ -254,6 +267,7 @@ def list_group_sources(current_user: str = Depends(get_current_user)) -> Collect
             trakt=trakt_sources,
             letterboxd=letterboxd_sources,
             mdblist=mdblist_sources,
+            anilist=anilist_sources,
         )
     except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/homescreen_hero/web/routers/config/helpers.py
+++ b/homescreen_hero/web/routers/config/helpers.py
@@ -69,3 +69,16 @@ def load_mdblist_sources(data: dict) -> list[dict]:
         raise ValueError("config.mdblist.sources must be a list")
 
     return list(sources or [])
+
+
+def load_anilist_sources(data: dict) -> list[dict]:
+    # Extract the list of AniList sources from config mapping
+    anilist_section = data.get("anilist")
+    if anilist_section and not isinstance(anilist_section, dict):
+        raise ValueError("config.anilist must be a mapping if present")
+
+    sources = anilist_section.get("sources") if isinstance(anilist_section, dict) else []
+    if sources and not isinstance(sources, list):
+        raise ValueError("config.anilist.sources must be a list")
+
+    return list(sources or [])

--- a/homescreen_hero/web/routers/config/helpers.py
+++ b/homescreen_hero/web/routers/config/helpers.py
@@ -82,3 +82,19 @@ def load_anilist_sources(data: dict) -> list[dict]:
         raise ValueError("config.anilist.sources must be a list")
 
     return list(sources or [])
+
+
+def get_all_source_names(data: dict) -> set[str]:
+    # Collect all source names across integrations (used for duplicate validation)
+    names: set[str] = set()
+    for section_key in ("trakt", "letterboxd", "mdblist", "anilist"):
+        section = data.get(section_key)
+        if not isinstance(section, dict):
+            continue
+        sources = section.get("sources") or []
+        if not isinstance(sources, list):
+            continue
+        for s in sources:
+            if isinstance(s, dict) and s.get("name"):
+                names.add(s["name"])
+    return names

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -14,6 +14,8 @@ from homescreen_hero.core.config.schema import (
     LetterboxdSource,
     MDBListSettings,
     MDBListSource,
+    AniListSettings,
+    AniListSource,
     TautulliSettings,
     SeerrSettings,
     CollectionGroupConfig,
@@ -79,6 +81,16 @@ class MDBListSourcePayload(MDBListSource):
     pass
 
 
+# Incoming payload for AniList settings updates.
+class AniListConfigSaveRequest(AniListSettings):
+    pass
+
+
+# Incoming payload for AniList source create/update operations.
+class AniListSourcePayload(AniListSource):
+    pass
+
+
 # Incoming payload for Tautulli settings updates.
 class TautulliConfigSaveRequest(TautulliSettings):
     pass
@@ -112,13 +124,14 @@ class GroupReorderRequest(BaseModel):
 class CollectionSourcesResponse(BaseModel):
     class CollectionSource(BaseModel):
         name: str
-        source: Literal["plex", "trakt", "letterboxd", "mdblist"]
+        source: Literal["plex", "trakt", "letterboxd", "mdblist", "anilist"]
         detail: Optional[str] = None
 
     plex: List[CollectionSource]
     trakt: List[CollectionSource]
     letterboxd: List[CollectionSource]
     mdblist: List[CollectionSource]
+    anilist: List[CollectionSource]
 
 
 # Status information for a Trakt source including sync history.
@@ -216,6 +229,42 @@ class MDBListMissingItemOut(BaseModel):
     tmdb_id: Optional[int]
     trakt_id: Optional[int]
     mdblist_id: Optional[str]
+    first_seen: datetime
+    last_seen: datetime
+    times_seen: int
+
+
+# Status information for an AniList source including sync history.
+class AniListSourceStatus(BaseModel):
+    source_index: int
+    name: str
+    last_sync_time: Optional[datetime] = None
+    sync_status: Literal["success", "error", "pending", "never_synced"]
+    error_message: Optional[str] = None
+    items_matched: int = 0
+    items_total: int = 0
+
+
+# Response from manual AniList sync operation.
+class AniListSyncResponse(BaseModel):
+    ok: bool
+    message: str
+    items_total: int
+    items_matched: int
+    items_missing: int
+    sync_time: datetime
+
+
+# An AniList item that wasn't found in Plex.
+class AniListMissingItemOut(BaseModel):
+    title: str
+    year: Optional[int]
+    media_format: Optional[str]
+    anilist_id: Optional[int]
+    mal_id: Optional[int]
+    tmdb_id: Optional[int]
+    imdb_id: Optional[str]
+    tvdb_id: Optional[int]
     first_seen: datetime
     last_seen: datetime
     times_seen: int

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -172,7 +172,7 @@ def get_letterboxd_settings(current_user: str = Depends(get_current_user)) -> Le
     # Return the currently configured Letterboxd settings
     try:
         config = load_config()
-        return config.letterboxd if config.letterboxd else LetterboxdSettings(enabled=False, sources=[])
+        return config.letterboxd if config.letterboxd else LetterboxdSettings(sources=[])
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive
@@ -191,9 +191,7 @@ def save_letterboxd_settings(
         letterboxd_section = data.get("letterboxd") if isinstance(data.get("letterboxd"), dict) else {}
         letterboxd_section = dict(letterboxd_section)
 
-        letterboxd_section.update(
-            enabled=payload.enabled,
-        )
+        # No settings to update (Letterboxd is credential-free)
 
         data["letterboxd"] = letterboxd_section
         save_config_mapping(data)
@@ -285,7 +283,7 @@ def get_anilist_settings(current_user: str = Depends(get_current_user)) -> AniLi
     try:
         config = load_config()
         if config.anilist is None:
-            return AniListSettings(enabled=False, sources=[])
+            return AniListSettings(sources=[])
         return config.anilist
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -305,9 +303,7 @@ def save_anilist_settings(
         anilist_section = data.get("anilist") if isinstance(data.get("anilist"), dict) else {}
         anilist_section = dict(anilist_section)
 
-        anilist_section.update(
-            enabled=payload.enabled,
-        )
+        # No settings to update (AniList is credential-free)
 
         data["anilist"] = anilist_section
         save_config_mapping(data)

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -16,6 +16,7 @@ from homescreen_hero.core.config.schema import (
     TraktSettings,
     LetterboxdSettings,
     MDBListSettings,
+    AniListSettings,
     TautulliSettings,
     SeerrSettings,
     DisplaySettings,
@@ -29,6 +30,7 @@ from .schemas import (
     TraktConfigSaveRequest,
     LetterboxdConfigSaveRequest,
     MDBListConfigSaveRequest,
+    AniListConfigSaveRequest,
     TautulliConfigSaveRequest,
     SeerrConfigSaveRequest,
     RotationConfigSaveRequest,
@@ -264,6 +266,58 @@ def save_mdblist_settings(
             path=str(config_path),
             env_override=CONFIG_ENV_VAR in os.environ,
             message="MDBList settings saved and validated.",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ========================================================================
+# ANILIST SETTINGS
+# ========================================================================
+
+@router.get("/anilist", response_model=AniListSettings)
+def get_anilist_settings(current_user: str = Depends(get_current_user)) -> AniListSettings:
+    # Return the currently configured AniList settings
+    try:
+        config = load_config()
+        if config.anilist is None:
+            return AniListSettings(enabled=False, sources=[])
+        return config.anilist
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/anilist", response_model=ConfigSaveResponse)
+def save_anilist_settings(
+    payload: AniListConfigSaveRequest,
+    current_user: str = Depends(get_current_user)
+) -> ConfigSaveResponse:
+    # Update only AniList settings in config.yaml while preserving other keys
+    try:
+        data = load_config_mapping()
+
+        anilist_section = data.get("anilist") if isinstance(data.get("anilist"), dict) else {}
+        anilist_section = dict(anilist_section)
+
+        anilist_section.update(
+            enabled=payload.enabled,
+        )
+
+        data["anilist"] = anilist_section
+        save_config_mapping(data)
+
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message="AniList settings saved and validated.",
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/homescreen_hero/web/routers/config/sources.py
+++ b/homescreen_hero/web/routers/config/sources.py
@@ -15,6 +15,7 @@ from homescreen_hero.core.config.schema import (
     TraktSource,
     LetterboxdSource,
     MDBListSource,
+    AniListSource,
 )
 from homescreen_hero.core.integrations.plex_client import get_plex_server
 
@@ -24,6 +25,7 @@ from .helpers import (
     load_trakt_sources,
     load_letterboxd_sources,
     load_mdblist_sources,
+    load_anilist_sources,
 )
 from .schemas import (
     ConfigSaveResponse,
@@ -39,6 +41,10 @@ from .schemas import (
     MDBListSourceStatus,
     MDBListSyncResponse,
     MDBListMissingItemOut,
+    AniListSourcePayload,
+    AniListSourceStatus,
+    AniListSyncResponse,
+    AniListMissingItemOut,
 )
 
 import os
@@ -775,4 +781,267 @@ def get_missing_items_for_mdblist_source(
         raise
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Error fetching missing items for MDBList source at index %d: %s", index, exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ========================================================================
+# ANILIST SOURCES
+# ========================================================================
+
+@router.get("/anilist/user-lists")
+def get_anilist_user_lists(
+    username: str,
+    current_user: str = Depends(get_current_user),
+):
+    # Fetch list names for an AniList user (for the dropdown)
+    from homescreen_hero.core.integrations.anilist_client import AniListClient, AniListConfig
+
+    if not username.strip():
+        raise HTTPException(status_code=400, detail="Username is required")
+
+    client = AniListClient(AniListConfig())
+    try:
+        lists = client.get_user_lists(username.strip())
+        return {"lists": lists}
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/anilist/sources", response_model=list[AniListSource])
+def list_anilist_sources(current_user: str = Depends(get_current_user)) -> list[AniListSource]:
+    # Return list of all configured AniList sources
+    try:
+        config = load_config()
+        return list(getattr(getattr(config, "anilist", None), "sources", []) or [])
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/anilist/sources", response_model=ConfigSaveResponse)
+def create_anilist_source(
+    payload: AniListSourcePayload,
+    current_user: str = Depends(get_current_user)
+) -> ConfigSaveResponse:
+    # Append new AniList source to config.yaml
+    try:
+        data = load_config_mapping()
+        anilist_section = data.get("anilist") if isinstance(data.get("anilist"), dict) else {}
+        anilist_section = dict(anilist_section)
+
+        sources = load_anilist_sources(data)
+        sources.append(payload.model_dump(exclude_none=True))
+
+        anilist_section["sources"] = sources
+        data["anilist"] = anilist_section
+
+        save_config_mapping(data)
+
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message=f"AniList source '{payload.name}' added.",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.put("/anilist/sources/{index}", response_model=ConfigSaveResponse)
+def update_anilist_source(
+    index: int,
+    payload: AniListSourcePayload,
+    current_user: str = Depends(get_current_user),
+) -> ConfigSaveResponse:
+    # Replace existing AniList source at given index in config.yaml
+    try:
+        data = load_config_mapping()
+        anilist_section = data.get("anilist") if isinstance(data.get("anilist"), dict) else {}
+        anilist_section = dict(anilist_section)
+
+        sources = load_anilist_sources(data)
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="AniList source not found")
+
+        sources[index] = payload.model_dump(exclude_none=True)
+        anilist_section["sources"] = sources
+        data["anilist"] = anilist_section
+
+        save_config_mapping(data)
+
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message=f"AniList source '{payload.name}' updated.",
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete("/anilist/sources/{index}", response_model=ConfigSaveResponse)
+def delete_anilist_source(
+    index: int,
+    current_user: str = Depends(get_current_user)
+) -> ConfigSaveResponse:
+    # Remove AniList source at given index from config.yaml
+    try:
+        data = load_config_mapping()
+        anilist_section = data.get("anilist") if isinstance(data.get("anilist"), dict) else {}
+        anilist_section = dict(anilist_section)
+
+        sources = load_anilist_sources(data)
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="AniList source not found")
+
+        removed = sources.pop(index)
+        anilist_section["sources"] = sources
+        data["anilist"] = anilist_section
+
+        save_config_mapping(data)
+
+        name = removed.get("name") if isinstance(removed, dict) else None
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message=f"AniList source '{name or index}' deleted.",
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/anilist/sources/status", response_model=list[AniListSourceStatus])
+def get_anilist_sources_status(
+    current_user: str = Depends(get_current_user)
+) -> list[AniListSourceStatus]:
+    # Return sync status for each configured AniList source.
+    try:
+        config = load_config()
+        sources = list(getattr(getattr(config, "anilist", None), "sources", []) or [])
+
+        statuses: list[AniListSourceStatus] = []
+        for idx, source in enumerate(sources):
+            statuses.append(
+                AniListSourceStatus(
+                    source_index=idx,
+                    name=source.name,
+                    last_sync_time=None,
+                    sync_status="never_synced",
+                    error_message=None,
+                    items_matched=0,
+                    items_total=0,
+                )
+            )
+
+        return statuses
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/anilist/sources/{index}/sync", response_model=AniListSyncResponse)
+def sync_anilist_source(
+    index: int,
+    current_user: str = Depends(get_current_user)
+) -> AniListSyncResponse:
+    # Manually sync a specific AniList source to Plex collection.
+    try:
+        from homescreen_hero.core.integrations.anilist_sync import sync_single_anilist_source
+
+        config = load_config()
+        sources = list(getattr(getattr(config, "anilist", None), "sources", []) or [])
+
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="AniList source not found")
+
+        source = sources[index]
+        server = get_plex_server(config)
+
+        # Execute the sync
+        total, matched = sync_single_anilist_source(server, config, source)
+        missing = total - matched
+
+        return AniListSyncResponse(
+            ok=True,
+            message=f"Synced '{source.name}' successfully",
+            items_total=total,
+            items_matched=matched,
+            items_missing=missing,
+            sync_time=datetime.utcnow(),
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Error syncing AniList source at index %d: %s", index, exc)
+        raise HTTPException(status_code=500, detail=f"Sync failed: {str(exc)}") from exc
+
+
+@router.get("/anilist/sources/{index}/missing", response_model=list[AniListMissingItemOut])
+def get_missing_items_for_anilist_source(
+    index: int,
+    current_user: str = Depends(get_current_user)
+) -> list[AniListMissingItemOut]:
+    # Get items from an AniList list that weren't found in Plex.
+    try:
+        from homescreen_hero.core.db import get_session
+        from homescreen_hero.core.db.models import AniListMissingItem
+
+        config = load_config()
+        sources = list(getattr(getattr(config, "anilist", None), "sources", []) or [])
+
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="AniList source not found")
+
+        source = sources[index]
+
+        with get_session() as session:
+            results = session.query(AniListMissingItem).filter(
+                AniListMissingItem.source_name == source.name,
+                AniListMissingItem.source_url == source.url
+            ).order_by(AniListMissingItem.last_seen.desc()).all()
+
+            return [
+                AniListMissingItemOut(
+                    title=item.title,
+                    year=item.year,
+                    media_format=item.media_format,
+                    anilist_id=item.anilist_id,
+                    mal_id=item.mal_id,
+                    tmdb_id=item.tmdb_id,
+                    imdb_id=item.imdb_id,
+                    tvdb_id=item.tvdb_id,
+                    first_seen=item.first_seen,
+                    last_seen=item.last_seen,
+                    times_seen=item.times_seen,
+                )
+                for item in results
+            ]
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error fetching missing items for AniList source at index %d: %s", index, exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/homescreen_hero/web/routers/config/sources.py
+++ b/homescreen_hero/web/routers/config/sources.py
@@ -26,6 +26,7 @@ from .helpers import (
     load_letterboxd_sources,
     load_mdblist_sources,
     load_anilist_sources,
+    get_all_source_names,
 )
 from .schemas import (
     ConfigSaveResponse,
@@ -78,6 +79,10 @@ def create_trakt_source(
     # Append new Trakt source to config.yaml
     try:
         data = load_config_mapping()
+
+        if payload.name in get_all_source_names(data):
+            raise HTTPException(status_code=409, detail=f"A source named '{payload.name}' already exists. Please choose a different name.")
+
         trakt_section = data.get("trakt") if isinstance(data.get("trakt"), dict) else {}
         trakt_section = dict(trakt_section)
 
@@ -96,6 +101,8 @@ def create_trakt_source(
             env_override=CONFIG_ENV_VAR in os.environ,
             message=f"Trakt source '{payload.name}' added.",
         )
+    except HTTPException:
+        raise
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except FileNotFoundError as exc:
@@ -322,6 +329,10 @@ def create_letterboxd_source(
     # Append new Letterboxd source to config.yaml
     try:
         data = load_config_mapping()
+
+        if payload.name in get_all_source_names(data):
+            raise HTTPException(status_code=409, detail=f"A source named '{payload.name}' already exists. Please choose a different name.")
+
         letterboxd_section = data.get("letterboxd") if isinstance(data.get("letterboxd"), dict) else {}
         letterboxd_section = dict(letterboxd_section)
 
@@ -340,6 +351,8 @@ def create_letterboxd_source(
             env_override=CONFIG_ENV_VAR in os.environ,
             message=f"Letterboxd source '{payload.name}' added.",
         )
+    except HTTPException:
+        raise
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except FileNotFoundError as exc:
@@ -564,6 +577,10 @@ def create_mdblist_source(
     # Append new MDBList source to config.yaml
     try:
         data = load_config_mapping()
+
+        if payload.name in get_all_source_names(data):
+            raise HTTPException(status_code=409, detail=f"A source named '{payload.name}' already exists. Please choose a different name.")
+
         mdblist_section = data.get("mdblist") if isinstance(data.get("mdblist"), dict) else {}
         mdblist_section = dict(mdblist_section)
 
@@ -582,6 +599,8 @@ def create_mdblist_source(
             env_override=CONFIG_ENV_VAR in os.environ,
             message=f"MDBList source '{payload.name}' added.",
         )
+    except HTTPException:
+        raise
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except FileNotFoundError as exc:
@@ -829,6 +848,10 @@ def create_anilist_source(
     # Append new AniList source to config.yaml
     try:
         data = load_config_mapping()
+
+        if payload.name in get_all_source_names(data):
+            raise HTTPException(status_code=409, detail=f"A source named '{payload.name}' already exists. Please choose a different name.")
+
         anilist_section = data.get("anilist") if isinstance(data.get("anilist"), dict) else {}
         anilist_section = dict(anilist_section)
 
@@ -847,6 +870,8 @@ def create_anilist_source(
             env_override=CONFIG_ENV_VAR in os.environ,
             message=f"AniList source '{payload.name}' added.",
         )
+    except HTTPException:
+        raise
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except FileNotFoundError as exc:

--- a/homescreen_hero/web/routers/config/sources.py
+++ b/homescreen_hero/web/routers/config/sources.py
@@ -195,22 +195,23 @@ def get_trakt_sources_status(
 ) -> list[TraktSourceStatus]:
     # Return sync status for each configured Trakt source.
     try:
+        from homescreen_hero.core.db import get_sync_status
+
         config = load_config()
         sources = list(getattr(getattr(config, "trakt", None), "sources", []) or [])
 
-        # For now, return basic status without historical sync data
-        # Future enhancement: query database for actual sync history
         statuses: list[TraktSourceStatus] = []
         for idx, source in enumerate(sources):
+            record = get_sync_status("trakt", source.name)
             statuses.append(
                 TraktSourceStatus(
                     source_index=idx,
                     name=source.name,
-                    last_sync_time=None,
-                    sync_status="never_synced",
-                    error_message=None,
-                    items_matched=0,
-                    items_total=0,
+                    last_sync_time=record.last_sync_time if record else None,
+                    sync_status=record.sync_status if record else "never_synced",
+                    error_message=record.error_message if record else None,
+                    items_matched=record.items_matched if record else 0,
+                    items_total=record.items_total if record else 0,
                 )
             )
 
@@ -229,6 +230,7 @@ def sync_trakt_source(
     # Manually sync a specific Trakt source to Plex collection.
     try:
         from homescreen_hero.core.integrations.trakt_sync import sync_single_trakt_source
+        from homescreen_hero.core.db import record_sync_result
 
         config = load_config()
         sources = list(getattr(getattr(config, "trakt", None), "sources", []) or [])
@@ -243,6 +245,14 @@ def sync_trakt_source(
         total, matched = sync_single_trakt_source(server, config, source)
         missing = total - matched
 
+        record_sync_result(
+            integration_type="trakt",
+            source_name=source.name,
+            source_url=source.url,
+            items_total=total,
+            items_matched=matched,
+        )
+
         return TraktSyncResponse(
             ok=True,
             message=f"Synced '{source.name}' successfully",
@@ -255,6 +265,25 @@ def sync_trakt_source(
         raise
     except Exception as exc:
         logger.error("Error syncing Trakt source at index %d: %s", index, exc)
+
+        # Record the failure
+        try:
+            from homescreen_hero.core.db import record_sync_result
+            config = load_config()
+            sources = list(getattr(getattr(config, "trakt", None), "sources", []) or [])
+            if 0 <= index < len(sources):
+                record_sync_result(
+                    integration_type="trakt",
+                    source_name=sources[index].name,
+                    source_url=sources[index].url,
+                    items_total=0,
+                    items_matched=0,
+                    sync_status="error",
+                    error_message=str(exc),
+                )
+        except Exception:
+            pass
+
         raise HTTPException(status_code=500, detail=f"Sync failed: {str(exc)}") from exc
 
 
@@ -445,22 +474,23 @@ def get_letterboxd_sources_status(
 ) -> list[LetterboxdSourceStatus]:
     # Return sync status for each configured Letterboxd source.
     try:
+        from homescreen_hero.core.db import get_sync_status
+
         config = load_config()
         sources = list(getattr(getattr(config, "letterboxd", None), "sources", []) or [])
 
-        # For now, return basic status without historical sync data
-        # Future enhancement: query database for actual sync history
         statuses: list[LetterboxdSourceStatus] = []
         for idx, source in enumerate(sources):
+            record = get_sync_status("letterboxd", source.name)
             statuses.append(
                 LetterboxdSourceStatus(
                     source_index=idx,
                     name=source.name,
-                    last_sync_time=None,
-                    sync_status="never_synced",
-                    error_message=None,
-                    items_matched=0,
-                    items_total=0,
+                    last_sync_time=record.last_sync_time if record else None,
+                    sync_status=record.sync_status if record else "never_synced",
+                    error_message=record.error_message if record else None,
+                    items_matched=record.items_matched if record else 0,
+                    items_total=record.items_total if record else 0,
                 )
             )
 
@@ -479,6 +509,7 @@ def sync_letterboxd_source(
     # Manually sync a specific Letterboxd source to Plex collection.
     try:
         from homescreen_hero.core.integrations.letterboxd_sync import sync_single_letterboxd_source
+        from homescreen_hero.core.db import record_sync_result
 
         config = load_config()
         sources = list(getattr(getattr(config, "letterboxd", None), "sources", []) or [])
@@ -493,6 +524,14 @@ def sync_letterboxd_source(
         total, matched = sync_single_letterboxd_source(server, config, source)
         missing = total - matched
 
+        record_sync_result(
+            integration_type="letterboxd",
+            source_name=source.name,
+            source_url=source.url,
+            items_total=total,
+            items_matched=matched,
+        )
+
         return LetterboxdSyncResponse(
             ok=True,
             message=f"Synced '{source.name}' successfully",
@@ -505,6 +544,24 @@ def sync_letterboxd_source(
         raise
     except Exception as exc:
         logger.error("Error syncing Letterboxd source at index %d: %s", index, exc)
+
+        try:
+            from homescreen_hero.core.db import record_sync_result
+            config = load_config()
+            sources = list(getattr(getattr(config, "letterboxd", None), "sources", []) or [])
+            if 0 <= index < len(sources):
+                record_sync_result(
+                    integration_type="letterboxd",
+                    source_name=sources[index].name,
+                    source_url=sources[index].url,
+                    items_total=0,
+                    items_matched=0,
+                    sync_status="error",
+                    error_message=str(exc),
+                )
+        except Exception:
+            pass
+
         raise HTTPException(status_code=500, detail=f"Sync failed: {str(exc)}") from exc
 
 
@@ -693,22 +750,23 @@ def get_mdblist_sources_status(
 ) -> list[MDBListSourceStatus]:
     # Return sync status for each configured MDBList source.
     try:
+        from homescreen_hero.core.db import get_sync_status
+
         config = load_config()
         sources = list(getattr(getattr(config, "mdblist", None), "sources", []) or [])
 
-        # For now, return basic status without historical sync data
-        # Future enhancement: query database for actual sync history
         statuses: list[MDBListSourceStatus] = []
         for idx, source in enumerate(sources):
+            record = get_sync_status("mdblist", source.name)
             statuses.append(
                 MDBListSourceStatus(
                     source_index=idx,
                     name=source.name,
-                    last_sync_time=None,
-                    sync_status="never_synced",
-                    error_message=None,
-                    items_matched=0,
-                    items_total=0,
+                    last_sync_time=record.last_sync_time if record else None,
+                    sync_status=record.sync_status if record else "never_synced",
+                    error_message=record.error_message if record else None,
+                    items_matched=record.items_matched if record else 0,
+                    items_total=record.items_total if record else 0,
                 )
             )
 
@@ -727,6 +785,7 @@ def sync_mdblist_source(
     # Manually sync a specific MDBList source to Plex collection.
     try:
         from homescreen_hero.core.integrations.mdblist_sync import sync_single_mdblist_source
+        from homescreen_hero.core.db import record_sync_result
 
         config = load_config()
         sources = list(getattr(getattr(config, "mdblist", None), "sources", []) or [])
@@ -741,6 +800,14 @@ def sync_mdblist_source(
         total, matched = sync_single_mdblist_source(server, config, source)
         missing = total - matched
 
+        record_sync_result(
+            integration_type="mdblist",
+            source_name=source.name,
+            source_url=source.url,
+            items_total=total,
+            items_matched=matched,
+        )
+
         return MDBListSyncResponse(
             ok=True,
             message=f"Synced '{source.name}' successfully",
@@ -753,6 +820,24 @@ def sync_mdblist_source(
         raise
     except Exception as exc:
         logger.error("Error syncing MDBList source at index %d: %s", index, exc)
+
+        try:
+            from homescreen_hero.core.db import record_sync_result
+            config = load_config()
+            sources = list(getattr(getattr(config, "mdblist", None), "sources", []) or [])
+            if 0 <= index < len(sources):
+                record_sync_result(
+                    integration_type="mdblist",
+                    source_name=sources[index].name,
+                    source_url=sources[index].url,
+                    items_total=0,
+                    items_matched=0,
+                    sync_status="error",
+                    error_message=str(exc),
+                )
+        except Exception:
+            pass
+
         raise HTTPException(status_code=500, detail=f"Sync failed: {str(exc)}") from exc
 
 
@@ -964,20 +1049,23 @@ def get_anilist_sources_status(
 ) -> list[AniListSourceStatus]:
     # Return sync status for each configured AniList source.
     try:
+        from homescreen_hero.core.db import get_sync_status
+
         config = load_config()
         sources = list(getattr(getattr(config, "anilist", None), "sources", []) or [])
 
         statuses: list[AniListSourceStatus] = []
         for idx, source in enumerate(sources):
+            record = get_sync_status("anilist", source.name)
             statuses.append(
                 AniListSourceStatus(
                     source_index=idx,
                     name=source.name,
-                    last_sync_time=None,
-                    sync_status="never_synced",
-                    error_message=None,
-                    items_matched=0,
-                    items_total=0,
+                    last_sync_time=record.last_sync_time if record else None,
+                    sync_status=record.sync_status if record else "never_synced",
+                    error_message=record.error_message if record else None,
+                    items_matched=record.items_matched if record else 0,
+                    items_total=record.items_total if record else 0,
                 )
             )
 
@@ -996,6 +1084,7 @@ def sync_anilist_source(
     # Manually sync a specific AniList source to Plex collection.
     try:
         from homescreen_hero.core.integrations.anilist_sync import sync_single_anilist_source
+        from homescreen_hero.core.db import record_sync_result
 
         config = load_config()
         sources = list(getattr(getattr(config, "anilist", None), "sources", []) or [])
@@ -1010,6 +1099,14 @@ def sync_anilist_source(
         total, matched = sync_single_anilist_source(server, config, source)
         missing = total - matched
 
+        record_sync_result(
+            integration_type="anilist",
+            source_name=source.name,
+            source_url=source.url,
+            items_total=total,
+            items_matched=matched,
+        )
+
         return AniListSyncResponse(
             ok=True,
             message=f"Synced '{source.name}' successfully",
@@ -1022,6 +1119,24 @@ def sync_anilist_source(
         raise
     except Exception as exc:
         logger.error("Error syncing AniList source at index %d: %s", index, exc)
+
+        try:
+            from homescreen_hero.core.db import record_sync_result
+            config = load_config()
+            sources = list(getattr(getattr(config, "anilist", None), "sources", []) or [])
+            if 0 <= index < len(sources):
+                record_sync_result(
+                    integration_type="anilist",
+                    source_name=sources[index].name,
+                    source_url=sources[index].url,
+                    items_total=0,
+                    items_matched=0,
+                    sync_status="error",
+                    error_message=str(exc),
+                )
+        except Exception:
+            pass
+
         raise HTTPException(status_code=500, detail=f"Sync failed: {str(exc)}") from exc
 
 

--- a/homescreen_hero/web/routers/health.py
+++ b/homescreen_hero/web/routers/health.py
@@ -12,6 +12,7 @@ from homescreen_hero.core.db import init_db
 from homescreen_hero.core.integrations.plex_client import get_plex_server
 from homescreen_hero.core.integrations.trakt_client import get_trakt_client
 from homescreen_hero.core.integrations.mdblist_client import get_mdblist_client
+from homescreen_hero.core.integrations.anilist_client import get_anilist_client
 from homescreen_hero.core.logging_config import level_from_name, setup_logging
 from homescreen_hero.core.config.schema import HealthComponent, HealthResponse
 
@@ -205,6 +206,57 @@ def _check_seerr(config: Any) -> HealthComponent:
         )
 
 
+# Helper function for AniList health check
+def _check_anilist(config: Any) -> HealthComponent:
+    try:
+        anilist_client = get_anilist_client(config)
+
+        if anilist_client is None:
+            return HealthComponent(ok=True, error="AniList disabled or not configured")
+
+        a_ok, a_error = anilist_client.ping()
+        issues: list[str] = []
+
+        if not a_ok:
+            issues.append(f"AniList ping failed: {a_error or 'unknown error'}")
+
+        try:
+            server = get_plex_server(config)
+
+            if config.anilist and config.anilist.sources:
+                for src in config.anilist.sources:
+                    if not src.plex_library:
+                        issues.append(f"Source '{src.name}' has no plex_library set")
+                        continue
+
+                    try:
+                        server.library.section(src.plex_library)
+                    except NotFound:
+                        issues.append(
+                            f"Source '{src.name}' uses unknown Plex library "
+                            f"'{src.plex_library}'"
+                        )
+                    except Exception as exc:  # pragma: no cover - defensive
+                        issues.append(
+                            f"Source '{src.name}' failed library check "
+                            f"'{src.plex_library}': {exc}"
+                        )
+        except Exception as exc:  # pragma: no cover - defensive
+            issues.append(f"Failed to validate AniList sources against Plex: {exc}")
+
+        return (
+            HealthComponent(ok=False, error="; ".join(issues))
+            if issues
+            else HealthComponent(ok=True)
+        )
+
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("AniList health check failed")
+        return HealthComponent(
+            ok=False, error=f"Unhandled error in AniList health check: {exc}"
+        )
+
+
 # Helper function for Plex health check
 def _check_plex(config: Any) -> HealthComponent:
     try:
@@ -303,6 +355,16 @@ def health_seerr() -> HealthComponent:
     return _check_seerr(config)
 
 
+# Validate AniList connectivity and configured Plex library references
+@router.get("/health/anilist", response_model=HealthComponent)
+def health_anilist() -> HealthComponent:
+    component, config = _check_config()
+    if not component.ok:
+        return HealthComponent(ok=False, error=component.error)
+
+    return _check_anilist(config)
+
+
 # Validate Plex connectivity and configured library is accessible
 @router.get("/health/plex", response_model=HealthComponent)
 def health_plex() -> HealthComponent:
@@ -331,6 +393,7 @@ def health_check() -> HealthResponse:
 
     components["trakt"] = _check_trakt(config)
     components["mdblist"] = _check_mdblist(config)
+    components["anilist"] = _check_anilist(config)
     components["tautulli"] = _check_tautulli(config)
     components["seerr"] = _check_seerr(config)
     components["plex"] = _check_plex(config)

--- a/homescreen_hero/web/routers/rotation.py
+++ b/homescreen_hero/web/routers/rotation.py
@@ -105,9 +105,9 @@ class SchedulerStatusResponse(BaseModel):
     is_running: bool
 
 
+#Get the current scheduler status including next scheduled rotation time.
 @router.get("/scheduler-status", response_model=SchedulerStatusResponse)
 def get_scheduler_status(current_user: str = Depends(get_current_user)) -> SchedulerStatusResponse:
-    """Get the current scheduler status including next scheduled rotation time."""
     try:
         config = load_config()
 
@@ -137,9 +137,9 @@ class SyncResponse(BaseModel):
     message: str
 
 
+# Manually sync all third party sources without running a rotation.
 @router.post("/sync-all", response_model=SyncResponse)
 def sync_all(current_user: str = Depends(get_current_user)) -> SyncResponse:
-    """Manually sync all Trakt, Letterboxd, and MDBList sources without running a rotation."""
     try:
         logger.info("Handling /sync-all request")
         sync_all_sources()
@@ -147,7 +147,7 @@ def sync_all(current_user: str = Depends(get_current_user)) -> SyncResponse:
         invalidate_collections_cache()
         return SyncResponse(
             status="success",
-            message="All Trakt, Letterboxd, and MDBList sources have been synced successfully"
+            message="All third-party lists have been synced successfully"
         )
     except Exception as exc:
         logger.exception("Manual sync failed")


### PR DESCRIPTION
## Feature: AniList Integration MVP

### Summary
Adds **AniList** as a new integration source, letting users sync anime lists from AniList into their Plex collections. Supports both user lists (watching, completed, custom, etc.) and public lists (Top 100, Trending, Next-Season, etc.)

### Major Changes
- New AniList client with GraphQL queries for fetching user and public anime lists
- AniList sync engine that matches AniList entries to Plex library items (big shoutout to [anime-lists](https://github.com/Fribb/anime-lists))
- New **Anime** tab on the Integration page for adding lists from AniList (**MyAnimeList** coming soon!)
- Sync status tracking for all third-party integration sources so users can see when lists were last synced and whether they succeeded

### Minor Changes
- Replaced inline banner notifications with toast notifications on the Integrations page
- Updated Letterboxd tab layout to match the new integration style
- Filtered out some noisy urllib3 log messages (holy crap these are annoying lol)

**Note:** as mentioned above, AniList **does not** have it's own tab on the Integrations page. I'm a bit worried about it getting cluttered, so I created an **Anime** tab that will house all third-party sources related to anime :)