### PR TITLE
Feature: MyAnimeList Integration MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,13 @@ HSH_TAUTULLI_API_KEY=your-tautulli-api-key-here
 # HSH_TAUTULLI_BASE_URL=http://your-tautulli-server:8181
 
 # ============================================
+# MYANIMELIST INTEGRATION (if mal.enabled = true)
+# ============================================
+# Your MAL API Client ID
+# Get this from: https://myanimelist.net/apiconfig
+HSH_MAL_CLIENT_ID=your-mal-client-id-here
+
+# ============================================
 # SEERR INTEGRATION (if seerr.enabled = true)
 # ============================================
 # Your Seerr/Jellyseerr/Overseerr API key

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -85,6 +85,27 @@ anilist:
 #   plex_library: "Anime"
 #   max_items: 50  # Limit items for browse lists (default: 100, range: 10-500)
 
+# Optional: MyAnimeList integration
+mal:
+  enabled: false
+  # client_id: "YOUR_MAL_CLIENT_ID"  # RECOMMENDED: Use HSH_MAL_CLIENT_ID environment variable instead
+  # Get your Client ID from: https://myanimelist.net/apiconfig
+  sources:
+  - name: "My MAL Watchlist"  # This is the name that will show up in Plex
+    url: "https://myanimelist.net/animelist/username"  # Fetches all statuses by default
+    plex_library: "Anime"
+# - name: "Completed Anime"
+#   url: "https://myanimelist.net/animelist/username?status=completed"  # A specific status filter
+#   plex_library: "Anime"
+# - name: "Top Anime"
+#   url: "mal://ranking/all"  # MAL global ranking (options: all, airing, upcoming, bypopularity, favorite)
+#   plex_library: "Anime"
+#   max_items: 50  # Limit items for ranking/seasonal lists (default: 100, range: 10-500)
+# - name: "Winter 2026 Anime"
+#   url: "mal://season/2026/winter"  # Seasonal anime (seasons: winter, spring, summer, fall)
+#   plex_library: "Anime"
+#   max_items: 50
+
 # Optional: MDBList integration
 mdblist:
   enabled: false

--- a/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/AniListIntegration.tsx
@@ -325,24 +325,6 @@ export function AniListIntegration() {
                 </div>
             )}
 
-            {/* Info note */}
-            <div className="rounded-lg border border-blue-700/50 bg-blue-900/20 px-4 py-3">
-                <p className="text-xs text-blue-200">
-                    <strong>Note:</strong> AniList items are matched to Plex using the{" "}
-                    <a
-                        href="https://github.com/Fribb/anime-lists"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="underline hover:text-blue-100"
-                    >
-                        anime-lists
-                    </a>{" "}
-                    ID mapping database, with a fallback to title/year matching. Point your
-                    source at a show library for anime series, or a movie library for anime
-                    films.
-                </p>
-            </div>
-
             {/* Source list */}
             <SourceList<AniListMissingItem>
                 sources={integration.sources}

--- a/homescreen-hero-ui/src/components/integrations/AnimeIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/AnimeIntegration.tsx
@@ -1,16 +1,36 @@
 import { useState } from "react";
 import { ChevronRight, Tv } from "lucide-react";
 import { AniListIntegration } from "./AniListIntegration";
+import { MALIntegration } from "./MALIntegration";
 
 export function AnimeIntegration() {
-    const [isExpanded, setIsExpanded] = useState(true);
+    const [anilistExpanded, setAnilistExpanded] = useState(true);
+    const [malExpanded, setMalExpanded] = useState(false);
 
     return (
         <div className="space-y-4">
+            {/* Shared note */}
+            <div className="rounded-lg border border-blue-700/50 bg-blue-900/20 px-4 py-3">
+                <p className="text-xs text-blue-200">
+                    All anime sources are matched to Plex using the{" "}
+                    <a
+                        href="https://github.com/Fribb/anime-lists"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-blue-100"
+                    >
+                        anime-lists
+                    </a>{" "}
+                    ID mapping database, with a fallback to title/year matching. Point your
+                    sources at a show library for anime series, or a movie library for anime films.
+                </p>
+            </div>
+
+            {/* AniList */}
             <div className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 overflow-hidden shadow-lg shadow-primary/5">
                 <button
                     type="button"
-                    onClick={() => setIsExpanded(!isExpanded)}
+                    onClick={() => setAnilistExpanded(!anilistExpanded)}
                     className="w-full px-6 py-4 flex items-center justify-between hover:bg-slate-800/30 transition"
                 >
                     <div className="text-left flex items-start gap-3">
@@ -26,20 +46,60 @@ export function AnimeIntegration() {
                     </div>
                     <ChevronRight
                         className={`h-5 w-5 text-slate-400 transition-transform duration-200 ${
-                            isExpanded ? "rotate-90" : ""
+                            anilistExpanded ? "rotate-90" : ""
                         }`}
                     />
                 </button>
 
                 <div
                     className={`grid transition-all duration-300 ease-in-out ${
-                        isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                        anilistExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
                     }`}
                 >
                     <div className="overflow-hidden">
                         <div className="px-6 pb-6 space-y-4 border-t border-slate-800">
                             <div className="pt-4">
                                 <AniListIntegration />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* MAL */}
+            <div className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 overflow-hidden shadow-lg shadow-primary/5">
+                <button
+                    type="button"
+                    onClick={() => setMalExpanded(!malExpanded)}
+                    className="w-full px-6 py-4 flex items-center justify-between hover:bg-slate-800/30 transition"
+                >
+                    <div className="text-left flex items-start gap-3">
+                        <div className="rounded-lg bg-primary/10 p-2 border border-primary/20 mt-0.5">
+                            <Tv className="h-5 w-5 text-primary" />
+                        </div>
+                        <div>
+                            <h3 className="text-lg font-semibold text-slate-100">MyAnimeList</h3>
+                            <p className="text-xs text-slate-400 mt-1">
+                                Sync your MAL anime lists, rankings, and seasonal charts to Plex collections.
+                            </p>
+                        </div>
+                    </div>
+                    <ChevronRight
+                        className={`h-5 w-5 text-slate-400 transition-transform duration-200 ${
+                            malExpanded ? "rotate-90" : ""
+                        }`}
+                    />
+                </button>
+
+                <div
+                    className={`grid transition-all duration-300 ease-in-out ${
+                        malExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                    }`}
+                >
+                    <div className="overflow-hidden">
+                        <div className="px-6 pb-6 space-y-4 border-t border-slate-800">
+                            <div className="pt-4">
+                                <MALIntegration />
                             </div>
                         </div>
                     </div>

--- a/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
@@ -98,15 +98,6 @@ export function LetterboxdIntegration() {
                                     </button>
                                 </div>
 
-                                {/* Note */}
-                                <div className="rounded-lg border border-blue-700/50 bg-blue-900/20 px-4 py-3">
-                                    <p className="text-xs text-blue-200">
-                                        <strong>Note:</strong> Letterboxd integration uses web scraping since their
-                                        API requires approval. Movies are matched by title and year, which may be
-                                        less accurate than ID-based matching.
-                                    </p>
-                                </div>
-
                                 {/* Source list */}
                                 <SourceList<LetterboxdMissingItem>
                                     sources={integration.sources}

--- a/homescreen-hero-ui/src/components/integrations/MALIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/MALIntegration.tsx
@@ -1,0 +1,587 @@
+import { useState, useCallback } from "react";
+import { Listbox, Switch } from "@headlessui/react";
+import { Check, ChevronDown, Minus, Plus, Wifi, WifiOff } from "lucide-react";
+import FieldRow from "../FieldRow";
+import Toast from "../Toast";
+import { ConfigPanel } from "./shared/ConfigPanel";
+import { SourceList } from "./shared/SourceListManager";
+import { LibrarySelect } from "./shared/LibrarySelect";
+import { ListTypeSelect } from "./shared/ListTypeSelect";
+import type { ListTypeOption } from "./shared/ListTypeSelect";
+import { useListIntegration } from "../../hooks/integrations/useListIntegration";
+import { usePlexLibraries } from "../../hooks/integrations/usePlexLibraries";
+import type { MALSettings, MALMissingItem } from "../../types/integrations";
+
+const initialSettings: MALSettings = {
+    enabled: false,
+    client_id: "",
+};
+
+function formatDate(dateString: string | null): string {
+    if (!dateString) return "Never";
+    return new Date(dateString).toLocaleString();
+}
+
+const MEDIA_TYPE_LABELS: Record<string, string> = {
+    tv: "TV",
+    ova: "OVA",
+    ona: "ONA",
+    movie: "Movie",
+    special: "Special",
+    tv_special: "TV Special",
+    music: "Music",
+};
+
+const STATUS_OPTIONS: ListTypeOption[] = [
+    { value: "watching", label: "Watching" },
+    { value: "completed", label: "Completed" },
+    { value: "on_hold", label: "On Hold" },
+    { value: "dropped", label: "Dropped" },
+    { value: "plan_to_watch", label: "Plan to Watch" },
+];
+
+const RANKING_OPTIONS: ListTypeOption[] = [
+    { value: "all", label: "Top Anime" },
+    { value: "airing", label: "Top Airing" },
+    { value: "upcoming", label: "Top Upcoming" },
+    { value: "bypopularity", label: "Most Popular" },
+    { value: "favorite", label: "Most Favorited" },
+];
+
+const SEASON_OPTIONS: ListTypeOption[] = [
+    { value: "winter", label: "Winter" },
+    { value: "spring", label: "Spring" },
+    { value: "summer", label: "Summer" },
+    { value: "fall", label: "Fall" },
+];
+
+// Capitalize first letter
+function capitalize(s: string): string {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export function MALIntegration() {
+    const { enabledLibraries } = usePlexLibraries();
+
+    const integration = useListIntegration<MALSettings, MALMissingItem>({
+        integrationName: "mal",
+        initialSettings,
+        hasSettings: true,
+        healthEndpoint: "/api/health/mal",
+    });
+
+    // Mode toggle: user lists vs rankings vs seasonal
+    const [mode, setMode] = useState<"user" | "ranking" | "seasonal">("user");
+
+    // User list form state
+    const [username, setUsername] = useState("");
+    const [statusFilter, setStatusFilter] = useState("");
+    const [collectionName, setCollectionName] = useState("");
+    const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
+    const [plexLibrary, setPlexLibrary] = useState("");
+
+    // Ranking form state
+    const [rankingType, setRankingType] = useState("");
+    const [rankingCollectionName, setRankingCollectionName] = useState("");
+    const [rankingNameManuallyEdited, setRankingNameManuallyEdited] = useState(false);
+    const [rankingPlexLibrary, setRankingPlexLibrary] = useState("");
+    const [rankingMaxItems, setRankingMaxItems] = useState(100);
+
+    // Seasonal form state
+    const currentYear = new Date().getFullYear();
+    const yearOptions = Array.from({ length: currentYear - 2000 + 2 }, (_, i) => currentYear + 1 - i);
+    const [seasonYear, setSeasonYear] = useState(currentYear);
+    const [season, setSeason] = useState("");
+    const [seasonCollectionName, setSeasonCollectionName] = useState("");
+    const [seasonNameManuallyEdited, setSeasonNameManuallyEdited] = useState(false);
+    const [seasonPlexLibrary, setSeasonPlexLibrary] = useState("");
+    const [seasonMaxItems, setSeasonMaxItems] = useState(100);
+
+    // User list handlers
+    const handleStatusChange = useCallback(
+        (value: string) => {
+            setStatusFilter(value);
+            if (!nameManuallyEdited) {
+                if (!value) {
+                    setCollectionName(username.trim() ? `${username.trim()}'s Anime` : "");
+                } else {
+                    const option = STATUS_OPTIONS.find((o) => o.value === value);
+                    setCollectionName(option ? option.label : capitalize(value));
+                }
+            }
+        },
+        [nameManuallyEdited, username]
+    );
+
+    const canAddUser = username.trim() && collectionName.trim() && plexLibrary;
+
+    const handleAddUser = useCallback(async () => {
+        if (!canAddUser) return;
+
+        const trimmedUsername = username.trim();
+        const url = `https://myanimelist.net/animelist/${trimmedUsername}${statusFilter ? `?status=${statusFilter}` : ""}`;
+
+        const ok = await integration.addSource({
+            name: collectionName.trim(),
+            url,
+            plex_library: plexLibrary,
+        });
+
+        if (ok) {
+            setUsername("");
+            setStatusFilter("");
+            setCollectionName("");
+            setNameManuallyEdited(false);
+            setPlexLibrary("");
+        }
+    }, [canAddUser, username, statusFilter, collectionName, plexLibrary, integration]);
+
+    // Ranking handlers
+    const handleRankingTypeChange = useCallback(
+        (value: string) => {
+            setRankingType(value);
+            if (!rankingNameManuallyEdited) {
+                const option = RANKING_OPTIONS.find((o) => o.value === value);
+                setRankingCollectionName(option ? `MAL ${option.label}` : "");
+            }
+        },
+        [rankingNameManuallyEdited]
+    );
+
+    const canAddRanking = rankingType && rankingCollectionName.trim() && rankingPlexLibrary;
+
+    const handleAddRanking = useCallback(async () => {
+        if (!canAddRanking) return;
+
+        const url = `mal://ranking/${rankingType}`;
+        const ok = await integration.addSource({
+            name: rankingCollectionName.trim(),
+            url,
+            plex_library: rankingPlexLibrary,
+            max_items: rankingMaxItems,
+        });
+
+        if (ok) {
+            setRankingType("");
+            setRankingCollectionName("");
+            setRankingNameManuallyEdited(false);
+            setRankingPlexLibrary("");
+            setRankingMaxItems(100);
+        }
+    }, [canAddRanking, rankingType, rankingCollectionName, rankingPlexLibrary, rankingMaxItems, integration]);
+
+    // Seasonal handlers
+    const handleSeasonChange = useCallback(
+        (value: string) => {
+            setSeason(value);
+            if (!seasonNameManuallyEdited) {
+                setSeasonCollectionName(value ? `MAL ${capitalize(value)} ${seasonYear}` : "");
+            }
+        },
+        [seasonNameManuallyEdited, seasonYear]
+    );
+
+    const canAddSeasonal = season && seasonCollectionName.trim() && seasonPlexLibrary;
+
+    const handleAddSeasonal = useCallback(async () => {
+        if (!canAddSeasonal) return;
+
+        const url = `mal://season/${seasonYear}/${season}`;
+        const ok = await integration.addSource({
+            name: seasonCollectionName.trim(),
+            url,
+            plex_library: seasonPlexLibrary,
+            max_items: seasonMaxItems,
+        });
+
+        if (ok) {
+            setSeason("");
+            setSeasonCollectionName("");
+            setSeasonNameManuallyEdited(false);
+            setSeasonPlexLibrary("");
+            setSeasonMaxItems(100);
+        }
+    }, [canAddSeasonal, season, seasonYear, seasonCollectionName, seasonPlexLibrary, seasonMaxItems, integration]);
+
+    const formDisabled = integration.savingSource || integration.loadingSources;
+
+    // Reusable max items stepper
+    const MaxItemsStepper = ({ value, onChange, disabled }: { value: number; onChange: (v: number) => void; disabled: boolean }) => (
+        <div className="flex items-center rounded-lg border border-slate-700 bg-slate-950 overflow-hidden">
+            <span className="pl-2.5 text-xs text-slate-500 whitespace-nowrap select-none">Max</span>
+            <button
+                type="button"
+                disabled={disabled || value <= 10}
+                onClick={() => onChange(Math.max(10, value - 10))}
+                className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+                <Minus className="h-3.5 w-3.5" />
+            </button>
+            <input
+                type="number"
+                min={10}
+                max={500}
+                step={10}
+                value={value}
+                onChange={(e) => onChange(Number(e.target.value) || 0)}
+                onBlur={() => onChange(Math.max(10, Math.min(500, value || 100)))}
+                disabled={disabled}
+                className="w-10 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                title="Max items"
+            />
+            <button
+                type="button"
+                disabled={disabled || value >= 500}
+                onClick={() => onChange(Math.min(500, value + 10))}
+                className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+                <Plus className="h-3.5 w-3.5" />
+            </button>
+        </div>
+    );
+
+    return (
+        <div className="space-y-4">
+            {/* Settings panel */}
+            <ConfigPanel
+                title="MAL Configuration"
+                description="Configure your MyAnimeList API credentials."
+            >
+                <FieldRow
+                    label="Enable MAL"
+                    description="Toggle syncing MAL anime lists to your Plex collections."
+                >
+                    <div className="flex justify-end">
+                        <Switch
+                            checked={integration.settings.enabled}
+                            onChange={() =>
+                                integration.setSettings((prev) => ({
+                                    ...prev,
+                                    enabled: !prev.enabled,
+                                }))
+                            }
+                            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 ease-in-out ${
+                                integration.settings.enabled ? "bg-primary" : "bg-slate-600"
+                            }`}
+                        >
+                            <span
+                                className={`inline-block h-5 w-5 transform rounded-full bg-white shadow-sm transition-transform duration-200 ease-in-out ${
+                                    integration.settings.enabled ? "translate-x-5" : "translate-x-0.5"
+                                }`}
+                            />
+                        </Switch>
+                    </div>
+                </FieldRow>
+
+                <FieldRow
+                    label="Client ID"
+                    description="Found in your MAL API application settings."
+                >
+                    <input
+                        type="password"
+                        placeholder="••••••••"
+                        className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={integration.settings.client_id}
+                        onChange={(e) =>
+                            integration.setSettings((prev) => ({
+                                ...prev,
+                                client_id: e.target.value,
+                            }))
+                        }
+                        disabled={integration.loadingSettings}
+                    />
+                </FieldRow>
+
+                {/* Test connection CTA */}
+                <div className="flex items-center justify-between gap-4 rounded-xl border border-slate-800 bg-slate-900/40 px-4 py-3 mt-6">
+                    <div className="flex items-center gap-3">
+                        <span
+                            className={`rounded-full p-2 ${
+                                integration.testStatus === "success"
+                                    ? "bg-emerald-500/15 text-emerald-400"
+                                    : integration.testStatus === "error"
+                                      ? "bg-rose-500/15 text-rose-400"
+                                      : "bg-amber-500/15 text-amber-400"
+                            }`}
+                        >
+                            {integration.testStatus === "success" ? (
+                                <Wifi size={18} />
+                            ) : (
+                                <WifiOff size={18} />
+                            )}
+                        </span>
+                        <div className="space-y-0.5">
+                            <p className="text-sm font-semibold text-white">Test MAL connection</p>
+                            <p className="text-xs text-slate-400">
+                                Run a dry connection test without restarting the service.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={integration.saveSettings}
+                            disabled={integration.savingSettings || integration.loadingSettings}
+                            className="rounded-lg border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-800 disabled:opacity-60"
+                        >
+                            {integration.savingSettings ? "Saving\u2026" : "Save Settings"}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={integration.testConnection}
+                            disabled={integration.testStatus === "testing"}
+                            className="inline-flex items-center gap-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-semibold px-3 py-2 transition disabled:opacity-70"
+                        >
+                            {integration.testStatus === "testing"
+                                ? "Testing\u2026"
+                                : integration.testStatus === "success"
+                                  ? "Retest"
+                                  : "Test connection"}
+                        </button>
+                    </div>
+                </div>
+            </ConfigPanel>
+
+            {/* Mode toggle */}
+            <div className="flex gap-1 rounded-lg bg-slate-800/50 p-1 w-fit">
+                {(["user", "ranking", "seasonal"] as const).map((m) => (
+                    <button
+                        key={m}
+                        type="button"
+                        onClick={() => setMode(m)}
+                        className={`px-3 py-1.5 rounded-md text-xs font-medium transition ${
+                            mode === m
+                                ? "bg-primary text-white"
+                                : "text-slate-400 hover:text-slate-200"
+                        }`}
+                    >
+                        {m === "user" ? "User Lists" : m === "ranking" ? "Rankings" : "Seasonal"}
+                    </button>
+                ))}
+            </div>
+
+            {/* Add form — user lists */}
+            {mode === "user" && (
+                <div className="flex gap-2 items-center flex-wrap">
+                    <input
+                        type="text"
+                        placeholder="Username"
+                        className="w-46 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        disabled={formDisabled}
+                    />
+                    <ListTypeSelect
+                        value={statusFilter}
+                        onChange={handleStatusChange}
+                        disabled={formDisabled}
+                        options={STATUS_OPTIONS}
+                    />
+                    <LibrarySelect
+                        value={plexLibrary}
+                        onChange={setPlexLibrary}
+                        libraries={enabledLibraries}
+                        disabled={formDisabled}
+                    />
+                    <input
+                        type="text"
+                        placeholder="Collection name"
+                        className="w-80 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={collectionName}
+                        onChange={(e) => {
+                            setCollectionName(e.target.value);
+                            setNameManuallyEdited(true);
+                        }}
+                        disabled={formDisabled}
+                    />
+                    <button
+                        type="button"
+                        onClick={handleAddUser}
+                        disabled={formDisabled || !canAddUser}
+                        className="shrink-0 cursor-pointer rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                        {integration.savingSource ? "Adding\u2026" : "Add List"}
+                    </button>
+                </div>
+            )}
+
+            {/* Add form — rankings */}
+            {mode === "ranking" && (
+                <div className="flex gap-2 items-center flex-wrap">
+                    <ListTypeSelect
+                        value={rankingType}
+                        onChange={handleRankingTypeChange}
+                        disabled={formDisabled}
+                        options={RANKING_OPTIONS}
+                        showAllOption={false}
+                    />
+                    <LibrarySelect
+                        value={rankingPlexLibrary}
+                        onChange={setRankingPlexLibrary}
+                        libraries={enabledLibraries}
+                        disabled={formDisabled}
+                    />
+                    <MaxItemsStepper
+                        value={rankingMaxItems}
+                        onChange={setRankingMaxItems}
+                        disabled={formDisabled}
+                    />
+                    <input
+                        type="text"
+                        placeholder="Collection name"
+                        className="w-80 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={rankingCollectionName}
+                        onChange={(e) => {
+                            setRankingCollectionName(e.target.value);
+                            setRankingNameManuallyEdited(true);
+                        }}
+                        disabled={formDisabled}
+                    />
+                    <button
+                        type="button"
+                        onClick={handleAddRanking}
+                        disabled={formDisabled || !canAddRanking}
+                        className="shrink-0 cursor-pointer rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                        {integration.savingSource ? "Adding\u2026" : "Add List"}
+                    </button>
+                </div>
+            )}
+
+            {/* Add form — seasonal */}
+            {mode === "seasonal" && (
+                <div className="flex gap-2 items-center flex-wrap">
+                    <Listbox
+                        value={seasonYear}
+                        onChange={(yr: number) => {
+                            setSeasonYear(yr);
+                            if (!seasonNameManuallyEdited && season) {
+                                setSeasonCollectionName(`MAL ${capitalize(season)} ${yr}`);
+                            }
+                        }}
+                        disabled={formDisabled}
+                    >
+                        <div className="relative w-24">
+                            <Listbox.Button className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-left text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 disabled:opacity-60 flex items-center justify-between">
+                                <span>{seasonYear}</span>
+                                <ChevronDown className="h-4 w-4 text-slate-400" />
+                            </Listbox.Button>
+                            <Listbox.Options className="absolute left-0 top-full z-50 mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 py-1 shadow-lg focus:outline-none max-h-48 overflow-auto scrollbar-thin">
+                                {yearOptions.map((yr) => (
+                                    <Listbox.Option
+                                        key={yr}
+                                        value={yr}
+                                        className="cursor-pointer px-3 py-2 text-sm text-slate-100 hover:bg-slate-800 data-[selected]:bg-primary/20 data-[selected]:font-semibold flex items-center justify-between gap-3"
+                                    >
+                                        {({ selected: isSelected }) => (
+                                            <>
+                                                <span>{yr}</span>
+                                                {isSelected && <Check className="h-4 w-4 text-primary" />}
+                                            </>
+                                        )}
+                                    </Listbox.Option>
+                                ))}
+                            </Listbox.Options>
+                        </div>
+                    </Listbox>
+                    <ListTypeSelect
+                        value={season}
+                        onChange={handleSeasonChange}
+                        disabled={formDisabled}
+                        options={SEASON_OPTIONS}
+                        showAllOption={false}
+                    />
+                    <LibrarySelect
+                        value={seasonPlexLibrary}
+                        onChange={setSeasonPlexLibrary}
+                        libraries={enabledLibraries}
+                        disabled={formDisabled}
+                    />
+                    <MaxItemsStepper
+                        value={seasonMaxItems}
+                        onChange={setSeasonMaxItems}
+                        disabled={formDisabled}
+                    />
+                    <input
+                        type="text"
+                        placeholder="Collection name"
+                        className="w-80 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                        value={seasonCollectionName}
+                        onChange={(e) => {
+                            setSeasonCollectionName(e.target.value);
+                            setSeasonNameManuallyEdited(true);
+                        }}
+                        disabled={formDisabled}
+                    />
+                    <button
+                        type="button"
+                        onClick={handleAddSeasonal}
+                        disabled={formDisabled || !canAddSeasonal}
+                        className="shrink-0 cursor-pointer rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition hover:bg-blue-600 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                        {integration.savingSource ? "Adding\u2026" : "Add List"}
+                    </button>
+                </div>
+            )}
+
+            {/* Source list */}
+            <SourceList<MALMissingItem>
+                sources={integration.sources}
+                statuses={integration.statuses}
+                onSyncSource={integration.syncSource}
+                onRemoveSource={integration.removeSource}
+                loadingSources={integration.loadingSources}
+                syncingSource={integration.syncingSource}
+                deletingSource={integration.deletingSource}
+                missingItems={integration.missingItems}
+                expandedMissing={integration.expandedMissing}
+                missingPages={integration.missingPages}
+                loadingMissing={integration.loadingMissing}
+                onToggleMissing={integration.toggleMissingItems}
+                onSetMissingPage={integration.setMissingPage}
+                renderMissingItem={(item, i) => (
+                    <div
+                        key={i}
+                        className="flex items-start justify-between gap-3 rounded-md border border-slate-800/40 bg-slate-950/40 px-3 py-2"
+                    >
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                                <p className="text-xs font-medium text-slate-200 truncate">
+                                    {item.title}
+                                    {item.year ? ` (${item.year})` : ""}
+                                </p>
+                                {item.media_type && (
+                                    <span className="shrink-0 rounded bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-400">
+                                        {MEDIA_TYPE_LABELS[item.media_type] ?? item.media_type}
+                                    </span>
+                                )}
+                            </div>
+                            {item.mal_id && (
+                                <a
+                                    href={`https://myanimelist.net/anime/${item.mal_id}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs text-primary hover:underline"
+                                >
+                                    View on MAL
+                                </a>
+                            )}
+                        </div>
+                        <div className="text-xs text-slate-500 whitespace-nowrap">
+                            {formatDate(item.last_seen)}
+                        </div>
+                    </div>
+                )}
+            />
+
+            {integration.toast && (
+                <Toast
+                    message={integration.toast.message}
+                    type={integration.toast.type}
+                    onClose={integration.clearToast}
+                />
+            )}
+        </div>
+    );
+}

--- a/homescreen-hero-ui/src/pages/IntegrationsPage.tsx
+++ b/homescreen-hero-ui/src/pages/IntegrationsPage.tsx
@@ -61,6 +61,15 @@ export default function IntegrationsPage() {
                 <Tab.Panels>
                     {tabs.map((tab) => (
                         <Tab.Panel key={tab.name} className="space-y-4 focus:outline-none">
+                            {tab.key === "letterboxd" && (
+                                <div className="rounded-lg border border-blue-700/50 bg-blue-900/20 px-4 py-3">
+                                    <p className="text-xs text-blue-200">
+                                        <strong>Note:</strong> Letterboxd integration uses web scraping since their
+                                        API requires approval. Movies are matched by title and year, which may be
+                                        less accurate than ID-based matching.
+                                    </p>
+                                </div>
+                            )}
                             {tab.component ? (
                                 <tab.component />
                             ) : (

--- a/homescreen-hero-ui/src/types/integrations.ts
+++ b/homescreen-hero-ui/src/types/integrations.ts
@@ -63,6 +63,16 @@ export interface AniListMissingItem extends BaseMissingItem {
     tvdb_id: number | null;
 }
 
+// MAL-specific missing item
+export interface MALMissingItem extends BaseMissingItem {
+    media_type: string | null;
+    mal_id: number | null;
+    anilist_id: number | null;
+    tmdb_id: number | null;
+    imdb_id: string | null;
+    tvdb_id: number | null;
+}
+
 // Settings types
 export interface TraktSettings {
     enabled: boolean;
@@ -90,6 +100,11 @@ export interface SeerrSettings {
     enabled: boolean;
     api_key: string;
     base_url: string;
+}
+
+export interface MALSettings {
+    enabled: boolean;
+    client_id: string;
 }
 
 export interface PlexLibraryConfig {

--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -163,6 +163,18 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             logger.info("Using Tautulli base URL from HSH_TAUTULLI_BASE_URL environment variable")
             config.tautulli.base_url = tautulli_base_url
 
+    # MAL Client ID override (if MAL is enabled)
+    if config.mal and config.mal.enabled:
+        mal_client_id = os.getenv("HSH_MAL_CLIENT_ID")
+        if mal_client_id:
+            logger.info("Using MAL Client ID from HSH_MAL_CLIENT_ID environment variable")
+            config.mal.client_id = mal_client_id
+        elif not config.mal.client_id:
+            raise ValueError(
+                "MAL Client ID is required when MAL is enabled. "
+                "Set it in config.yaml or via HSH_MAL_CLIENT_ID environment variable"
+            )
+
     # Seerr API key override (if Seerr is enabled)
     if config.seerr and config.seerr.enabled:
         seerr_api_key = os.getenv("HSH_SEERR_API_KEY")
@@ -223,6 +235,10 @@ def _validate_collection_references(config: AppConfig) -> None:
 
     if config.anilist and config.anilist.sources:
         for source in config.anilist.sources:
+            integration_collections.add(source.name)
+
+    if config.mal and config.mal.enabled and config.mal.sources:
+        for source in config.mal.sources:
             integration_collections.add(source.name)
 
     # Check each group for collections that don't have integration sources

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -247,6 +247,30 @@ class AniListSettings(BaseModel):
     sources: List[AniListSource] = Field(default_factory=list)
 
 
+class MALSource(BaseModel):
+    name: str = Field(..., description="Display name for this list (becomes Plex collection name)")
+    url: str = Field(..., description="MAL user list URL or mal://ranking/... or mal://season/...")
+    plex_library: str = Field(..., description="Target Plex library name")
+    max_items: Optional[int] = Field(
+        default=100,
+        ge=10,
+        le=500,
+        description="Maximum number of items to fetch for ranking/seasonal lists (ignored for user lists)",
+    )
+
+
+class MALSettings(BaseModel):
+    enabled: bool = Field(
+        default=False,
+        description="Whether MAL integration is enabled",
+    )
+    client_id: Optional[str] = Field(
+        default=None,
+        description="MAL Client ID (can be set via HSH_MAL_CLIENT_ID env var)",
+    )
+    sources: List[MALSource] = Field(default_factory=list)
+
+
 class TautulliSettings(BaseModel):
     # Tautulli connection details for analytics.
     enabled: bool = Field(
@@ -306,6 +330,7 @@ class AppConfig(BaseModel):
     letterboxd: Optional[LetterboxdSettings] = None
     mdblist: Optional[MDBListSettings] = None
     anilist: Optional[AniListSettings] = None
+    mal: Optional[MALSettings] = None
     tautulli: Optional[TautulliSettings] = None
     seerr: Optional[SeerrSettings] = None
     logging: LoggingSettings = LoggingSettings()

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -193,6 +193,43 @@ class AniListMissingItem(Base):
     times_seen: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
 
 
+class MALMissingItem(Base):
+    __tablename__ = "mal_missing_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Which MAL source this came from
+    source_name: Mapped[str] = mapped_column(String, nullable=False)
+    source_url: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Where we expected to find it in Plex
+    plex_library: Mapped[str] = mapped_column(String, nullable=False)
+    plex_collection: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Media identity
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    year: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    media_type: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    # MAL ID
+    mal_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Mapped IDs (from anime-lists)
+    anilist_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tmdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    imdb_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    tvdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Tracking
+    first_seen: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
+    last_seen: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
+    times_seen: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+
 class CollectionAnalytics(Base):
     # Analytics snapshots for collection watch statistics from Tautulli
     __tablename__ = "collection_analytics"

--- a/homescreen_hero/core/integrations/__init__.py
+++ b/homescreen_hero/core/integrations/__init__.py
@@ -4,6 +4,7 @@ from .trakt_sync import sync_all_trakt_sources
 from .letterboxd_sync import sync_all_letterboxd_sources
 from .mdblist_sync import sync_all_mdblist_sources
 from .anilist_sync import sync_all_anilist_sources
+from .mal_sync import sync_all_mal_sources
 
 __all__ = [
     "get_plex_server",
@@ -12,5 +13,6 @@ __all__ = [
     "sync_all_letterboxd_sources",
     "sync_all_mdblist_sources",
     "sync_all_anilist_sources",
+    "sync_all_mal_sources",
     "apply_home_screen_selection",
 ]

--- a/homescreen_hero/core/integrations/anime_id_map.py
+++ b/homescreen_hero/core/integrations/anime_id_map.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+# Shared anime-lists mapping download, cache, and indexing.
+# Used by both AniList sync (indexes by anilist_id) and MAL sync (indexes by mal_id).
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+ANIME_LIST_URL = (
+    "https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-full.json"
+)
+ANIME_LIST_CACHE_FILE = "anime-list-full.json"
+ANIME_LIST_MAX_AGE_SECONDS = 86400  # 24 hours
+
+
+def _get_data_dir() -> Path:
+    data_dir = Path(os.getenv("HSH_DATA_DIR", "data"))
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir
+
+
+def _load_raw_anime_list(data_dir: Optional[Path] = None) -> List[Dict[str, Any]]:
+    # Download (or load from cache) the raw anime-lists JSON array
+    if data_dir is None:
+        data_dir = _get_data_dir()
+
+    cache_path = data_dir / ANIME_LIST_CACHE_FILE
+    needs_download = True
+
+    if cache_path.exists():
+        age = time.time() - cache_path.stat().st_mtime
+        if age < ANIME_LIST_MAX_AGE_SECONDS:
+            needs_download = False
+
+    if needs_download:
+        logger.info("Downloading anime-lists mapping from GitHub...")
+        try:
+            resp = requests.get(ANIME_LIST_URL, timeout=60)
+            resp.raise_for_status()
+            cache_path.write_bytes(resp.content)
+            logger.info(
+                "Anime-lists mapping downloaded and cached (%d bytes)", len(resp.content)
+            )
+        except Exception as exc:
+            if cache_path.exists():
+                logger.warning(
+                    "Failed to refresh anime-lists mapping: %s. Using cached version.",
+                    exc,
+                )
+            else:
+                logger.error("Failed to download anime-lists mapping: %s", exc)
+                return []
+
+    try:
+        return json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.error("Failed to parse anime-lists JSON: %s", exc)
+        return []
+
+
+def load_anime_id_map_by_anilist(
+    data_dir: Optional[Path] = None,
+) -> Dict[int, Dict[str, Any]]:
+    # Returns {anilist_id: {tmdb_id, imdb_id, tvdb_id, type}}
+    raw = _load_raw_anime_list(data_dir)
+    id_map: Dict[int, Dict[str, Any]] = {}
+    for entry in raw:
+        anilist_id = entry.get("anilist_id")
+        if anilist_id is None:
+            continue
+        id_map[anilist_id] = {
+            "tmdb_id": entry.get("themoviedb_id"),
+            "imdb_id": entry.get("imdb_id"),
+            "tvdb_id": entry.get("tvdb_id"),
+            "type": entry.get("type"),
+        }
+
+    logger.info(
+        "Loaded anime-lists mapping: %d entries indexed by AniList ID", len(id_map)
+    )
+    return id_map
+
+
+def load_anime_id_map_by_mal(
+    data_dir: Optional[Path] = None,
+) -> Dict[int, Dict[str, Any]]:
+    # Returns {mal_id: {tmdb_id, imdb_id, tvdb_id, anilist_id, type}}
+    raw = _load_raw_anime_list(data_dir)
+    id_map: Dict[int, Dict[str, Any]] = {}
+    for entry in raw:
+        mal_id = entry.get("mal_id")
+        if mal_id is None:
+            continue
+        id_map[mal_id] = {
+            "tmdb_id": entry.get("themoviedb_id"),
+            "imdb_id": entry.get("imdb_id"),
+            "tvdb_id": entry.get("tvdb_id"),
+            "anilist_id": entry.get("anilist_id"),
+            "type": entry.get("type"),
+        }
+
+    logger.info(
+        "Loaded anime-lists mapping: %d entries indexed by MAL ID", len(id_map)
+    )
+    return id_map

--- a/homescreen_hero/core/integrations/mal_client.py
+++ b/homescreen_hero/core/integrations/mal_client.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+MAL_API_BASE = "https://api.myanimelist.net/v2"
+MAL_FIELDS = "id,title,alternative_titles,media_type,num_episodes,start_season"
+MAL_PAGE_LIMIT = 100  # max per request
+
+# MAL media_type values
+SHOW_TYPES = {"tv", "ova", "ona", "special"}
+MOVIE_TYPES = {"movie"}
+
+# Ranking type options
+RANKING_OPTIONS = {
+    "all": "All",
+    "airing": "Airing",
+    "upcoming": "Upcoming",
+    "bypopularity": "Most Popular",
+    "favorite": "Most Favorited",
+}
+
+SEASONS = ["winter", "spring", "summer", "fall"]
+
+# URL patterns
+_USER_URL_PATTERN = re.compile(
+    r"https?://myanimelist\.net/animelist/([^/?#]+)(?:\?.*)?",
+    re.IGNORECASE,
+)
+_RANKING_URL_PATTERN = re.compile(r"mal://ranking/([a-z]+)", re.IGNORECASE)
+_SEASON_URL_PATTERN = re.compile(r"mal://season/(\d{4})/([a-z]+)", re.IGNORECASE)
+
+# MAL animelist status values
+MAL_STATUSES = {
+    "watching": "Watching",
+    "completed": "Completed",
+    "on_hold": "On Hold",
+    "dropped": "Dropped",
+    "plan_to_watch": "Plan to Watch",
+}
+
+# MAL website uses numeric status values in URLs
+_NUMERIC_STATUS_MAP = {
+    "1": "watching",
+    "2": "completed",
+    "3": "on_hold",
+    "4": "dropped",
+    "6": "plan_to_watch",
+}
+
+
+@dataclass
+class MALConfig:
+    client_id: str
+    base_url: str = MAL_API_BASE
+
+
+@dataclass
+class MALItem:
+    mal_id: int
+    title: str
+    title_en: Optional[str]
+    title_ja: Optional[str]
+    year: Optional[int]
+    media_type: Optional[str]  # tv, movie, ova, ona, special, etc.
+    num_episodes: Optional[int]
+
+
+class MALClient:
+    def __init__(self, cfg: MALConfig):
+        self.cfg = cfg
+        self.session = requests.Session()
+        self.session.headers.update({
+            "X-MAL-Client-ID": cfg.client_id,
+        })
+        self._last_request_time = 0.0
+
+    def _rate_limit(self):
+        # ~1 req/sec to respect MAL's unofficial rate limit
+        elapsed = time.time() - self._last_request_time
+        if elapsed < 1.0:
+            time.sleep(1.0 - elapsed)
+        self._last_request_time = time.time()
+
+    def _parse_item(self, node: dict) -> MALItem:
+        alt = node.get("alternative_titles") or {}
+        start_season = node.get("start_season") or {}
+        return MALItem(
+            mal_id=node["id"],
+            title=node.get("title", ""),
+            title_en=alt.get("en") or None,
+            title_ja=alt.get("ja") or None,
+            year=start_season.get("year"),
+            media_type=node.get("media_type"),
+            num_episodes=node.get("num_episodes"),
+        )
+
+    def ping(self) -> Tuple[bool, Optional[str]]:
+        try:
+            self._rate_limit()
+            resp = self.session.get(
+                f"{self.cfg.base_url}/anime/ranking",
+                params={"ranking_type": "all", "limit": 1, "fields": "id"},
+                timeout=10,
+            )
+            if resp.status_code == 403:
+                return False, "Invalid MAL Client ID"
+            if resp.status_code == 429:
+                return False, "MAL API rate limited"
+            resp.raise_for_status()
+            return True, None
+        except requests.ConnectionError:
+            return False, "Could not connect to MAL API"
+        except requests.Timeout:
+            return False, "MAL API request timed out"
+        except requests.HTTPError as exc:
+            return False, f"MAL API returned HTTP {exc.response.status_code}"
+        except Exception as exc:
+            return False, str(exc)
+
+    def get_user_list(
+        self,
+        username: str,
+        status: Optional[str] = None,
+    ) -> List[MALItem]:
+        items: List[MALItem] = []
+        seen_ids: set[int] = set()
+        offset = 0
+
+        while True:
+            self._rate_limit()
+            params: Dict[str, Any] = {
+                "fields": MAL_FIELDS,
+                "limit": MAL_PAGE_LIMIT,
+                "offset": offset,
+                "nsfw": "true",
+            }
+            if status:
+                params["status"] = status
+
+            resp = self.session.get(
+                f"{self.cfg.base_url}/users/{username}/animelist",
+                params=params,
+                timeout=30,
+            )
+            if resp.status_code == 429:
+                raise RuntimeError("MAL API rate limited -- try again later")
+            resp.raise_for_status()
+
+            data = resp.json()
+            for entry in data.get("data") or []:
+                node = entry.get("node") or {}
+                mal_id = node.get("id")
+                if not mal_id or mal_id in seen_ids:
+                    continue
+                seen_ids.add(mal_id)
+                items.append(self._parse_item(node))
+
+            if not data.get("paging", {}).get("next"):
+                break
+            offset += MAL_PAGE_LIMIT
+
+        logger.info("Fetched %d anime from MAL user '%s'", len(items), username)
+        return items
+
+    def get_ranking_list(
+        self,
+        ranking_type: str,
+        max_items: int = 100,
+    ) -> List[MALItem]:
+        if ranking_type not in RANKING_OPTIONS:
+            raise ValueError(
+                f"Unknown ranking type: {ranking_type}. "
+                f"Valid: {list(RANKING_OPTIONS.keys())}"
+            )
+
+        items: List[MALItem] = []
+        seen_ids: set[int] = set()
+        offset = 0
+
+        while len(items) < max_items:
+            self._rate_limit()
+            limit = min(MAL_PAGE_LIMIT, max_items - len(items))
+            resp = self.session.get(
+                f"{self.cfg.base_url}/anime/ranking",
+                params={
+                    "ranking_type": ranking_type,
+                    "limit": limit,
+                    "offset": offset,
+                    "fields": MAL_FIELDS,
+                    "nsfw": "true",
+                },
+                timeout=30,
+            )
+            if resp.status_code == 429:
+                raise RuntimeError("MAL API rate limited -- try again later")
+            resp.raise_for_status()
+
+            data = resp.json()
+            for entry in data.get("data") or []:
+                node = entry.get("node") or {}
+                mal_id = node.get("id")
+                if not mal_id or mal_id in seen_ids:
+                    continue
+                seen_ids.add(mal_id)
+                items.append(self._parse_item(node))
+
+            if not data.get("paging", {}).get("next"):
+                break
+            offset += limit
+
+        items = items[:max_items]
+        logger.info(
+            "Fetched %d anime from MAL ranking '%s'", len(items), ranking_type
+        )
+        return items
+
+    def get_seasonal_list(
+        self,
+        year: int,
+        season: str,
+        max_items: int = 100,
+    ) -> List[MALItem]:
+        if season not in SEASONS:
+            raise ValueError(f"Unknown season: {season}. Valid: {SEASONS}")
+
+        items: List[MALItem] = []
+        seen_ids: set[int] = set()
+        offset = 0
+
+        while len(items) < max_items:
+            self._rate_limit()
+            limit = min(MAL_PAGE_LIMIT, max_items - len(items))
+            resp = self.session.get(
+                f"{self.cfg.base_url}/anime/season/{year}/{season}",
+                params={
+                    "sort": "anime_score",
+                    "limit": limit,
+                    "offset": offset,
+                    "fields": MAL_FIELDS,
+                    "nsfw": "true",
+                },
+                timeout=30,
+            )
+            if resp.status_code == 429:
+                raise RuntimeError("MAL API rate limited -- try again later")
+            resp.raise_for_status()
+
+            data = resp.json()
+            for entry in data.get("data") or []:
+                node = entry.get("node") or {}
+                mal_id = node.get("id")
+                if not mal_id or mal_id in seen_ids:
+                    continue
+                seen_ids.add(mal_id)
+                items.append(self._parse_item(node))
+
+            if not data.get("paging", {}).get("next"):
+                break
+            offset += limit
+
+        items = items[:max_items]
+        logger.info(
+            "Fetched %d anime from MAL season %s %d", len(items), season, year
+        )
+        return items
+
+
+# URL parsing helpers
+
+def is_ranking_url(url: str) -> bool:
+    return url.strip().startswith("mal://ranking/")
+
+
+def is_season_url(url: str) -> bool:
+    return url.strip().startswith("mal://season/")
+
+
+def is_browse_url(url: str) -> bool:
+    return is_ranking_url(url) or is_season_url(url)
+
+
+def parse_ranking_url(url: str) -> str:
+    # Extract ranking_type from mal://ranking/{type}
+    match = _RANKING_URL_PATTERN.match(url.strip())
+    if not match:
+        raise ValueError(f"Invalid MAL ranking URL: {url}")
+    ranking_type = match.group(1)
+    if ranking_type not in RANKING_OPTIONS:
+        raise ValueError(
+            f"Unknown ranking type: {ranking_type}. "
+            f"Valid: {list(RANKING_OPTIONS.keys())}"
+        )
+    return ranking_type
+
+
+def parse_season_url(url: str) -> Tuple[int, str]:
+    # Extract (year, season) from mal://season/{year}/{season}
+    match = _SEASON_URL_PATTERN.match(url.strip())
+    if not match:
+        raise ValueError(f"Invalid MAL season URL: {url}")
+    year = int(match.group(1))
+    season = match.group(2)
+    if season not in SEASONS:
+        raise ValueError(f"Unknown season: {season}. Valid: {SEASONS}")
+    return year, season
+
+
+def parse_mal_user_url(url: str) -> Tuple[str, Optional[str]]:
+    # Extract (username, status_or_None) from MAL user list URL
+    match = _USER_URL_PATTERN.match(url.strip())
+    if not match:
+        raise ValueError(
+            f"Invalid MAL URL: {url}. "
+            "Expected: https://myanimelist.net/animelist/username"
+        )
+    username = match.group(1)
+
+    # Parse status from query string if present
+    # MAL website uses numeric values (e.g. ?status=2), API uses text keys
+    status = None
+    if "?" in url:
+        from urllib.parse import parse_qs, urlparse
+        qs = parse_qs(urlparse(url).query)
+        status_val = qs.get("status", [None])[0]
+        if status_val:
+            status_val = _NUMERIC_STATUS_MAP.get(status_val, status_val)
+            if status_val in MAL_STATUSES:
+                status = status_val
+
+    return username, status
+
+
+def get_mal_client(config) -> Optional[MALClient]:
+    if not config.mal:
+        return None
+    if not config.mal.enabled:
+        return None
+    client_id = config.mal.client_id
+    if not client_id:
+        return None
+    return MALClient(MALConfig(client_id=client_id))

--- a/homescreen_hero/core/integrations/mal_sync.py
+++ b/homescreen_hero/core/integrations/mal_sync.py
@@ -7,17 +7,21 @@ from typing import Any, Dict, List, Optional, Tuple
 from plexapi.exceptions import NotFound
 from plexapi.server import PlexServer
 
-from homescreen_hero.core.config.schema import AppConfig, AniListSource
-from homescreen_hero.core.db.models import AniListMissingItem
+from homescreen_hero.core.config.schema import AppConfig, MALSource
+from homescreen_hero.core.db.models import MALMissingItem
 from homescreen_hero.core.db.sync_status import record_sync_result
-from homescreen_hero.core.integrations.anilist_client import (
-    AniListItem,
-    get_anilist_client,
+from homescreen_hero.core.integrations.anime_id_map import load_anime_id_map_by_mal
+from homescreen_hero.core.integrations.mal_client import (
+    MALClient,
+    MALConfig,
+    MALItem,
     is_browse_url,
-    parse_anilist_url,
-    parse_browse_url,
+    is_ranking_url,
+    is_season_url,
+    parse_mal_user_url,
+    parse_ranking_url,
+    parse_season_url,
 )
-from homescreen_hero.core.integrations.anime_id_map import load_anime_id_map_by_anilist
 from homescreen_hero.core.integrations.plex_match import (
     build_guid_map,
     normalize_title,
@@ -25,13 +29,12 @@ from homescreen_hero.core.integrations.plex_match import (
 
 logger = logging.getLogger(__name__)
 
-# AniList formats that map to Plex show libraries
-SHOW_FORMATS = {"TV", "TV_SHORT", "OVA", "ONA", "SPECIAL"}
-MOVIE_FORMATS = {"MOVIE"}
+# MAL media_type values that map to Plex show vs movie libraries
+SHOW_TYPES = {"tv", "ova", "ona", "special"}
+MOVIE_TYPES = {"movie"}
 
 
 def _guid_lookup(guid_map: dict, *keys: str):
-    # Try multiple GUID keys against the map, return first match
     for key in keys:
         if key and key in guid_map:
             return guid_map[key]
@@ -39,21 +42,18 @@ def _guid_lookup(guid_map: dict, *keys: str):
 
 
 def _match_item(
-    item: AniListItem,
+    item: MALItem,
     guid_map: dict,
     library,
     anime_id_map: Dict[int, Dict[str, Any]],
     is_movie_library: bool,
 ):
-    # Try to find a Plex item matching an AniList entry
-    # 1. Look up mapped IDs from anime-lists
-    mapped = anime_id_map.get(item.anilist_id, {})
+
+    mapped = anime_id_map.get(item.mal_id, {})
     tmdb_id = mapped.get("tmdb_id")
     imdb_id = mapped.get("imdb_id")
     tvdb_id = mapped.get("tvdb_id")
 
-    # 2. Direct GUID map lookup (no title fallback — avoids false positives
-    #    from find_show/find_movie searching Plex with empty/partial titles)
     if is_movie_library:
         plex_item = _guid_lookup(
             guid_map,
@@ -75,8 +75,8 @@ def _match_item(
     if plex_item:
         return plex_item
 
-    # 3. Fallback: title/year search
-    title = item.title_english or item.title_romaji
+    # Fallback: title/year search
+    title = item.title_en or item.title
     if not title:
         return None
 
@@ -91,36 +91,35 @@ def _match_item(
     if results:
         return results[0]
 
-    # Try romaji title if English title didn't match
-    if item.title_romaji and item.title_english and item.title_romaji != title:
-        romaji = item.title_romaji
+    # Try Japanese title if English title didn't match
+    if item.title_ja and item.title_ja != title:
         if item.year:
-            results = library.search(title=romaji, year=item.year)
+            results = library.search(title=item.title_ja, year=item.year)
         else:
-            results = library.search(title=romaji)
+            results = library.search(title=item.title_ja)
         if results:
             return results[0]
 
     return None
 
 
-def sync_single_anilist_source(
+def sync_single_mal_source(
     server: PlexServer,
     config: AppConfig,
-    source: AniListSource,
+    source: MALSource,
 ) -> Tuple[int, int]:
-    # Returns (total_items, matched_items)
-    # AniList needs no credentials, so create the client directly
-    from homescreen_hero.core.integrations.anilist_client import AniListClient, AniListConfig
-    client = AniListClient(AniListConfig())
-
-    logger.info("Syncing AniList source '%s' from %s", source.name, source.url)
-
-    if not source.plex_library:
-        logger.warning("AniList source '%s' has no plex_library set; skipping", source.name)
+    if not config.mal or not config.mal.client_id:
+        logger.warning("MAL is not configured; skipping sync for '%s'", source.name)
         return 0, 0
 
-    # Resolve the Plex library
+    client = MALClient(MALConfig(client_id=config.mal.client_id))
+
+    logger.info("Syncing MAL source '%s' from %s", source.name, source.url)
+
+    if not source.plex_library:
+        logger.warning("MAL source '%s' has no plex_library set; skipping", source.name)
+        return 0, 0
+
     try:
         library = server.library.section(source.plex_library)
     except NotFound:
@@ -129,62 +128,62 @@ def sync_single_anilist_source(
         except Exception:
             available = "unknown (failed to list libraries)"
         logger.error(
-            "AniList source '%s' references unknown Plex library '%s'. Available: %s. Skipping.",
+            "MAL source '%s' references unknown Plex library '%s'. Available: %s. Skipping.",
             source.name, source.plex_library, available,
         )
         return 0, 0
     except Exception as exc:
         logger.error(
-            "Unexpected error looking up Plex library '%s' for AniList source '%s': %s. Skipping.",
+            "Unexpected error looking up Plex library '%s' for MAL source '%s': %s. Skipping.",
             source.plex_library, source.name, exc,
         )
         return 0, 0
 
-    # Detect library type
     is_movie_library = library.type == "movie"
 
-    # Fetch items from AniList (browse list vs user list)
-    if is_browse_url(source.url):
+    max_items = source.max_items or 100
+    if is_ranking_url(source.url):
         try:
-            sort_key = parse_browse_url(source.url)
+            ranking_type = parse_ranking_url(source.url)
         except ValueError as exc:
-            logger.error("Invalid AniList browse URL for source '%s': %s", source.name, exc)
+            logger.error("Invalid MAL ranking URL for source '%s': %s", source.name, exc)
             return 0, 0
-        # Pre-filter by format at the API level so we get a full page of the right type
-        format_filter = list(MOVIE_FORMATS) if is_movie_library else list(SHOW_FORMATS)
-        max_items = source.max_items or 100
-        items = client.get_browse_list(sort_key, max_items=max_items, format_in=format_filter)
+        items = client.get_ranking_list(ranking_type, max_items=max_items)
+    elif is_season_url(source.url):
+        try:
+            year, season = parse_season_url(source.url)
+        except ValueError as exc:
+            logger.error("Invalid MAL season URL for source '%s': %s", source.name, exc)
+            return 0, 0
+        items = client.get_seasonal_list(year, season, max_items=max_items)
     else:
         try:
-            username, list_name = parse_anilist_url(source.url)
+            username, status = parse_mal_user_url(source.url)
         except ValueError as exc:
-            logger.error("Invalid AniList URL for source '%s': %s", source.name, exc)
+            logger.error("Invalid MAL URL for source '%s': %s", source.name, exc)
             return 0, 0
-        items = client.get_user_list(username, list_name)
+        items = client.get_user_list(username, status)
 
-    # Filter items by format based on library type
+    # Filter items by media_type based on library type
     if is_movie_library:
-        filtered_items = [i for i in items if i.media_format in MOVIE_FORMATS]
+        filtered_items = [i for i in items if i.media_type in MOVIE_TYPES]
     else:
-        filtered_items = [i for i in items if i.media_format in SHOW_FORMATS]
+        filtered_items = [i for i in items if i.media_type in SHOW_TYPES]
 
     if not filtered_items:
         logger.info(
-            "AniList source '%s': no %s items found (had %d total items)",
+            "MAL source '%s': no %s items found (had %d total items)",
             source.name,
             "movie" if is_movie_library else "show",
             len(items),
         )
         return len(items), 0
 
-    # Load anime-lists ID mapping
-    anime_id_map = load_anime_id_map_by_anilist()
+    anime_id_map = load_anime_id_map_by_mal()
 
-    # Build Plex GUID map
     logger.info("Building Plex library GUID index for '%s'...", source.plex_library)
     guid_map = build_guid_map(library)
 
-    # Get existing collection items for diff
     existing_collection_items = []
     try:
         existing_collection_items = library.collection(source.name).items()
@@ -202,23 +201,21 @@ def sync_single_anilist_source(
         if plex_item is not None:
             matched_items.append(plex_item)
         else:
-            mapped = anime_id_map.get(item.anilist_id, {})
+            mapped = anime_id_map.get(item.mal_id, {})
             missing_items.append({
-                "title": item.title_english or item.title_romaji or "Unknown",
+                "title": item.title_en or item.title or "Unknown",
                 "year": item.year,
-                "anilist_id": item.anilist_id,
                 "mal_id": item.mal_id,
-                "media_format": item.media_format,
+                "media_type": item.media_type,
+                "anilist_id": mapped.get("anilist_id"),
                 "tmdb_id": mapped.get("tmdb_id"),
                 "imdb_id": mapped.get("imdb_id"),
                 "tvdb_id": mapped.get("tvdb_id"),
             })
 
-    # Add matched items to the collection
     for plex_item in matched_items:
         plex_item.addCollection(source.name)
 
-    # Only remove items if we successfully fetched from AniList
     if items:
         new_keys = {item.ratingKey for item in matched_items}
         to_remove_keys = existing_ids - new_keys
@@ -234,7 +231,7 @@ def sync_single_anilist_source(
                     )
     else:
         logger.warning(
-            "AniList source '%s' returned no items — skipping removal to prevent data loss.",
+            "MAL source '%s' returned no items -- skipping removal to prevent data loss.",
             source.name,
         )
 
@@ -243,15 +240,15 @@ def sync_single_anilist_source(
     missing = len(missing_items)
 
     logger.info(
-        "AniList source '%s': total %d (%s), matched %d, missing %d",
+        "MAL source '%s': total %d (%s), matched %d, missing %d",
         source.name, total, "movies" if is_movie_library else "shows", matched, missing,
     )
 
     if missing_items:
         for m in missing_items:
             logger.debug(
-                "AniList missing in Plex: %s (%s) anilist_id=%s",
-                m.get("title"), m.get("year"), m.get("anilist_id"),
+                "MAL missing in Plex: %s (%s) mal_id=%s",
+                m.get("title"), m.get("year"), m.get("mal_id"),
             )
 
     record_missing_items_in_db(source, missing_items)
@@ -259,28 +256,28 @@ def sync_single_anilist_source(
     return total, matched
 
 
-def sync_all_anilist_sources(
+def sync_all_mal_sources(
     server: PlexServer,
     config: AppConfig,
 ) -> None:
-    if not config.anilist or not config.anilist.sources:
-        logger.info("No AniList sources configured; skipping AniList sync")
+    if not config.mal or not config.mal.enabled or not config.mal.sources:
+        logger.info("No MAL sources configured; skipping MAL sync")
         return
 
-    for source in config.anilist.sources:
+    for source in config.mal.sources:
         try:
-            total, matched = sync_single_anilist_source(server, config, source)
+            total, matched = sync_single_mal_source(server, config, source)
             record_sync_result(
-                integration_type="anilist",
+                integration_type="mal",
                 source_name=source.name,
                 source_url=source.url,
                 items_total=total,
                 items_matched=matched,
             )
         except Exception as e:
-            logger.error("Failed to sync AniList source '%s': %s", source.name, e, exc_info=True)
+            logger.error("Failed to sync MAL source '%s': %s", source.name, e, exc_info=True)
             record_sync_result(
-                integration_type="anilist",
+                integration_type="mal",
                 source_name=source.name,
                 source_url=source.url,
                 items_total=0,
@@ -291,7 +288,7 @@ def sync_all_anilist_sources(
 
 
 def record_missing_items_in_db(
-    source: AniListSource,
+    source: MALSource,
     missing_items: List[Dict[str, Any]],
 ) -> None:
     if not missing_items:
@@ -301,32 +298,32 @@ def record_missing_items_in_db(
 
     with get_session() as session:
         for m in missing_items:
-            anilist_id = m.get("anilist_id")
+            mal_id = m.get("mal_id")
             title = m.get("title")
             year = m.get("year")
 
-            existing = session.query(AniListMissingItem).filter(
-                AniListMissingItem.source_name == source.name,
-                AniListMissingItem.source_url == source.url,
-                AniListMissingItem.title == title,
-                AniListMissingItem.year == year,
-                AniListMissingItem.anilist_id == anilist_id,
+            existing = session.query(MALMissingItem).filter(
+                MALMissingItem.source_name == source.name,
+                MALMissingItem.source_url == source.url,
+                MALMissingItem.title == title,
+                MALMissingItem.year == year,
+                MALMissingItem.mal_id == mal_id,
             ).first()
 
             if existing:
                 existing.last_seen = datetime.utcnow()
                 existing.times_seen += 1
             else:
-                row = AniListMissingItem(
+                row = MALMissingItem(
                     source_name=source.name,
                     source_url=source.url,
                     plex_library=source.plex_library,
                     plex_collection=source.name,
                     title=title,
                     year=year,
-                    media_format=m.get("media_format"),
-                    anilist_id=anilist_id,
-                    mal_id=m.get("mal_id"),
+                    media_type=m.get("media_type"),
+                    mal_id=mal_id,
+                    anilist_id=m.get("anilist_id"),
                     tmdb_id=m.get("tmdb_id"),
                     imdb_id=m.get("imdb_id"),
                     tvdb_id=m.get("tvdb_id"),

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -11,6 +11,7 @@ from .integrations import (
     sync_all_letterboxd_sources,
     sync_all_mdblist_sources,
     sync_all_anilist_sources,
+    sync_all_mal_sources,
     apply_home_screen_selection,
 )
 from .integrations.plex_client import get_library_collections
@@ -119,6 +120,7 @@ def _sync_selected_collections(
     from .integrations.letterboxd_sync import sync_single_letterboxd_source
     from .integrations.mdblist_sync import sync_single_mdblist_source
     from .integrations.anilist_sync import sync_single_anilist_source
+    from .integrations.mal_sync import sync_single_mal_source
     from .db import record_sync_result
 
     # Build a map of collection name -> source for quick lookup
@@ -126,6 +128,7 @@ def _sync_selected_collections(
     letterboxd_sources = {}
     mdblist_sources = {}
     anilist_sources = {}
+    mal_sources = {}
 
     if config.trakt and config.trakt.enabled:
         for source in config.trakt.sources:
@@ -142,6 +145,10 @@ def _sync_selected_collections(
     if config.anilist and config.anilist.sources:
         for source in config.anilist.sources:
             anilist_sources[source.name] = source
+
+    if config.mal and config.mal.enabled:
+        for source in config.mal.sources:
+            mal_sources[source.name] = source
 
     def _sync_and_record(integration_type: str, source, sync_fn):
         try:
@@ -179,6 +186,9 @@ def _sync_selected_collections(
         elif collection_name in anilist_sources:
             logger.info(f"Syncing selected AniList collection: {collection_name}")
             _sync_and_record("anilist", anilist_sources[collection_name], sync_single_anilist_source)
+        elif collection_name in mal_sources:
+            logger.info(f"Syncing selected MAL collection: {collection_name}")
+            _sync_and_record("mal", mal_sources[collection_name], sync_single_mal_source)
         else:
             logger.debug(f"Collection '{collection_name}' is not a synced source, skipping sync")
 
@@ -237,6 +247,10 @@ def run_rotation_once(
             sync_all_anilist_sources(server, config)
         except Exception as e:
             logger.error("AniList sync failed, continuing with rotation: %s", e)
+        try:
+            sync_all_mal_sources(server, config)
+        except Exception as e:
+            logger.error("MAL sync failed, continuing with rotation: %s", e)
     else:
         # First, select collections to determine which ones need syncing
         logger.info("Selective sync mode: will only sync collections selected for rotation")
@@ -432,6 +446,7 @@ def sync_all_sources(config: Optional[AppConfig] = None) -> Dict[str, int]:
     sync_all_letterboxd_sources(server, config)
     sync_all_mdblist_sources(server, config)
     sync_all_anilist_sources(server, config)
+    sync_all_mal_sources(server, config)
 
     logger.info("Manual sync complete")
 

--- a/homescreen_hero/web/routers/config/groups.py
+++ b/homescreen_hero/web/routers/config/groups.py
@@ -17,6 +17,7 @@ from homescreen_hero.core.config.schema import (
     LetterboxdSettings,
     MDBListSettings,
     AniListSettings,
+    MALSettings,
 )
 from homescreen_hero.core.integrations.plex_client import get_plex_server
 
@@ -257,9 +258,21 @@ def list_group_sources(current_user: str = Depends(get_current_user)) -> Collect
                     )
                 )
 
+        mal_sources: list[CollectionSourcesResponse.CollectionSource] = []
+        mal_cfg: Optional[MALSettings] = getattr(config, "mal", None)
+        if mal_cfg and getattr(mal_cfg, "sources", None):
+            for src in mal_cfg.sources:
+                mal_sources.append(
+                    CollectionSourcesResponse.CollectionSource(
+                        name=src.name,
+                        source="mal",
+                        detail=src.plex_library or src.url,
+                    )
+                )
+
         # Plex collections created by third-party sync duplicate those sources.
         # Filter them out so the UI only shows the authoritative source.
-        third_party_names = {s.name for s in trakt_sources + letterboxd_sources + mdblist_sources + anilist_sources}
+        third_party_names = {s.name for s in trakt_sources + letterboxd_sources + mdblist_sources + anilist_sources + mal_sources}
         plex_sources = [s for s in plex_sources if s.name not in third_party_names]
 
         return CollectionSourcesResponse(
@@ -268,6 +281,7 @@ def list_group_sources(current_user: str = Depends(get_current_user)) -> Collect
             letterboxd=letterboxd_sources,
             mdblist=mdblist_sources,
             anilist=anilist_sources,
+            mal=mal_sources,
         )
     except Exception as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/homescreen_hero/web/routers/config/helpers.py
+++ b/homescreen_hero/web/routers/config/helpers.py
@@ -84,10 +84,23 @@ def load_anilist_sources(data: dict) -> list[dict]:
     return list(sources or [])
 
 
+def load_mal_sources(data: dict) -> list[dict]:
+    # Extract the list of MAL sources from config mapping
+    mal_section = data.get("mal")
+    if mal_section and not isinstance(mal_section, dict):
+        raise ValueError("config.mal must be a mapping if present")
+
+    sources = mal_section.get("sources") if isinstance(mal_section, dict) else []
+    if sources and not isinstance(sources, list):
+        raise ValueError("config.mal.sources must be a list")
+
+    return list(sources or [])
+
+
 def get_all_source_names(data: dict) -> set[str]:
     # Collect all source names across integrations (used for duplicate validation)
     names: set[str] = set()
-    for section_key in ("trakt", "letterboxd", "mdblist", "anilist"):
+    for section_key in ("trakt", "letterboxd", "mdblist", "anilist", "mal"):
         section = data.get(section_key)
         if not isinstance(section, dict):
             continue

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -16,6 +16,8 @@ from homescreen_hero.core.config.schema import (
     MDBListSource,
     AniListSettings,
     AniListSource,
+    MALSettings,
+    MALSource,
     TautulliSettings,
     SeerrSettings,
     CollectionGroupConfig,
@@ -91,6 +93,16 @@ class AniListSourcePayload(AniListSource):
     pass
 
 
+# Incoming payload for MAL settings updates.
+class MALConfigSaveRequest(MALSettings):
+    pass
+
+
+# Incoming payload for MAL source create/update operations.
+class MALSourcePayload(MALSource):
+    pass
+
+
 # Incoming payload for Tautulli settings updates.
 class TautulliConfigSaveRequest(TautulliSettings):
     pass
@@ -124,7 +136,7 @@ class GroupReorderRequest(BaseModel):
 class CollectionSourcesResponse(BaseModel):
     class CollectionSource(BaseModel):
         name: str
-        source: Literal["plex", "trakt", "letterboxd", "mdblist", "anilist"]
+        source: Literal["plex", "trakt", "letterboxd", "mdblist", "anilist", "mal"]
         detail: Optional[str] = None
 
     plex: List[CollectionSource]
@@ -132,6 +144,7 @@ class CollectionSourcesResponse(BaseModel):
     letterboxd: List[CollectionSource]
     mdblist: List[CollectionSource]
     anilist: List[CollectionSource]
+    mal: List[CollectionSource]
 
 
 # Status information for a Trakt source including sync history.
@@ -270,6 +283,42 @@ class AniListMissingItemOut(BaseModel):
     times_seen: int
 
 
+# Status information for a MAL source including sync history.
+class MALSourceStatus(BaseModel):
+    source_index: int
+    name: str
+    last_sync_time: Optional[datetime] = None
+    sync_status: Literal["success", "error", "pending", "never_synced"]
+    error_message: Optional[str] = None
+    items_matched: int = 0
+    items_total: int = 0
+
+
+# Response from manual MAL sync operation.
+class MALSyncResponse(BaseModel):
+    ok: bool
+    message: str
+    items_total: int
+    items_matched: int
+    items_missing: int
+    sync_time: datetime
+
+
+# A MAL item that wasn't found in Plex.
+class MALMissingItemOut(BaseModel):
+    title: str
+    year: Optional[int]
+    media_type: Optional[str]
+    mal_id: Optional[int]
+    anilist_id: Optional[int]
+    tmdb_id: Optional[int]
+    imdb_id: Optional[str]
+    tvdb_id: Optional[int]
+    first_seen: datetime
+    last_seen: datetime
+    times_seen: int
+
+
 # Quick start setup endpoints
 class ConfigExistsResponse(BaseModel):
     exists: bool
@@ -289,6 +338,7 @@ class EnvVarsResponse(BaseModel):
     tautulli_url_from_env: bool
     seerr_api_key_from_env: bool
     seerr_url_from_env: bool
+    mal_client_id_from_env: bool
 
 
 # Request payload for testing Trakt connection with provided credentials.
@@ -313,6 +363,11 @@ class TautulliTestRequest(BaseModel):
 class SeerrTestRequest(BaseModel):
     api_key: Optional[str] = None  # Falls back to HSH_SEERR_API_KEY env var
     base_url: str = "http://localhost:5055"  # Falls back to HSH_SEERR_BASE_URL env var
+
+
+# Request payload for testing MAL connection with provided credentials.
+class MALTestRequest(BaseModel):
+    client_id: Optional[str] = None  # Falls back to HSH_MAL_CLIENT_ID env var
 
 
 # Response for connection test endpoints.

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -17,6 +17,7 @@ from homescreen_hero.core.config.schema import (
     LetterboxdSettings,
     MDBListSettings,
     AniListSettings,
+    MALSettings,
     TautulliSettings,
     SeerrSettings,
     DisplaySettings,
@@ -31,6 +32,7 @@ from .schemas import (
     LetterboxdConfigSaveRequest,
     MDBListConfigSaveRequest,
     AniListConfigSaveRequest,
+    MALConfigSaveRequest,
     TautulliConfigSaveRequest,
     SeerrConfigSaveRequest,
     RotationConfigSaveRequest,
@@ -314,6 +316,67 @@ def save_anilist_settings(
             path=str(config_path),
             env_override=CONFIG_ENV_VAR in os.environ,
             message="AniList settings saved and validated.",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ========================================================================
+# MAL SETTINGS
+# ========================================================================
+
+@router.get("/mal", response_model=MALSettings)
+def get_mal_settings(current_user: str = Depends(get_current_user)) -> MALSettings:
+    # Return the currently configured MAL settings
+    try:
+        config = load_config()
+        if config.mal is None:
+            return MALSettings(enabled=False, client_id=None, sources=[])
+        return config.mal
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/mal", response_model=ConfigSaveResponse)
+def save_mal_settings(
+    payload: MALConfigSaveRequest,
+    current_user: str = Depends(get_current_user)
+) -> ConfigSaveResponse:
+    # Update only MAL settings in config.yaml while preserving other keys
+    try:
+        data = load_config_mapping()
+
+        mal_section = data.get("mal") if isinstance(data.get("mal"), dict) else {}
+        mal_section = dict(mal_section)
+
+        # Only save client_id to config if it's not coming from environment variable
+        client_id_from_env = os.getenv("HSH_MAL_CLIENT_ID")
+        if client_id_from_env:
+            # Don't write client_id to config if it's set in environment
+            mal_section.pop("client_id", None)
+        else:
+            # Write client_id to config only if not using env var
+            mal_section["client_id"] = payload.client_id
+
+        mal_section.update(
+            enabled=payload.enabled,
+        )
+
+        data["mal"] = mal_section
+        save_config_mapping(data)
+
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message="MAL settings saved and validated.",
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/homescreen_hero/web/routers/config/setup.py
+++ b/homescreen_hero/web/routers/config/setup.py
@@ -37,6 +37,7 @@ from .schemas import (
     MDBListTestRequest,
     TautulliTestRequest,
     SeerrTestRequest,
+    MALTestRequest,
     ConnectionTestResponse,
     QuickStartRequest,
 )
@@ -294,6 +295,7 @@ def check_env_vars() -> EnvVarsResponse:
         tautulli_url_from_env=bool(os.getenv("HSH_TAUTULLI_BASE_URL")),
         seerr_api_key_from_env=bool(os.getenv("HSH_SEERR_API_KEY")),
         seerr_url_from_env=bool(os.getenv("HSH_SEERR_BASE_URL")),
+        mal_client_id_from_env=bool(os.getenv("HSH_MAL_CLIENT_ID")),
     )
 
 
@@ -384,6 +386,26 @@ def test_seerr_connection(payload: SeerrTestRequest) -> ConnectionTestResponse:
         return ConnectionTestResponse(ok=ok, error=error)
     except Exception as exc:
         logger.exception("Seerr connection test failed")
+        return ConnectionTestResponse(ok=False, error=str(exc))
+
+
+@router.post("/test-mal", response_model=ConnectionTestResponse)
+def test_mal_connection(payload: MALTestRequest) -> ConnectionTestResponse:
+    # Test MAL connection with provided credentials (for quick-start wizard).
+    try:
+        from homescreen_hero.core.integrations.mal_client import MALClient, MALConfig
+
+        # Use provided client_id or fall back to environment variable
+        client_id = payload.client_id or os.getenv("HSH_MAL_CLIENT_ID")
+        if not client_id:
+            return ConnectionTestResponse(ok=False, error="No MAL Client ID provided")
+
+        cfg = MALConfig(client_id=client_id)
+        client = MALClient(cfg)
+        ok, error = client.ping()
+        return ConnectionTestResponse(ok=ok, error=error)
+    except Exception as exc:
+        logger.exception("MAL connection test failed")
         return ConnectionTestResponse(ok=False, error=str(exc))
 
 

--- a/homescreen_hero/web/routers/config/sources.py
+++ b/homescreen_hero/web/routers/config/sources.py
@@ -16,6 +16,7 @@ from homescreen_hero.core.config.schema import (
     LetterboxdSource,
     MDBListSource,
     AniListSource,
+    MALSource,
 )
 from homescreen_hero.core.integrations.plex_client import get_plex_server
 
@@ -26,6 +27,7 @@ from .helpers import (
     load_letterboxd_sources,
     load_mdblist_sources,
     load_anilist_sources,
+    load_mal_sources,
     get_all_source_names,
 )
 from .schemas import (
@@ -46,6 +48,10 @@ from .schemas import (
     AniListSourceStatus,
     AniListSyncResponse,
     AniListMissingItemOut,
+    MALSourcePayload,
+    MALSourceStatus,
+    MALSyncResponse,
+    MALMissingItemOut,
 )
 
 import os
@@ -1184,4 +1190,282 @@ def get_missing_items_for_anilist_source(
         raise
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Error fetching missing items for AniList source at index %d: %s", index, exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ========================================================================
+# MAL SOURCES
+# ========================================================================
+
+@router.get("/mal/sources", response_model=list[MALSource])
+def list_mal_sources(current_user: str = Depends(get_current_user)) -> list[MALSource]:
+    # Return list of all configured MAL sources
+    try:
+        config = load_config()
+        return list(getattr(getattr(config, "mal", None), "sources", []) or [])
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/mal/sources", response_model=ConfigSaveResponse)
+def create_mal_source(
+    payload: MALSourcePayload,
+    current_user: str = Depends(get_current_user)
+) -> ConfigSaveResponse:
+    # Append new MAL source to config.yaml
+    try:
+        data = load_config_mapping()
+
+        if payload.name in get_all_source_names(data):
+            raise HTTPException(status_code=409, detail=f"A source named '{payload.name}' already exists. Please choose a different name.")
+
+        mal_section = data.get("mal") if isinstance(data.get("mal"), dict) else {}
+        mal_section = dict(mal_section)
+
+        sources = load_mal_sources(data)
+        sources.append(payload.model_dump(exclude_none=True))
+
+        mal_section["sources"] = sources
+        data["mal"] = mal_section
+
+        save_config_mapping(data)
+
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message=f"MAL source '{payload.name}' added.",
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.put("/mal/sources/{index}", response_model=ConfigSaveResponse)
+def update_mal_source(
+    index: int,
+    payload: MALSourcePayload,
+    current_user: str = Depends(get_current_user),
+) -> ConfigSaveResponse:
+    # Replace existing MAL source at given index in config.yaml
+    try:
+        data = load_config_mapping()
+        mal_section = data.get("mal") if isinstance(data.get("mal"), dict) else {}
+        mal_section = dict(mal_section)
+
+        sources = load_mal_sources(data)
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="MAL source not found")
+
+        sources[index] = payload.model_dump(exclude_none=True)
+        mal_section["sources"] = sources
+        data["mal"] = mal_section
+
+        save_config_mapping(data)
+
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message=f"MAL source '{payload.name}' updated.",
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete("/mal/sources/{index}", response_model=ConfigSaveResponse)
+def delete_mal_source(
+    index: int,
+    current_user: str = Depends(get_current_user)
+) -> ConfigSaveResponse:
+    # Remove MAL source at given index from config.yaml
+    try:
+        data = load_config_mapping()
+        mal_section = data.get("mal") if isinstance(data.get("mal"), dict) else {}
+        mal_section = dict(mal_section)
+
+        sources = load_mal_sources(data)
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="MAL source not found")
+
+        removed = sources.pop(index)
+        mal_section["sources"] = sources
+        data["mal"] = mal_section
+
+        save_config_mapping(data)
+
+        name = removed.get("name") if isinstance(removed, dict) else None
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message=f"MAL source '{name or index}' deleted.",
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/mal/sources/status", response_model=list[MALSourceStatus])
+def get_mal_sources_status(
+    current_user: str = Depends(get_current_user)
+) -> list[MALSourceStatus]:
+    # Return sync status for each configured MAL source.
+    try:
+        from homescreen_hero.core.db import get_sync_status
+
+        config = load_config()
+        sources = list(getattr(getattr(config, "mal", None), "sources", []) or [])
+
+        statuses: list[MALSourceStatus] = []
+        for idx, source in enumerate(sources):
+            record = get_sync_status("mal", source.name)
+            statuses.append(
+                MALSourceStatus(
+                    source_index=idx,
+                    name=source.name,
+                    last_sync_time=record.last_sync_time if record else None,
+                    sync_status=record.sync_status if record else "never_synced",
+                    error_message=record.error_message if record else None,
+                    items_matched=record.items_matched if record else 0,
+                    items_total=record.items_total if record else 0,
+                )
+            )
+
+        return statuses
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/mal/sources/{index}/sync", response_model=MALSyncResponse)
+def sync_mal_source(
+    index: int,
+    current_user: str = Depends(get_current_user)
+) -> MALSyncResponse:
+    # Manually sync a specific MAL source to Plex collection.
+    try:
+        from homescreen_hero.core.integrations.mal_sync import sync_single_mal_source
+        from homescreen_hero.core.db import record_sync_result
+
+        config = load_config()
+        sources = list(getattr(getattr(config, "mal", None), "sources", []) or [])
+
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="MAL source not found")
+
+        source = sources[index]
+        server = get_plex_server(config)
+
+        # Execute the sync
+        total, matched = sync_single_mal_source(server, config, source)
+        missing = total - matched
+
+        record_sync_result(
+            integration_type="mal",
+            source_name=source.name,
+            source_url=source.url,
+            items_total=total,
+            items_matched=matched,
+        )
+
+        return MALSyncResponse(
+            ok=True,
+            message=f"Synced '{source.name}' successfully",
+            items_total=total,
+            items_matched=matched,
+            items_missing=missing,
+            sync_time=datetime.utcnow(),
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Error syncing MAL source at index %d: %s", index, exc)
+
+        try:
+            from homescreen_hero.core.db import record_sync_result
+            config = load_config()
+            sources = list(getattr(getattr(config, "mal", None), "sources", []) or [])
+            if 0 <= index < len(sources):
+                record_sync_result(
+                    integration_type="mal",
+                    source_name=sources[index].name,
+                    source_url=sources[index].url,
+                    items_total=0,
+                    items_matched=0,
+                    sync_status="error",
+                    error_message=str(exc),
+                )
+        except Exception:
+            pass
+
+        raise HTTPException(status_code=500, detail=f"Sync failed: {str(exc)}") from exc
+
+
+@router.get("/mal/sources/{index}/missing", response_model=list[MALMissingItemOut])
+def get_missing_items_for_mal_source(
+    index: int,
+    current_user: str = Depends(get_current_user)
+) -> list[MALMissingItemOut]:
+    # Get items from a MAL list that weren't found in Plex.
+    try:
+        from homescreen_hero.core.db import get_session
+        from homescreen_hero.core.db.models import MALMissingItem
+
+        config = load_config()
+        sources = list(getattr(getattr(config, "mal", None), "sources", []) or [])
+
+        if index < 0 or index >= len(sources):
+            raise HTTPException(status_code=404, detail="MAL source not found")
+
+        source = sources[index]
+
+        with get_session() as session:
+            results = session.query(MALMissingItem).filter(
+                MALMissingItem.source_name == source.name,
+                MALMissingItem.source_url == source.url
+            ).order_by(MALMissingItem.last_seen.desc()).all()
+
+            return [
+                MALMissingItemOut(
+                    title=item.title,
+                    year=item.year,
+                    media_type=item.media_type,
+                    mal_id=item.mal_id,
+                    anilist_id=item.anilist_id,
+                    tmdb_id=item.tmdb_id,
+                    imdb_id=item.imdb_id,
+                    tvdb_id=item.tvdb_id,
+                    first_seen=item.first_seen,
+                    last_seen=item.last_seen,
+                    times_seen=item.times_seen,
+                )
+                for item in results
+            ]
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Error fetching missing items for MAL source at index %d: %s", index, exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/homescreen_hero/web/routers/health.py
+++ b/homescreen_hero/web/routers/health.py
@@ -13,6 +13,7 @@ from homescreen_hero.core.integrations.plex_client import get_plex_server
 from homescreen_hero.core.integrations.trakt_client import get_trakt_client
 from homescreen_hero.core.integrations.mdblist_client import get_mdblist_client
 from homescreen_hero.core.integrations.anilist_client import get_anilist_client
+from homescreen_hero.core.integrations.mal_client import get_mal_client
 from homescreen_hero.core.logging_config import level_from_name, setup_logging
 from homescreen_hero.core.config.schema import HealthComponent, HealthResponse
 
@@ -257,6 +258,60 @@ def _check_anilist(config: Any) -> HealthComponent:
         )
 
 
+# Helper function for MAL health check
+def _check_mal(config: Any) -> HealthComponent:
+    try:
+        mal_client = get_mal_client(config)
+
+        if mal_client is None:
+            # Check if MAL is enabled - if so, this is an error (missing client ID)
+            if config.mal and config.mal.enabled:
+                return HealthComponent(ok=False, error="MAL enabled but Client ID not configured")
+            return HealthComponent(ok=True, error="MAL disabled or not configured")
+
+        m_ok, m_error = mal_client.ping()
+        issues: list[str] = []
+
+        if not m_ok:
+            issues.append(f"MAL ping failed: {m_error or 'unknown error'}")
+
+        try:
+            server = get_plex_server(config)
+
+            if config.mal and config.mal.sources:
+                for src in config.mal.sources:
+                    if not src.plex_library:
+                        issues.append(f"Source '{src.name}' has no plex_library set")
+                        continue
+
+                    try:
+                        server.library.section(src.plex_library)
+                    except NotFound:
+                        issues.append(
+                            f"Source '{src.name}' uses unknown Plex library "
+                            f"'{src.plex_library}'"
+                        )
+                    except Exception as exc:  # pragma: no cover - defensive
+                        issues.append(
+                            f"Source '{src.name}' failed library check "
+                            f"'{src.plex_library}': {exc}"
+                        )
+        except Exception as exc:  # pragma: no cover - defensive
+            issues.append(f"Failed to validate MAL sources against Plex: {exc}")
+
+        return (
+            HealthComponent(ok=False, error="; ".join(issues))
+            if issues
+            else HealthComponent(ok=True)
+        )
+
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("MAL health check failed")
+        return HealthComponent(
+            ok=False, error=f"Unhandled error in MAL health check: {exc}"
+        )
+
+
 # Helper function for Plex health check
 def _check_plex(config: Any) -> HealthComponent:
     try:
@@ -365,6 +420,16 @@ def health_anilist() -> HealthComponent:
     return _check_anilist(config)
 
 
+# Validate MAL connectivity and configured Plex library references
+@router.get("/health/mal", response_model=HealthComponent)
+def health_mal() -> HealthComponent:
+    component, config = _check_config()
+    if not component.ok:
+        return HealthComponent(ok=False, error=component.error)
+
+    return _check_mal(config)
+
+
 # Validate Plex connectivity and configured library is accessible
 @router.get("/health/plex", response_model=HealthComponent)
 def health_plex() -> HealthComponent:
@@ -394,6 +459,7 @@ def health_check() -> HealthResponse:
     components["trakt"] = _check_trakt(config)
     components["mdblist"] = _check_mdblist(config)
     components["anilist"] = _check_anilist(config)
+    components["mal"] = _check_mal(config)
     components["tautulli"] = _check_tautulli(config)
     components["seerr"] = _check_seerr(config)
     components["plex"] = _check_plex(config)

--- a/homescreen_hero/web/routers/integrations.py
+++ b/homescreen_hero/web/routers/integrations.py
@@ -19,6 +19,8 @@ from .health import (
     _check_seerr,
     _check_plex,
     _check_mdblist,
+    _check_anilist,
+    _check_mal,
 )
 
 logger = logging.getLogger(__name__)
@@ -161,6 +163,52 @@ def get_integrations_health(
             ok=seerr_health.ok or not seerr_enabled,
             status=seerr_status,
             detail=seerr_detail,
+        )
+    )
+
+    # 6. AniList
+    anilist_health = _check_anilist(config)
+    anilist_enabled = bool(config.anilist and config.anilist.sources)
+    if not anilist_enabled:
+        anilist_status = "disabled"
+        anilist_detail = anilist_health.error or "AniList not configured"
+    elif not anilist_health.ok:
+        anilist_status = "error"
+        anilist_detail = anilist_health.error
+    else:
+        anilist_status = "online"
+        anilist_detail = "AniList OK"
+
+    integrations.append(
+        IntegrationHealthOut(
+            name="AniList",
+            enabled=anilist_enabled,
+            ok=anilist_health.ok or not anilist_enabled,
+            status=anilist_status,
+            detail=anilist_detail,
+        )
+    )
+
+    # 7. MAL
+    mal_health = _check_mal(config)
+    mal_enabled = bool(config.mal and config.mal.enabled)
+    if not mal_enabled:
+        mal_status = "disabled"
+        mal_detail = mal_health.error or "MAL disabled"
+    elif not mal_health.ok:
+        mal_status = "error"
+        mal_detail = mal_health.error
+    else:
+        mal_status = "online"
+        mal_detail = "MAL OK"
+
+    integrations.append(
+        IntegrationHealthOut(
+            name="MAL",
+            enabled=mal_enabled,
+            ok=mal_health.ok or not mal_enabled,
+            status=mal_status,
+            detail=mal_detail,
         )
     )
 


### PR DESCRIPTION
## Feature: MyAnimeList Integration MVP

### Summary
Adds MyAnimeList as a second anime integration alongside AniList. Users can sync their MAL user lists, global rankings, and seasonal charts to Plex collections, all matched to Plex using the same anime-lists ID mapping database.

### Major Changes
- MAL API client and sync engine supporting three source types: user lists (with status filtering), rankings, and seasonal charts
- Frontend component under the Anime tab with a mode toggle for each source type
- Extracted anime-lists download/caching into a shared module so both AniList and MAL reuse it

### Minor Changes
- Config schema, loader, env example, and DB model additions for MAL
- API routes for MAL sources, settings, and health check