### PR TITLE
Feature: Randomize group order setting

### DIFF
--- a/homescreen-hero-ui/src/pages/GroupsPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupsPage.tsx
@@ -19,6 +19,7 @@ import {
     RefreshCw,
     Search,
     Share2,
+    Shuffle,
     SlidersHorizontal,
     Trash2,
 } from "lucide-react";
@@ -96,6 +97,7 @@ type RotationSettings = {
     sync_all_on_rotation: boolean;
     blacklisted_collections: string[];
     auto_rotate: AutoRotateSettings;
+    randomize_group_order: boolean;
 };
 
 const defaultAutoRotate: AutoRotateSettings = {
@@ -1174,6 +1176,40 @@ export default function GroupsPage() {
                                 <div className="flex items-center gap-2.5 rounded-lg bg-primary/10 border border-primary/20 px-3 py-2.5">
                                     <Lightbulb className="h-4 w-4 text-slate-300 shrink-0" strokeWidth={1.5} />
                                     <p className="text-xs text-blue-200">Groups are processed in display order. Collections that haven't been featured recently are picked first.</p>
+                                </div>
+                            )}
+                        </div>
+
+                        <hr className="border-slate-700/50" />
+
+                        {/* Randomize Group Order */}
+                        <div className="space-y-2">
+                            <div className="flex items-center justify-between">
+                                <div className="space-y-1">
+                                    <label className="text-sm font-medium text-white">Randomize Group Order</label>
+                                    <p className="text-xs text-slate-400">
+                                        Shuffle which groups get priority each rotation so no single group always dominates.
+                                    </p>
+                                </div>
+                                <Switch
+                                    checked={rotationSettings?.randomize_group_order ?? false}
+                                    onChange={(val) => saveRotationField({ randomize_group_order: val })}
+                                    disabled={!rotationSettings}
+                                    className={`${
+                                        rotationSettings?.randomize_group_order ? "bg-primary" : "bg-slate-700"
+                                    } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/70 disabled:opacity-60 shrink-0 ml-4`}
+                                >
+                                    <span
+                                        className={`${
+                                            rotationSettings?.randomize_group_order ? "translate-x-6" : "translate-x-1"
+                                        } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+                                    />
+                                </Switch>
+                            </div>
+                            {rotationSettings?.randomize_group_order && (
+                                <div className="flex items-center gap-2.5 rounded-lg bg-primary/10 border border-primary/20 px-3 py-2.5">
+                                    <Shuffle className="h-4 w-4 text-slate-300 shrink-0" strokeWidth={1.5} />
+                                    <p className="text-xs text-blue-200">Group processing order will be shuffled each rotation, overriding display order and weight-based sorting.</p>
                                 </div>
                             )}
                         </div>

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -26,6 +26,7 @@ type RotationSettings = {
     strategy: string;
     allow_repeats: boolean;
     sync_all_on_rotation: boolean;
+    randomize_group_order: boolean;
     blacklisted_collections: string[];
     per_library_limits: Record<string, number>;
 };
@@ -135,6 +136,7 @@ export default function SettingsPage() {
         strategy: "random",
         allow_repeats: false,
         sync_all_on_rotation: true,
+        randomize_group_order: false,
         blacklisted_collections: [],
         per_library_limits: {},
     });

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -85,6 +85,10 @@ class RotationSettings(BaseModel):
         default_factory=AutoRotateSettings,
         description="Settings for auto-rotate mode",
     )
+    randomize_group_order: bool = Field(
+        default=False,
+        description="Shuffle the processing order of groups each rotation instead of using display_order or weight",
+    )
     per_library_limits: Dict[str, int] = Field(
         default_factory=dict,
         description="Maximum collections per library during rotation. Keys are library names, values are max counts.",

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -23,6 +23,7 @@ def _get_ordered_groups(
     groups: List[CollectionGroupConfig],
     strategy: str,
     rng: random.Random,
+    randomize: bool = False,
 ) -> List[CollectionGroupConfig]:
     """
     Order groups based on the selection strategy.
@@ -31,10 +32,17 @@ def _get_ordered_groups(
         groups: List of all groups from config
         strategy: Selection strategy ('random', 'weighted', or 'lru')
         rng: Random number generator for reproducibility
+        randomize: Shuffle group order each rotation
 
     Returns:
         Ordered list of groups to process
     """
+    if randomize:
+        logger.debug("Randomizing group processing order")
+        shuffled = list(groups)
+        rng.shuffle(shuffled)
+        return shuffled
+
     if strategy == "weighted":
         # Sort groups by weight (descending), then by config order for ties
         # Higher weight = processed first = higher priority
@@ -220,7 +228,10 @@ def run_rotation_with_history(
     )
 
     # Order groups based on strategy
-    ordered_groups = _get_ordered_groups(config.groups, config.rotation.strategy, rng)
+    ordered_groups = _get_ordered_groups(
+        config.groups, config.rotation.strategy, rng,
+        randomize=config.rotation.randomize_group_order,
+    )
 
     for group in ordered_groups:
         is_active = _group_is_active(group, today)
@@ -541,7 +552,10 @@ def run_rotation_dry(
     logger.info("Starting dry rotation for %d groups", len(config.groups))
 
     # Order groups based on strategy
-    ordered_groups = _get_ordered_groups(config.groups, config.rotation.strategy, rng)
+    ordered_groups = _get_ordered_groups(
+        config.groups, config.rotation.strategy, rng,
+        randomize=config.rotation.randomize_group_order,
+    )
 
     # For dry run, we don't have usage history, so use empty map
     usage_map: Dict[str, CollectionUsage] = {}

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -561,6 +561,7 @@ def save_rotation_settings(
             sync_all_on_rotation=payload.sync_all_on_rotation,
             blacklisted_collections=payload.blacklisted_collections,
             auto_rotate=payload.auto_rotate.model_dump(),
+            randomize_group_order=payload.randomize_group_order,
             per_library_limits=payload.per_library_limits,
         )
 


### PR DESCRIPTION
## Summary
Adds a "Randomize Group Order" toggle to the Layout Settings sheet. When enabled, groups are shuffled each rotation so no single group always gets priority when the max collections cap is hit.

## Changes
- Added `randomize_group_order` field to rotation settings (schema, backend save, frontend types)
- Updated `_get_ordered_groups()` in rotation logic to shuffle when enabled
- Added toggle with info hint in the Configure Layout sheet