### PR TITLE
Feature: Plex Authentication + User Management

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -48,6 +48,7 @@ rotation:
 # Optional: Authentication settings
 auth:
   enabled: true
+  method: "password"  # "password", "plex", or "both"
   username: "admin"
   # password: ""  # RECOMMENDED: Use HSH_AUTH_PASSWORD environment variable instead
   # secret_key: ""  # RECOMMENDED: Use HSH_AUTH_SECRET_KEY environment variable instead

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -53,6 +53,7 @@ auth:
   # password: ""  # RECOMMENDED: Use HSH_AUTH_PASSWORD environment variable instead
   # secret_key: ""  # RECOMMENDED: Use HSH_AUTH_SECRET_KEY environment variable instead
   token_expire_days: 30
+  auto_approve_users: true  # When false, new Plex users require admin approval before they can sign in
 
 # Optional: Trakt integration
 trakt:

--- a/homescreen-hero-ui/src/components/CollapsibleFormSection.tsx
+++ b/homescreen-hero-ui/src/components/CollapsibleFormSection.tsx
@@ -30,7 +30,7 @@ export default function CollapsibleFormSection({
     }, [expanded]);
 
     return (
-        <section className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 overflow-hidden shadow-lg shadow-primary/5">
+        <section className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 shadow-lg shadow-primary/5">
             <button
                 type="button"
                 onClick={() => setIsExpanded(!isExpanded)}
@@ -61,7 +61,7 @@ export default function CollapsibleFormSection({
                     isExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
                 }`}
             >
-                <div className="overflow-hidden">
+                <div className={isExpanded ? "overflow-visible" : "overflow-hidden"}>
                     <div className="px-6 pb-6 space-y-4 border-t border-slate-800">
                         {actions && (
                             <div className="flex justify-end pt-4">

--- a/homescreen-hero-ui/src/components/ProtectedRoute.tsx
+++ b/homescreen-hero-ui/src/components/ProtectedRoute.tsx
@@ -5,10 +5,11 @@ import { useEffect, useState } from "react";
 
 interface ProtectedRouteProps {
     children: ReactNode;
+    requireAdmin?: boolean;
 }
 
-export default function ProtectedRoute({ children }: ProtectedRouteProps) {
-    const { isAuthenticated, authEnabled, loading } = useAuth();
+export default function ProtectedRoute({ children, requireAdmin = false }: ProtectedRouteProps) {
+    const { isAuthenticated, authEnabled, role, loading } = useAuth();
     const [configStatus, setConfigStatus] = useState<{
         exists: boolean;
         is_configured: boolean;
@@ -63,6 +64,11 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     // If auth is enabled but user is not authenticated, redirect to login
     if (!isAuthenticated) {
         return <Navigate to="/login" replace />;
+    }
+
+    // If admin is required but user is not admin, redirect to user landing
+    if (requireAdmin && role !== "admin") {
+        return <Navigate to="/user" replace />;
     }
 
     return <>{children}</>;

--- a/homescreen-hero-ui/src/components/TopNav.tsx
+++ b/homescreen-hero-ui/src/components/TopNav.tsx
@@ -61,7 +61,7 @@ export default function TopNav() {
                         <Settings size={20} />
                     </IconButton>
 
-                    <IconButton label={username ?? "User"}>
+                    <div className="text-slate-400" title={username ?? "User"}>
                         {thumb ? (
                             <img
                                 src={thumb}
@@ -71,7 +71,7 @@ export default function TopNav() {
                         ) : (
                             <User size={20} />
                         )}
-                    </IconButton>
+                    </div>
 
                     {authEnabled && (
                         <IconButton label="Logout" onClick={handleLogout}>

--- a/homescreen-hero-ui/src/components/TopNav.tsx
+++ b/homescreen-hero-ui/src/components/TopNav.tsx
@@ -22,7 +22,7 @@ function NavItem({ to, label }: { to: string; label: string }) {
 }
 
 export default function TopNav() {
-    const { logout, username, authEnabled } = useAuth();
+    const { logout, username, authEnabled, thumb } = useAuth();
     const navigate = useNavigate();
 
     const handleLogout = () => {
@@ -62,7 +62,15 @@ export default function TopNav() {
                     </IconButton>
 
                     <IconButton label={username ?? "User"}>
-                        <User size={20} />
+                        {thumb ? (
+                            <img
+                                src={thumb}
+                                alt={username ?? "User"}
+                                className="h-5 w-5 rounded-full object-cover"
+                            />
+                        ) : (
+                            <User size={20} />
+                        )}
                     </IconButton>
 
                     {authEnabled && (

--- a/homescreen-hero-ui/src/components/UserRow.tsx
+++ b/homescreen-hero-ui/src/components/UserRow.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react";
+import { fetchWithAuth } from "../utils/api";
+import { Check, X, ShieldCheck, ShieldEllipsis, User, Trash2 } from "lucide-react";
+import { ConfirmDialog } from "./ui/confirm-dialog";
+
+type UserListItem = {
+    id: number;
+    plex_username: string | null;
+    plex_email: string | null;
+    plex_thumb: string | null;
+    role: string;
+    status: string;
+    created_at: string;
+    last_login_at: string | null;
+};
+
+interface UserRowProps {
+    user: UserListItem;
+    currentUsername: string | null;
+    onUpdate: () => void;
+}
+
+export default function UserRow({ user, currentUsername, onUpdate }: UserRowProps) {
+    const [loading, setLoading] = useState(false);
+    const [confirmDialog, setConfirmDialog] = useState<{
+        title: string;
+        description: string;
+        confirmLabel: string;
+        variant: "danger" | "warning" | "default";
+        onConfirm: () => void;
+    } | null>(null);
+
+    const isSelf = user.plex_username === currentUsername;
+    const isPending = user.status === "pending";
+    const displayName = user.plex_username || "this user";
+
+    async function updateUser(body: Record<string, string>) {
+        setLoading(true);
+        try {
+            const r = await fetchWithAuth(`/api/auth/users/${user.id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({ detail: "Failed" }));
+                alert(err.detail || "Failed to update user");
+                return;
+            }
+            onUpdate();
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function deleteUser() {
+        setLoading(true);
+        try {
+            const r = await fetchWithAuth(`/api/auth/users/${user.id}`, { method: "DELETE" });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({ detail: "Failed" }));
+                alert(err.detail || "Failed to remove user");
+                return;
+            }
+            onUpdate();
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    function confirmRoleChange() {
+        const newRole = user.role === "admin" ? "user" : "admin";
+        const isPromotion = newRole === "admin";
+        setConfirmDialog({
+            title: isPromotion ? `Promote ${displayName}?` : `Demote ${displayName}?`,
+            description: isPromotion
+                ? `This will give ${displayName} full admin access to the dashboard.`
+                : `This will remove admin access from ${displayName}. They will only have basic user access.`,
+            confirmLabel: isPromotion ? "Promote to Admin" : "Demote to User",
+            variant: isPromotion ? "warning" : "default",
+            onConfirm: () => updateUser({ role: newRole }),
+        });
+    }
+
+    function confirmDelete() {
+        setConfirmDialog({
+            title: isPending ? `Deny ${displayName}?` : `Remove ${displayName}?`,
+            description: isPending
+                ? `This will deny access for ${displayName}. They will need to sign in again if you change your mind.`
+                : `This will remove ${displayName} and revoke their access. They will be signed out immediately.`,
+            confirmLabel: isPending ? "Deny Access" : "Remove User",
+            variant: "danger",
+            onConfirm: deleteUser,
+        });
+    }
+
+    // Format relative time
+    const lastLogin = user.last_login_at
+        ? new Date(user.last_login_at).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+        : "Never";
+
+    return (
+        <>
+            <div className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 transition ${
+                isPending
+                    ? "border-amber-500/30 bg-amber-500/5"
+                    : "border-slate-700/50 bg-slate-800/30"
+            } ${loading ? "opacity-50 pointer-events-none" : ""}`}>
+                {/* Avatar */}
+                {user.plex_thumb ? (
+                    <img
+                        src={user.plex_thumb}
+                        alt={user.plex_username || "User"}
+                        className="h-9 w-9 rounded-full object-cover flex-shrink-0"
+                    />
+                ) : (
+                    <div className="h-9 w-9 rounded-full bg-slate-700 flex items-center justify-center flex-shrink-0">
+                        <span className="text-sm font-medium text-slate-300">
+                            {(user.plex_username || "?")[0].toUpperCase()}
+                        </span>
+                    </div>
+                )}
+
+                {/* Name + email */}
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-slate-100 truncate">
+                            {user.plex_username || "Unknown"}
+                        </span>
+                        {isSelf && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-slate-700 text-slate-400">You</span>
+                        )}
+                    </div>
+                    <p className="text-xs text-slate-500 truncate">
+                        Last login: {lastLogin}
+                    </p>
+                </div>
+
+                {/* Status badge (pending only) */}
+                {isPending && (
+                    <span className="text-[11px] px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-400 font-medium flex-shrink-0">
+                        Pending
+                    </span>
+                )}
+
+                {/* Role badge (display only) */}
+                <span className={`flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full font-medium flex-shrink-0 ${
+                    user.role === "admin"
+                        ? "bg-blue-500/15 text-blue-400"
+                        : "bg-slate-700/50 text-slate-400"
+                }`}>
+                    {user.role === "admin" ? <ShieldCheck size={12} /> : <User size={12} />}
+                    {user.role === "admin" ? "Admin" : "User"}
+                </span>
+
+                {/* Actions */}
+                {!isSelf && (
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                        {isPending && (
+                            <button
+                                type="button"
+                                onClick={() => updateUser({ status: "approved" })}
+                                title="Approve user"
+                                className="p-1.5 rounded-md text-emerald-400 hover:bg-emerald-500/10 transition"
+                            >
+                                <Check size={15} />
+                            </button>
+                        )}
+                        {!isPending && (
+                            <button
+                                type="button"
+                                onClick={confirmRoleChange}
+                                title={user.role === "admin" ? "Demote to user" : "Promote to admin"}
+                                className="p-1.5 rounded-md text-slate-400 hover:bg-slate-700/50 transition"
+                            >
+                                <ShieldEllipsis size={14} />
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            onClick={confirmDelete}
+                            title={isPending ? "Deny user" : "Remove user"}
+                            className="p-1.5 rounded-md text-rose-400 hover:bg-rose-500/10 transition"
+                        >
+                            {isPending ? <X size={15} /> : <Trash2 size={14} />}
+                        </button>
+                    </div>
+                )}
+            </div>
+
+            {/* Confirmation dialog */}
+            {confirmDialog && (
+                <ConfirmDialog
+                    open={!!confirmDialog}
+                    onOpenChange={(open) => { if (!open) setConfirmDialog(null); }}
+                    title={confirmDialog.title}
+                    description={confirmDialog.description}
+                    confirmLabel={confirmDialog.confirmLabel}
+                    variant={confirmDialog.variant}
+                    onConfirm={() => {
+                        confirmDialog.onConfirm();
+                        setConfirmDialog(null);
+                    }}
+                />
+            )}
+        </>
+    );
+}

--- a/homescreen-hero-ui/src/main.tsx
+++ b/homescreen-hero-ui/src/main.tsx
@@ -19,6 +19,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import CollectionDetailPage from "./pages/CollectionDetailPage";
 import CollectionsPage from "./pages/CollectionsPage";
 import ToolsPage from "./pages/ToolsPage";
+import UserLandingPage from "./pages/UserLandingPage";
 
 
 const router = createBrowserRouter([
@@ -31,8 +32,16 @@ const router = createBrowserRouter([
     element: <QuickStartPage />,
   },
   {
+    path: "/user",
     element: (
       <ProtectedRoute>
+        <UserLandingPage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    element: (
+      <ProtectedRoute requireAdmin>
         <AppLayout />
       </ProtectedRoute>
     ),

--- a/homescreen-hero-ui/src/pages/DashboardPage.tsx
+++ b/homescreen-hero-ui/src/pages/DashboardPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState, useMemo, useRef } from "react";
 import { DndContext, rectIntersection, DragOverlay } from "@dnd-kit/core";
 import type { DragEndEvent, DragStartEvent, DragOverEvent } from "@dnd-kit/core";
-import { Lock, Unlock, ChevronDown } from "lucide-react";
+import { Lock, Unlock, ChevronDown, Users } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../utils/auth";
 import type { ActiveCollection } from "../components/ActiveCollectionsCard";
 import { DraggableWidget, DroppableSection, EditModeBanner } from "../components/dashboard";
 import { widgetRegistry } from "../widgets/registry";
@@ -81,6 +83,8 @@ export default function Dashboard() {
     const [showSimulationModal, setShowSimulationModal] = useState(false);
     const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
 
+    const [pendingUserCount, setPendingUserCount] = useState(0);
+
     const [activeCollections, setActiveCollections] = useState<ActiveCollection[]>([]);
     const [activeLoading, setActiveLoading] = useState(true);
     const [tautulliEnabled, setTautulliEnabled] = useState<boolean>(false);
@@ -94,6 +98,9 @@ export default function Dashboard() {
     const [currentTime, setCurrentTime] = useState(Date.now());
     const [rotationDropdownOpen, setRotationDropdownOpen] = useState(false);
     const rotationDropdownRef = useRef<HTMLDivElement>(null);
+
+    const navigate = useNavigate();
+    const { authMethod } = useAuth();
 
     // Dashboard layout customization
     const {
@@ -292,11 +299,26 @@ export default function Dashboard() {
         }
     };
 
+    const loadPendingUsers = async () => {
+        if (authMethod !== "plex" && authMethod !== "both") return;
+        try {
+            const resp = await fetchWithAuth("/api/auth/users");
+            if (resp.ok) {
+                const data = await resp.json();
+                const pending = (data.users ?? []).filter((u: { status: string }) => u.status === "pending");
+                setPendingUserCount(pending.length);
+            }
+        } catch {
+            // Non-critical — silently ignore
+        }
+    };
+
     useEffect(() => {
         void loadActiveCollections();
         void loadSchedulerStatus();
         void loadTautulliConfig();
         void loadSeerrConfig();
+        void loadPendingUsers();
     }, []);
 
     // Update current time every second for live countdown
@@ -717,6 +739,23 @@ export default function Dashboard() {
                         </div>
                     </div>
                 </div>
+
+                {/* Pending user approvals banner */}
+                {pendingUserCount > 0 && (
+                    <button
+                        onClick={() => navigate("/settings?section=auth")}
+                        className="flex items-center gap-3 w-full p-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-300 text-sm hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
+                    >
+                        <Users size={18} />
+                        <span>
+                            <strong>{pendingUserCount}</strong> {pendingUserCount === 1 ? "user" : "users"} pending approval
+                        </span>
+                        <span className="ml-auto flex items-center gap-1 font-bold text-amber-600 dark:text-amber-400 text-sm">
+                            Review
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4"><path fillRule="evenodd" d="M3 10a.75.75 0 01.75-.75h10.638L10.23 5.29a.75.75 0 111.04-1.08l5.5 5.25a.75.75 0 010 1.08l-5.5 5.25a.75.75 0 11-1.04-1.08l4.158-3.96H3.75A.75.75 0 013 10z" clipRule="evenodd" /></svg>
+                        </span>
+                    </button>
+                )}
 
                 {/* Errors */}
                 {error ? (

--- a/homescreen-hero-ui/src/pages/LoginPage.tsx
+++ b/homescreen-hero-ui/src/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ export default function LoginPage() {
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
     const [plexLoading, setPlexLoading] = useState(false);
+    const [pendingApproval, setPendingApproval] = useState(false);
     const navigate = useNavigate();
     const { login, authEnabled, authMethod, loading: authLoading } = useAuth();
 
@@ -41,7 +42,7 @@ export default function LoginPage() {
                     }
                     // User is pending admin approval
                     if (data.status === "pending_approval") {
-                        setError("Your account is pending admin approval. Please contact your server admin.");
+                        setPendingApproval(true);
                         setPlexLoading(false);
                         return;
                     }
@@ -145,8 +146,16 @@ export default function LoginPage() {
                         />
                     </div>
 
+                    {/* Pending approval message */}
+                    {pendingApproval && (
+                        <div className="p-4 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-400 text-sm">
+                            <p className="font-medium">Account pending approval</p>
+                            <p className="mt-1">Your sign-in was successful, but an admin needs to approve your account before you can access the app. Please check back later.</p>
+                        </div>
+                    )}
+
                     {/* Error message */}
-                    {error && (
+                    {error && !pendingApproval && (
                         <div className="p-4 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 text-sm">
                             {error}
                         </div>

--- a/homescreen-hero-ui/src/pages/LoginPage.tsx
+++ b/homescreen-hero-ui/src/pages/LoginPage.tsx
@@ -39,6 +39,12 @@ export default function LoginPage() {
                         await new Promise((r) => setTimeout(r, 2000));
                         continue;
                     }
+                    // User is pending admin approval
+                    if (data.status === "pending_approval") {
+                        setError("Your account is pending admin approval. Please contact your server admin.");
+                        setPlexLoading(false);
+                        return;
+                    }
                     login(data.access_token, data.username, data.role, data.thumb);
                     navigate("/");
                     return;

--- a/homescreen-hero-ui/src/pages/LoginPage.tsx
+++ b/homescreen-hero-ui/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from "react";
+import { useState, useEffect, useCallback, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../utils/auth";
 import PosterBackground from "../components/PosterBackground";
@@ -8,8 +8,9 @@ export default function LoginPage() {
     const [password, setPassword] = useState("");
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
+    const [plexLoading, setPlexLoading] = useState(false);
     const navigate = useNavigate();
-    const { login, authEnabled, loading: authLoading } = useAuth();
+    const { login, authEnabled, authMethod, loading: authLoading } = useAuth();
 
     // If auth is disabled, redirect to dashboard
     useEffect(() => {
@@ -18,7 +19,57 @@ export default function LoginPage() {
         }
     }, [authEnabled, authLoading, navigate]);
 
-    const handleSubmit = async (e: FormEvent) => {
+    // Complete Plex login by polling the callback endpoint
+    const completePlexLogin = useCallback(async (pinId: number) => {
+        setPlexLoading(true);
+        setError("");
+
+        for (let i = 0; i < 15; i++) {
+            try {
+                const resp = await fetch("/api/auth/plex/callback", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ pin_id: pinId }),
+                });
+
+                if (resp.ok) {
+                    const data = await resp.json();
+                    // PIN not yet claimed, poll again
+                    if (data.status === "pending") {
+                        await new Promise((r) => setTimeout(r, 2000));
+                        continue;
+                    }
+                    login(data.access_token, data.username, data.role, data.thumb);
+                    navigate("/");
+                    return;
+                }
+
+                // Error (403, 502, etc.)
+                const errData = await resp.json().catch(() => ({ detail: "Plex login failed" }));
+                setError(errData.detail || "Plex login failed");
+                setPlexLoading(false);
+                return;
+            } catch {
+                setError("Failed to complete Plex login");
+                setPlexLoading(false);
+                return;
+            }
+        }
+
+        setError("Plex login timed out. Please try again.");
+        setPlexLoading(false);
+    }, [login, navigate]);
+
+    // On mount, check for a pending Plex PIN (returning from Plex OAuth redirect)
+    useEffect(() => {
+        const pinId = sessionStorage.getItem("plex_pin_id");
+        if (pinId) {
+            sessionStorage.removeItem("plex_pin_id");
+            completePlexLogin(parseInt(pinId, 10));
+        }
+    }, [completePlexLogin]);
+
+    const handlePasswordSubmit = async (e: FormEvent) => {
         e.preventDefault();
         setError("");
         setLoading(true);
@@ -36,11 +87,7 @@ export default function LoginPage() {
             }
 
             const data = await response.json();
-
-            // Use the auth context to store the token
-            login(data.access_token, data.username);
-
-            // Redirect to dashboard
+            login(data.access_token, data.username, data.role, data.thumb);
             navigate("/");
         } catch (err) {
             setError(err instanceof Error ? err.message : "Login failed");
@@ -48,6 +95,36 @@ export default function LoginPage() {
             setLoading(false);
         }
     };
+
+    const handlePlexLogin = async () => {
+        setPlexLoading(true);
+        setError("");
+
+        try {
+            const resp = await fetch("/api/auth/plex/pin", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    forward_url: `${window.location.origin}/login`,
+                }),
+            });
+
+            if (!resp.ok) {
+                const errData = await resp.json().catch(() => ({ detail: "Failed to start Plex login" }));
+                throw new Error(errData.detail);
+            }
+
+            const data = await resp.json();
+            sessionStorage.setItem("plex_pin_id", String(data.pin_id));
+            window.location.href = data.oauth_url;
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to start Plex login");
+            setPlexLoading(false);
+        }
+    };
+
+    const showPasswordForm = authMethod === "password" || authMethod === "both";
+    const showPlexButton = authMethod === "plex" || authMethod === "both";
 
     return (
         <PosterBackground>
@@ -62,67 +139,111 @@ export default function LoginPage() {
                         />
                     </div>
 
-                    {/* Login Form */}
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        <div>
-                            <label
-                                htmlFor="username"
-                                className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
-                            >
-                                Username
-                            </label>
-                            <input
-                                id="username"
-                                type="text"
-                                value={username}
-                                onChange={(e) => setUsername(e.target.value)}
-                                required
-                                autoFocus
-                                className="w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
-                                placeholder="Enter your username"
-                            />
+                    {/* Error message */}
+                    {error && (
+                        <div className="p-4 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 text-sm">
+                            {error}
                         </div>
+                    )}
 
-                        <div>
-                            <label
-                                htmlFor="password"
-                                className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
-                            >
-                                Password
-                            </label>
-                            <input
-                                id="password"
-                                type="password"
-                                value={password}
-                                onChange={(e) => setPassword(e.target.value)}
-                                required
-                                className="w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
-                                placeholder="Enter your password"
-                            />
-                        </div>
-
-                        {error && (
-                            <div className="p-4 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 text-sm">
-                                {error}
-                            </div>
-                        )}
-
+                    {/* Plex Login Button */}
+                    {showPlexButton && (
                         <button
-                            type="submit"
-                            disabled={loading}
-                            className="w-full py-3 px-4 bg-gradient-to-r from-primary to-purple-600 hover:from-primary/90 hover:to-purple-600/90 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-slate-950"
+                            type="button"
+                            onClick={handlePlexLogin}
+                            disabled={plexLoading}
+                            className="w-full py-3 px-4 bg-[#e5a00d] hover:bg-[#cc8e0b] text-black font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-3"
                         >
-                            {loading ? (
+                            {plexLoading ? (
                                 <span className="flex items-center justify-center gap-2">
                                     <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                                     </svg>
-                                    Logging in...
+                                    Signing in with Plex...
                                 </span>
-                            ) : "Sign In"}
+                            ) : (
+                                <>
+                                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M11.643 0H4.68l7.679 12L4.68 24h6.963l7.677-12z"/>
+                                    </svg>
+                                    Sign in with Plex
+                                </>
+                            )}
                         </button>
-                    </form>
+                    )}
+
+                    {/* Separator */}
+                    {showPasswordForm && showPlexButton && (
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <div className="w-full border-t border-slate-300 dark:border-slate-700"></div>
+                            </div>
+                            <div className="relative flex justify-center text-sm">
+                                <span className="px-3 bg-white/85 dark:bg-slate-900/85 text-slate-500 dark:text-slate-400">
+                                    or
+                                </span>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Password Login Form */}
+                    {showPasswordForm && (
+                        <form onSubmit={handlePasswordSubmit} className="space-y-4">
+                            <div>
+                                <label
+                                    htmlFor="username"
+                                    className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+                                >
+                                    Username
+                                </label>
+                                <input
+                                    id="username"
+                                    type="text"
+                                    value={username}
+                                    onChange={(e) => setUsername(e.target.value)}
+                                    required
+                                    autoFocus={!showPlexButton}
+                                    className="w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                                    placeholder="Enter your username"
+                                />
+                            </div>
+
+                            <div>
+                                <label
+                                    htmlFor="password"
+                                    className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+                                >
+                                    Password
+                                </label>
+                                <input
+                                    id="password"
+                                    type="password"
+                                    value={password}
+                                    onChange={(e) => setPassword(e.target.value)}
+                                    required
+                                    className="w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                                    placeholder="Enter your password"
+                                />
+                            </div>
+
+                            <button
+                                type="submit"
+                                disabled={loading}
+                                className="w-full py-3 px-4 bg-gradient-to-r from-primary to-purple-600 hover:from-primary/90 hover:to-purple-600/90 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-slate-950"
+                            >
+                                {loading ? (
+                                    <span className="flex items-center justify-center gap-2">
+                                        <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                        </svg>
+                                        Logging in...
+                                    </span>
+                                ) : "Sign In"}
+                            </button>
+                        </form>
+                    )}
                 </div>
             </div>
         </PosterBackground>

--- a/homescreen-hero-ui/src/pages/QuickStartPage.tsx
+++ b/homescreen-hero-ui/src/pages/QuickStartPage.tsx
@@ -6,6 +6,7 @@ import { Switch, Listbox } from "@headlessui/react";
 import PosterBackground from "../components/PosterBackground";
 import { Checkbox } from "../components/ui/checkbox";
 import { getShuffledStaticPosters } from "../utils/staticPosters";
+import { useAuth } from "../utils/auth";
 
 type EnvVars = {
     plex_token_from_env: boolean;
@@ -1575,6 +1576,7 @@ function RotationStep({ wizardData, setWizardData }: { wizardData: WizardData; s
 
 function CompleteStep({ wizardData }: { wizardData: WizardData }) {
     const navigate = useNavigate();
+    const { refreshAuthConfig } = useAuth();
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
 
@@ -1618,6 +1620,7 @@ function CompleteStep({ wizardData }: { wizardData: WizardData }) {
                 throw new Error(text || "Setup failed");
             }
 
+            await refreshAuthConfig();
             navigate("/");
         } catch (err) {
             setError(err instanceof Error ? err.message : "Setup failed");

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { fetchWithAuth } from "../utils/api";
-import { SlidersHorizontal, Check, ChevronDown, FileText, Copy, Download, Pause, Play, RefreshCw, Search, Server, CalendarSync, Ban, Archive, Upload, HardDriveDownload, HardDriveUpload, Undo2, Shield } from "lucide-react";
+import { SlidersHorizontal, Check, ChevronDown, FileText, Copy, Download, Pause, Play, RefreshCw, Search, Server, CalendarSync, Ban, Archive, Upload, HardDriveDownload, HardDriveUpload, Undo2, Shield, Users } from "lucide-react";
 import { Switch, Listbox } from "@headlessui/react";
 import FieldRow from "../components/FieldRow";
 import CollapsibleFormSection from "../components/CollapsibleFormSection";
 import TestConnectionCta from "../components/TestConnectionCta";
 import Toast from "../components/Toast";
+import UserRow from "../components/UserRow";
+import { useAuth } from "../utils/auth";
 
 const tabs = [
     { id: "general", label: "General", icon: SlidersHorizontal },
@@ -164,12 +166,28 @@ export default function SettingsPage() {
     const [plexError, setPlexError] = useState<string | null>(null);
     const [plexMessage, setPlexMessage] = useState<string | null>(null);
 
-    // Auth method state
+    // Auth settings state
     const [authMethod, setAuthMethod] = useState<"password" | "plex" | "both">("password");
+    const [autoApproveUsers, setAutoApproveUsers] = useState(true);
     const [loadingAuth, setLoadingAuth] = useState(true);
     const [savingAuth, setSavingAuth] = useState(false);
     const [authError, setAuthError] = useState<string | null>(null);
     const [authMessage, setAuthMessage] = useState<string | null>(null);
+
+    // User management state
+    type UserListItem = {
+        id: number;
+        plex_username: string | null;
+        plex_email: string | null;
+        plex_thumb: string | null;
+        role: string;
+        status: string;
+        created_at: string;
+        last_login_at: string | null;
+    };
+    const [users, setUsers] = useState<UserListItem[]>([]);
+    const [loadingUsers, setLoadingUsers] = useState(false);
+    const { username: currentUsername } = useAuth();
 
     // Logs state
     const [lines, setLines] = useState<string[]>([]);
@@ -339,7 +357,7 @@ export default function SettingsPage() {
         };
     }, []);
 
-    // Fetch auth method
+    // Fetch auth settings
     useEffect(() => {
         let isMounted = true;
         fetchWithAuth("/api/admin/config/auth-method")
@@ -347,9 +365,10 @@ export default function SettingsPage() {
                 if (!r.ok) throw new Error(await r.text());
                 return r.json();
             })
-            .then((data: { method: "password" | "plex" | "both" }) => {
+            .then((data: { method: "password" | "plex" | "both"; auto_approve_users: boolean }) => {
                 if (!isMounted) return;
                 setAuthMethod(data.method);
+                setAutoApproveUsers(data.auto_approve_users);
             })
             .catch((e) => {
                 if (!isMounted) return;
@@ -362,7 +381,29 @@ export default function SettingsPage() {
         return () => { isMounted = false; };
     }, []);
 
-    async function saveAuthMethod() {
+    // Fetch users list
+    const fetchUsers = useCallback(async () => {
+        setLoadingUsers(true);
+        try {
+            const r = await fetchWithAuth("/api/auth/users");
+            if (!r.ok) throw new Error(await r.text());
+            const data = await r.json();
+            setUsers(data.users);
+        } catch {
+            // Silently fail — user list is non-critical
+        } finally {
+            setLoadingUsers(false);
+        }
+    }, []);
+
+    // Load users when auth method includes plex
+    useEffect(() => {
+        if (authMethod === "plex" || authMethod === "both") {
+            fetchUsers();
+        }
+    }, [authMethod, fetchUsers]);
+
+    async function saveAuthSettings() {
         try {
             setSavingAuth(true);
             setAuthError(null);
@@ -371,7 +412,7 @@ export default function SettingsPage() {
             const r = await fetchWithAuth("/api/admin/config/auth-method", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ method: authMethod }),
+                body: JSON.stringify({ method: authMethod, auto_approve_users: autoApproveUsers }),
             });
 
             if (!r.ok) throw new Error(await r.text());
@@ -943,9 +984,9 @@ export default function SettingsPage() {
                                 <div className="relative">
                                     <Listbox.Button className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 text-left flex items-center justify-between data-[disabled]:opacity-50">
                                         <span>
-                                            {authMethod === "password" ? "Local Username/Password" :
-                                             authMethod === "plex" ? "Plex OAuth" :
-                                             "Both"}
+                                            {authMethod === "password" ? "Password Only" :
+                                             authMethod === "plex" ? "Plex Only" :
+                                             "Password + Plex"}
                                         </span>
                                         <ChevronDown size={16} className="text-slate-400" />
                                     </Listbox.Button>
@@ -957,8 +998,8 @@ export default function SettingsPage() {
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
                                                 <div>
-                                                    <span className="data-[selected]:font-medium">Local User</span>
-                                                    <p className="text-xs text-slate-500">Sign in with username and password.</p>
+                                                    <span className="data-[selected]:font-medium">Password Only</span>
+                                                    <p className="text-xs text-slate-500">Admin signs in with a local username and password. No multi-user support.</p>
                                                 </div>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
@@ -969,8 +1010,8 @@ export default function SettingsPage() {
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
                                                 <div>
-                                                    <span className="data-[selected]:font-medium">Plex Account</span>
-                                                    <p className="text-xs text-slate-500">Sign in via your Plex account.</p>
+                                                    <span className="data-[selected]:font-medium">Plex Only</span>
+                                                    <p className="text-xs text-slate-500">All users sign in with their Plex account. Server owner is admin.</p>
                                                 </div>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
@@ -981,8 +1022,8 @@ export default function SettingsPage() {
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
                                                 <div>
-                                                    <span className="data-[selected]:font-medium">Both</span>
-                                                    <p className="text-xs text-slate-500">Sign in with either your Plex account or Local username/password.</p>
+                                                    <span className="data-[selected]:font-medium">Password + Plex</span>
+                                                    <p className="text-xs text-slate-500">Admin can use password or Plex. Shared users sign in with Plex.</p>
                                                 </div>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
@@ -991,6 +1032,20 @@ export default function SettingsPage() {
                                 </div>
                             </Listbox>
                         </FieldRow>
+
+                        {/* Auto-approve toggle */}
+                        <div className={authMethod === "password" ? "opacity-40 pointer-events-none" : ""}>
+                            <FieldRow label="Auto-approve Users" hint="When off, new Plex users must be approved by an admin before they can sign in.">
+                                <Switch
+                                    checked={autoApproveUsers}
+                                    onChange={setAutoApproveUsers}
+                                    disabled={authMethod === "password"}
+                                    className="group relative inline-flex h-6 w-11 items-center rounded-full transition data-[checked]:bg-primary bg-slate-600"
+                                >
+                                    <span className="inline-block h-5 w-5 transform rounded-full bg-white transition group-data-[checked]:translate-x-5 translate-x-1" />
+                                </Switch>
+                            </FieldRow>
+                        </div>
 
                         {/* Save Button */}
                         <div className="flex items-center justify-between mt-4 pt-4 border-t border-slate-700/50">
@@ -1004,7 +1059,7 @@ export default function SettingsPage() {
                             </div>
                             <button
                                 type="button"
-                                onClick={saveAuthMethod}
+                                onClick={saveAuthSettings}
                                 disabled={savingAuth || loadingAuth}
                                 className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed"
                             >
@@ -1020,6 +1075,48 @@ export default function SettingsPage() {
                                     </>
                                 )}
                             </button>
+                        </div>
+
+                        {/* User list */}
+                        <div className={`mt-4 pt-4 border-t border-slate-700/50 ${authMethod === "password" ? "opacity-40 pointer-events-none" : ""}`}>
+                            <div className="flex items-center justify-between mb-3">
+                                <div className="flex items-center gap-2">
+                                    <Users size={15} className="text-slate-400" />
+                                    <h4 className="text-sm font-semibold text-slate-200">Users</h4>
+                                    {users.filter(u => u.status === "pending").length > 0 && (
+                                        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-400 font-medium">
+                                            {users.filter(u => u.status === "pending").length} pending
+                                        </span>
+                                    )}
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={fetchUsers}
+                                    disabled={loadingUsers || authMethod === "password"}
+                                    className="text-xs text-primary hover:text-blue-400 transition disabled:opacity-50"
+                                >
+                                    {loadingUsers ? "Loading..." : "Refresh"}
+                                </button>
+                            </div>
+
+                            {authMethod === "password" ? (
+                                <p className="text-xs text-slate-500 py-3 text-center">Enable Plex authentication to manage users.</p>
+                            ) : loadingUsers && users.length === 0 ? (
+                                <p className="text-xs text-slate-500 py-3 text-center">Loading users...</p>
+                            ) : users.length === 0 ? (
+                                <p className="text-xs text-slate-500 py-3 text-center">No Plex users have signed in yet.</p>
+                            ) : (
+                                <div className="space-y-2">
+                                    {users.map((u) => (
+                                        <UserRow
+                                            key={u.id}
+                                            user={u}
+                                            currentUsername={currentUsername}
+                                            onUpdate={fetchUsers}
+                                        />
+                                    ))}
+                                </div>
+                            )}
                         </div>
                     </CollapsibleFormSection>
 

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -124,11 +124,19 @@ export default function SettingsPage() {
     // Track which section should be expanded based on URL param
     const sectionParam = searchParams.get("section");
     const [rotationExpanded] = useState(sectionParam === "rotation");
+    const [authExpanded] = useState(sectionParam === "auth");
+    const authSectionRef = useRef<HTMLDivElement | null>(null);
 
-    // Clear the URL param after initial load to avoid re-expanding on tab switches
+    // Clear the URL param after initial load and scroll to the target section
     useEffect(() => {
         if (sectionParam) {
             setSearchParams({}, { replace: true });
+            if (sectionParam === "auth") {
+                // Small delay to let the section render before scrolling
+                setTimeout(() => {
+                    authSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }, 200);
+            }
         }
     }, []);
     const [rotationSettings, setRotationSettings] = useState<RotationSettings>({
@@ -970,10 +978,12 @@ export default function SettingsPage() {
                         />
                     </CollapsibleFormSection>
 
+                    <div ref={authSectionRef}>
                     <CollapsibleFormSection
                         title="Authentication"
                         description="Control how users sign in to the dashboard."
                         icon={Shield}
+                        defaultExpanded={authExpanded}
                     >
                         <FieldRow label="Login Methods" hint="Choose which authentication methods are available on the login page.">
                             <Listbox
@@ -1119,6 +1129,7 @@ export default function SettingsPage() {
                             )}
                         </div>
                     </CollapsibleFormSection>
+                    </div>
 
                     <CollapsibleFormSection
                         title="Rotation Settings"

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { fetchWithAuth } from "../utils/api";
-import { SlidersHorizontal, Check, ChevronDown, FileText, Copy, Download, Pause, Play, RefreshCw, Search, Server, CalendarSync, Ban, Archive, Upload, HardDriveDownload, HardDriveUpload, Undo2 } from "lucide-react";
+import { SlidersHorizontal, Check, ChevronDown, FileText, Copy, Download, Pause, Play, RefreshCw, Search, Server, CalendarSync, Ban, Archive, Upload, HardDriveDownload, HardDriveUpload, Undo2, Shield } from "lucide-react";
 import { Switch, Listbox } from "@headlessui/react";
 import FieldRow from "../components/FieldRow";
 import CollapsibleFormSection from "../components/CollapsibleFormSection";
@@ -163,6 +163,13 @@ export default function SettingsPage() {
     const [savingPlex, setSavingPlex] = useState(false);
     const [plexError, setPlexError] = useState<string | null>(null);
     const [plexMessage, setPlexMessage] = useState<string | null>(null);
+
+    // Auth method state
+    const [authMethod, setAuthMethod] = useState<"password" | "plex" | "both">("password");
+    const [loadingAuth, setLoadingAuth] = useState(true);
+    const [savingAuth, setSavingAuth] = useState(false);
+    const [authError, setAuthError] = useState<string | null>(null);
+    const [authMessage, setAuthMessage] = useState<string | null>(null);
 
     // Logs state
     const [lines, setLines] = useState<string[]>([]);
@@ -331,6 +338,51 @@ export default function SettingsPage() {
             isMounted = false;
         };
     }, []);
+
+    // Fetch auth method
+    useEffect(() => {
+        let isMounted = true;
+        fetchWithAuth("/api/admin/config/auth-method")
+            .then(async (r) => {
+                if (!r.ok) throw new Error(await r.text());
+                return r.json();
+            })
+            .then((data: { method: "password" | "plex" | "both" }) => {
+                if (!isMounted) return;
+                setAuthMethod(data.method);
+            })
+            .catch((e) => {
+                if (!isMounted) return;
+                setAuthError(String(e));
+            })
+            .finally(() => {
+                if (!isMounted) return;
+                setLoadingAuth(false);
+            });
+        return () => { isMounted = false; };
+    }, []);
+
+    async function saveAuthMethod() {
+        try {
+            setSavingAuth(true);
+            setAuthError(null);
+            setAuthMessage(null);
+
+            const r = await fetchWithAuth("/api/admin/config/auth-method", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ method: authMethod }),
+            });
+
+            if (!r.ok) throw new Error(await r.text());
+            const data: ConfigSaveResponse = await r.json();
+            setAuthMessage(data.message);
+        } catch (e) {
+            setAuthError(String(e));
+        } finally {
+            setSavingAuth(false);
+        }
+    }
 
     const fetchAvailableLibraries = async () => {
         try {
@@ -875,6 +927,100 @@ export default function SettingsPage() {
                                 </button>
                             }
                         />
+                    </CollapsibleFormSection>
+
+                    <CollapsibleFormSection
+                        title="Authentication"
+                        description="Control how users sign in to the dashboard."
+                        icon={Shield}
+                    >
+                        <FieldRow label="Login Methods" hint="Choose which authentication methods are available on the login page.">
+                            <Listbox
+                                value={authMethod}
+                                onChange={(val) => setAuthMethod(val)}
+                                disabled={loadingAuth}
+                            >
+                                <div className="relative">
+                                    <Listbox.Button className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 text-left flex items-center justify-between data-[disabled]:opacity-50">
+                                        <span>
+                                            {authMethod === "password" ? "Local Username/Password" :
+                                             authMethod === "plex" ? "Plex OAuth" :
+                                             "Both"}
+                                        </span>
+                                        <ChevronDown size={16} className="text-slate-400" />
+                                    </Listbox.Button>
+
+                                    <Listbox.Options className="absolute z-10 mt-1 w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg shadow-lg overflow-hidden focus:outline-none">
+                                        <Listbox.Option
+                                            value="password"
+                                            className="px-3 py-2 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
+                                                <div>
+                                                    <span className="data-[selected]:font-medium">Local User</span>
+                                                    <p className="text-xs text-slate-500">Sign in with username and password.</p>
+                                                </div>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                        <Listbox.Option
+                                            value="plex"
+                                            className="px-3 py-2 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
+                                                <div>
+                                                    <span className="data-[selected]:font-medium">Plex Account</span>
+                                                    <p className="text-xs text-slate-500">Sign in via your Plex account.</p>
+                                                </div>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                        <Listbox.Option
+                                            value="both"
+                                            className="px-3 py-2 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
+                                        >
+                                            <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
+                                                <div>
+                                                    <span className="data-[selected]:font-medium">Both</span>
+                                                    <p className="text-xs text-slate-500">Sign in with either your Plex account or Local username/password.</p>
+                                                </div>
+                                                <Check size={14} className="text-primary invisible data-[selected]:visible" />
+                                            </div>
+                                        </Listbox.Option>
+                                    </Listbox.Options>
+                                </div>
+                            </Listbox>
+                        </FieldRow>
+
+                        {/* Save Button */}
+                        <div className="flex items-center justify-between mt-4 pt-4 border-t border-slate-700/50">
+                            <div className="flex-1">
+                                {authMessage && (
+                                    <p className="text-xs text-emerald-400">{authMessage}</p>
+                                )}
+                                {authError && (
+                                    <p className="text-xs text-rose-400">{authError}</p>
+                                )}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={saveAuthMethod}
+                                disabled={savingAuth || loadingAuth}
+                                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {savingAuth ? (
+                                    <>
+                                        <span className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                                        Saving...
+                                    </>
+                                ) : (
+                                    <>
+                                        <Check className="h-4 w-4" />
+                                        Save Settings
+                                    </>
+                                )}
+                            </button>
+                        </div>
                     </CollapsibleFormSection>
 
                     <CollapsibleFormSection

--- a/homescreen-hero-ui/src/pages/UserLandingPage.tsx
+++ b/homescreen-hero-ui/src/pages/UserLandingPage.tsx
@@ -1,0 +1,58 @@
+import { useNavigate } from "react-router-dom";
+import { LogOut } from "lucide-react";
+import { useAuth } from "../utils/auth";
+
+export default function UserLandingPage() {
+    const { logout, username, thumb } = useAuth();
+    const navigate = useNavigate();
+
+    const handleLogout = () => {
+        logout();
+        navigate("/login");
+    };
+
+    return (
+        <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex items-center justify-center p-4">
+            <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 w-full max-w-md p-8 space-y-6 text-center">
+                {/* User avatar + name */}
+                <div className="flex flex-col items-center gap-3">
+                    {thumb ? (
+                        <img
+                            src={thumb}
+                            alt={username ?? "User"}
+                            className="h-16 w-16 rounded-full object-cover ring-2 ring-slate-200 dark:ring-slate-700"
+                        />
+                    ) : (
+                        <div className="h-16 w-16 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center">
+                            <span className="text-2xl font-semibold text-slate-500 dark:text-slate-400">
+                                {username?.charAt(0).toUpperCase() ?? "?"}
+                            </span>
+                        </div>
+                    )}
+                    <p className="text-lg font-medium text-slate-900 dark:text-white">
+                        Hey, {username}!
+                    </p>
+                </div>
+
+                {/* Message */}
+                <div className="space-y-2">
+                    <p className="text-slate-600 dark:text-slate-400">
+                        User tools are coming soon.
+                    </p>
+                    <p className="text-sm text-slate-500 dark:text-slate-500">
+                        Your server admin is working on some cool features for you. Check back later!
+                    </p>
+                </div>
+
+                {/* Logout */}
+                <button
+                    onClick={handleLogout}
+                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
+                >
+                    <LogOut size={16} />
+                    Sign out
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/homescreen-hero-ui/src/utils/api.ts
+++ b/homescreen-hero-ui/src/utils/api.ts
@@ -19,9 +19,12 @@ export async function fetchWithAuth(
         headers,
     });
 
-    if (response.status === 401) {
+    // 401 = invalid/expired token, 403 = account removed or pending
+    if (response.status === 401 || response.status === 403) {
         localStorage.removeItem("auth_token");
         localStorage.removeItem("username");
+        localStorage.removeItem("role");
+        localStorage.removeItem("thumb");
         window.location.href = "/login";
     }
 

--- a/homescreen-hero-ui/src/utils/auth.tsx
+++ b/homescreen-hero-ui/src/utils/auth.tsx
@@ -12,6 +12,7 @@ interface AuthContextType {
     thumb: string | null;
     login: (token: string, username: string, role?: string, thumb?: string) => void;
     logout: () => void;
+    refreshAuthConfig: () => Promise<void>;
     loading: boolean;
 }
 
@@ -26,6 +27,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const [authMethod, setAuthMethod] = useState<AuthMethod>(null);
     const [loading, setLoading] = useState(true);
 
+    // Re-fetch auth config from the backend (public endpoint)
+    const refreshAuthConfig = async () => {
+        try {
+            const resp = await fetch("/api/auth/config");
+            if (resp.ok) {
+                const data = await resp.json();
+                setAuthEnabled(data.auth_enabled);
+                setAuthMethod(data.method || null);
+            }
+        } catch (error) {
+            console.error("Failed to refresh auth config:", error);
+        }
+    };
+
     // Check backend auth status and load token from localStorage on mount
     useEffect(() => {
         const checkAuthStatus = async () => {
@@ -36,12 +51,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 const storedThumb = localStorage.getItem("thumb");
 
                 // Fetch auth config (public endpoint)
-                const configResp = await fetch("/api/auth/config");
-                if (configResp.ok) {
-                    const configData = await configResp.json();
-                    setAuthEnabled(configData.auth_enabled);
-                    setAuthMethod(configData.method || null);
-                }
+                await refreshAuthConfig();
 
                 // Try to validate stored token via /api/auth/me
                 const headers: HeadersInit = {};
@@ -99,6 +109,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setUsername(null);
         setRole(null);
         setThumb(null);
+        // Re-fetch config so login page reflects current auth method
+        refreshAuthConfig();
     };
 
     const value: AuthContextType = {
@@ -111,6 +123,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         thumb,
         login,
         logout,
+        refreshAuthConfig,
         loading,
     };
 

--- a/homescreen-hero-ui/src/utils/auth.tsx
+++ b/homescreen-hero-ui/src/utils/auth.tsx
@@ -1,11 +1,16 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from "react";
 
+type AuthMethod = "password" | "plex" | "both" | null;
+
 interface AuthContextType {
     isAuthenticated: boolean;
     authEnabled: boolean;
+    authMethod: AuthMethod;
     token: string | null;
     username: string | null;
-    login: (token: string, username: string) => void;
+    role: string | null;
+    thumb: string | null;
+    login: (token: string, username: string, role?: string, thumb?: string) => void;
     logout: () => void;
     loading: boolean;
 }
@@ -15,18 +20,30 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export function AuthProvider({ children }: { children: ReactNode }) {
     const [token, setToken] = useState<string | null>(null);
     const [username, setUsername] = useState<string | null>(null);
+    const [role, setRole] = useState<string | null>(null);
+    const [thumb, setThumb] = useState<string | null>(null);
     const [authEnabled, setAuthEnabled] = useState<boolean>(true);
+    const [authMethod, setAuthMethod] = useState<AuthMethod>(null);
     const [loading, setLoading] = useState(true);
 
     // Check backend auth status and load token from localStorage on mount
     useEffect(() => {
         const checkAuthStatus = async () => {
             try {
-                // First, check if we have a stored token
                 const storedToken = localStorage.getItem("auth_token");
                 const storedUsername = localStorage.getItem("username");
+                const storedRole = localStorage.getItem("role");
+                const storedThumb = localStorage.getItem("thumb");
 
-                // Try to call /api/auth/me to check if auth is enabled
+                // Fetch auth config (public endpoint)
+                const configResp = await fetch("/api/auth/config");
+                if (configResp.ok) {
+                    const configData = await configResp.json();
+                    setAuthEnabled(configData.auth_enabled);
+                    setAuthMethod(configData.method || null);
+                }
+
+                // Try to validate stored token via /api/auth/me
                 const headers: HeadersInit = {};
                 if (storedToken) {
                     headers["Authorization"] = `Bearer ${storedToken}`;
@@ -37,21 +54,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 if (response.ok) {
                     const data = await response.json();
                     setAuthEnabled(data.auth_enabled);
+                    setAuthMethod(data.method || null);
 
-                    // If auth is enabled and we got a valid response, we're authenticated
                     if (data.auth_enabled && storedToken && storedUsername) {
                         setToken(storedToken);
                         setUsername(data.username);
+                        setRole(data.role || storedRole || "admin");
+                        setThumb(data.thumb || storedThumb || null);
                     } else if (!data.auth_enabled) {
-                        // If auth is disabled, set anonymous user
                         setUsername(data.username || "anonymous");
+                        setRole("admin");
                     }
                 } else {
-                    // If the request fails, assume auth is enabled and we're not authenticated
                     setAuthEnabled(true);
                 }
             } catch (error) {
-                // On error, assume auth is enabled (safer default)
                 console.error("Failed to check auth status:", error);
                 setAuthEnabled(true);
             } finally {
@@ -62,25 +79,36 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         checkAuthStatus();
     }, []);
 
-    const login = (newToken: string, newUsername: string) => {
+    const login = (newToken: string, newUsername: string, newRole?: string, newThumb?: string) => {
         localStorage.setItem("auth_token", newToken);
         localStorage.setItem("username", newUsername);
+        if (newRole) localStorage.setItem("role", newRole);
+        if (newThumb) localStorage.setItem("thumb", newThumb);
         setToken(newToken);
         setUsername(newUsername);
+        setRole(newRole || "admin");
+        setThumb(newThumb || null);
     };
 
     const logout = () => {
         localStorage.removeItem("auth_token");
         localStorage.removeItem("username");
+        localStorage.removeItem("role");
+        localStorage.removeItem("thumb");
         setToken(null);
         setUsername(null);
+        setRole(null);
+        setThumb(null);
     };
 
-    const value = {
+    const value: AuthContextType = {
         isAuthenticated: !authEnabled || !!token,
         authEnabled,
+        authMethod,
         token,
         username,
+        role,
+        thumb,
         login,
         logout,
         loading,

--- a/homescreen_hero/core/auth.py
+++ b/homescreen_hero/core/auth.py
@@ -129,6 +129,8 @@ async def get_current_user(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="Account is not active",
                 )
+            # Refresh role from DB so demotions take effect immediately
+            user = CurrentUser(id=user.id, username=user.username, role=db_user.role)
 
     return user
 

--- a/homescreen_hero/core/auth.py
+++ b/homescreen_hero/core/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -20,6 +21,17 @@ security = HTTPBearer(auto_error=False)
 ALGORITHM = "HS256"
 
 
+@dataclass
+class CurrentUser:
+    id: int
+    username: str
+    role: str  # "admin" or "user"
+    plex_id: int | None = field(default=None)
+
+    def __str__(self) -> str:
+        return self.username
+
+
 def hash_password(password: str) -> str:
     # Hash a plaintext password (bcrypt)
     return pwd_context.hash(password)
@@ -36,39 +48,56 @@ def is_password_hashed(password: str) -> bool:
 
 
 def create_access_token(
-    username: str, secret_key: str, expires_delta: timedelta
+    username: str,
+    secret_key: str,
+    expires_delta: timedelta,
+    user_id: int = 0,
+    role: str = "admin",
 ) -> str:
-    # Create a JWT access token
+    # Create a JWT access token with user identity and role
     expire = datetime.utcnow() + expires_delta
     to_encode = {
-        "sub": username,  # Subject (username)
-        "exp": expire,  # Expiration time
+        "sub": str(user_id),
+        "username": username,
+        "role": role,
+        "exp": expire,
     }
     encoded_jwt = jwt.encode(to_encode, secret_key, algorithm=ALGORITHM)
     return encoded_jwt
 
 
-def verify_token(token: str, secret_key: str) -> Optional[str]:
-    # Verify a JWT token and return the username if valid.
-    # Returns None if the token is invalid or expired.
+def verify_token(token: str, secret_key: str) -> Optional[CurrentUser]:
+    # Verify a JWT token and return a CurrentUser if valid.
+    # Handles both new (sub=user_id, username, role) and legacy (sub=username) formats.
     try:
         payload = jwt.decode(token, secret_key, algorithms=[ALGORITHM])
-        username: str = payload.get("sub")
-        if username is None:
+        sub = payload.get("sub")
+        if sub is None:
             return None
-        return username
-    except JWTError:
+
+        # New format: sub is a numeric user_id string, username and role are separate claims
+        username = payload.get("username")
+        if username:
+            return CurrentUser(
+                id=int(sub),
+                username=username,
+                role=payload.get("role", "admin"),
+            )
+
+        # Legacy format: sub is the username string, assume admin
+        return CurrentUser(id=0, username=sub, role="admin")
+    except (JWTError, ValueError):
         return None
 
 
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-) -> str:
+) -> CurrentUser:
     config = load_config()
 
     # If auth is not enabled or not configured, allow access
     if not config.auth or not config.auth.enabled:
-        return "anonymous"
+        return CurrentUser(id=0, username="anonymous", role="admin")
 
     # Auth is enabled, so we need a valid token
     if credentials is None:
@@ -79,13 +108,25 @@ async def get_current_user(
         )
 
     token = credentials.credentials
-    username = verify_token(token, config.auth.secret_key)
+    user = verify_token(token, config.auth.secret_key)
 
-    if username is None:
+    if user is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    return username
+    return user
+
+
+async def require_admin(
+    current_user: CurrentUser = Depends(get_current_user),
+) -> CurrentUser:
+    # Dependency that requires the current user to be an admin
+    if current_user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return current_user

--- a/homescreen_hero/core/auth.py
+++ b/homescreen_hero/core/auth.py
@@ -117,6 +117,19 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # For Plex users (id > 0), verify they still exist and are approved
+    if user.id > 0:
+        from homescreen_hero.core.db.base import session_scope
+        from homescreen_hero.core.db.models import User as UserModel
+
+        with session_scope() as db:
+            db_user = db.query(UserModel).filter(UserModel.id == user.id).first()
+            if db_user is None or db_user.status != "approved":
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Account is not active",
+                )
+
     return user
 
 

--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -106,18 +106,23 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             "Plex token is required. Set it in config.yaml or via HSH_PLEX_TOKEN environment variable"
         )
 
-    # Auth password override
+    # Auth overrides
     if config.auth and config.auth.enabled:
-        auth_password = os.getenv("HSH_AUTH_PASSWORD")
-        if auth_password:
-            logger.info("Using auth password from HSH_AUTH_PASSWORD environment variable")
-            config.auth.password = auth_password
-        elif not config.auth.password:
-            raise ValueError(
-                "Auth password is required when auth is enabled. Set it in config.yaml or via HSH_AUTH_PASSWORD environment variable"
-            )
+        method = config.auth.method
 
-        # Auth secret key override
+        # Password is only required when method allows password login
+        if method in ("password", "both"):
+            auth_password = os.getenv("HSH_AUTH_PASSWORD")
+            if auth_password:
+                logger.info("Using auth password from HSH_AUTH_PASSWORD environment variable")
+                config.auth.password = auth_password
+            elif not config.auth.password:
+                raise ValueError(
+                    "Auth password is required when auth method is '%s'. "
+                    "Set it in config.yaml or via HSH_AUTH_PASSWORD environment variable" % method
+                )
+
+        # Secret key is always required when auth is enabled (used for JWT signing)
         auth_secret = os.getenv("HSH_AUTH_SECRET_KEY")
         if auth_secret:
             logger.info("Using auth secret key from HSH_AUTH_SECRET_KEY environment variable")

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -179,6 +179,10 @@ class AuthSettings(BaseModel):
         ge=1,
         description="Number of days before JWT tokens expire",
     )
+    auto_approve_users: bool = Field(
+        default=True,
+        description="Auto-approve new Plex users. When off, new users are pending until admin approves.",
+    )
 
 
 class TraktSource(BaseModel):

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
 
@@ -158,9 +158,13 @@ class AuthSettings(BaseModel):
         default=False,
         description="Whether authentication is required",
     )
+    method: Literal["password", "plex", "both"] = Field(
+        default="password",
+        description="Auth method: 'password', 'plex', or 'both'",
+    )
     username: str = Field(
         default="admin",
-        description="Username for authentication",
+        description="Username for password authentication",
     )
     password: Optional[str] = Field(
         default=None,

--- a/homescreen_hero/core/db/history.py
+++ b/homescreen_hero/core/db/history.py
@@ -23,6 +23,7 @@ def init_db() -> None:
     # Run schema migrations for existing tables
     _migrate_collection_analytics(engine)
     _migrate_pinned_collections_visibility(engine)
+    _migrate_users_status(engine)
 
 
 def _migrate_collection_analytics(engine) -> None:
@@ -75,6 +76,25 @@ def _migrate_pinned_collections_visibility(engine) -> None:
     with engine.connect() as conn:
         for col_name, col_type, default_val in columns_to_add:
             conn.execute(text(f"ALTER TABLE pinned_collections ADD COLUMN {col_name} {col_type} NOT NULL DEFAULT {default_val}"))
+        conn.commit()
+
+
+def _migrate_users_status(engine) -> None:
+    # Add status column to users table if it doesn't exist
+    from sqlalchemy import text, inspect
+
+    inspector = inspect(engine)
+
+    if "users" not in inspector.get_table_names():
+        return
+
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "status" in columns:
+        return
+
+    logger.info("Migrating users: adding status column")
+    with engine.connect() as conn:
+        conn.execute(text("ALTER TABLE users ADD COLUMN status VARCHAR NOT NULL DEFAULT 'approved'"))
         conn.commit()
 
 

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -291,6 +291,27 @@ class SourceSyncRecord(Base):
     error_message = Column(Text, nullable=True)
 
 
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # Plex identity (nullable for password-only admin)
+    plex_id = Column(Integer, nullable=True, unique=True, index=True)
+    plex_username = Column(String, nullable=True)
+    plex_email = Column(String, nullable=True)
+    plex_thumb = Column(String, nullable=True)
+
+    # "admin" or "user"
+    role = Column(String, nullable=False, default="user")
+
+    # For password-auth fallback (only admin uses this)
+    password_hash = Column(String, nullable=True)
+
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    last_login_at = Column(DateTime, nullable=True)
+
+
 class CollectionDisplayOrder(Base):
     # Tracks the display order of active collections on the homescreen
     __tablename__ = "collection_display_order"

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -305,6 +305,9 @@ class User(Base):
     # "admin" or "user"
     role = Column(String, nullable=False, default="user")
 
+    # "approved" or "pending"
+    status = Column(String, nullable=False, default="approved")
+
     # For password-auth fallback (only admin uses this)
     password_hash = Column(String, nullable=True)
 

--- a/homescreen_hero/core/integrations/plex_auth.py
+++ b/homescreen_hero/core/integrations/plex_auth.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import requests
+from cachetools import TTLCache
+from plexapi.myplex import MyPlexAccount
+
+logger = logging.getLogger(__name__)
+
+# Pending PIN cache (5 min TTL, max 100 concurrent logins)
+_pending_pins: TTLCache = TTLCache(maxsize=100, ttl=300)
+
+PLEX_PINS_URL = "https://plex.tv/api/v2/pins"
+
+# Persistent client identifier — generated once per process, but could be
+# stored in DB for cross-restart consistency in the future.
+_client_id: str | None = None
+
+
+def _get_client_id() -> str:
+    global _client_id
+    if _client_id is None:
+        _client_id = str(uuid.uuid4())
+    return _client_id
+
+
+def _plex_headers() -> Dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "X-Plex-Client-Identifier": _get_client_id(),
+        "X-Plex-Product": "Homescreen Hero",
+        "X-Plex-Version": "1.0",
+        "X-Plex-Platform": "Web",
+        "X-Plex-Device": "Browser",
+        "X-Plex-Device-Name": "Homescreen Hero",
+    }
+
+
+def create_plex_pin(forward_url: str) -> Dict[str, Any]:
+    # Create a Plex OAuth PIN and return the pin_id + OAuth URL.
+    resp = requests.post(
+        PLEX_PINS_URL,
+        headers=_plex_headers(),
+        params={"strong": "true"},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    pin_id = data["id"]
+    code = data["code"]
+
+    _pending_pins[pin_id] = code
+
+    headers = _plex_headers()
+    oauth_params = {
+        "clientID": headers["X-Plex-Client-Identifier"],
+        "code": code,
+        "forwardUrl": forward_url,
+        "context[device][product]": headers["X-Plex-Product"],
+        "context[device][version]": headers["X-Plex-Version"],
+        "context[device][platform]": headers["X-Plex-Platform"],
+        "context[device][device]": headers["X-Plex-Device"],
+    }
+    oauth_url = f"https://app.plex.tv/auth/#!?{urlencode(oauth_params)}"
+
+    return {"pin_id": pin_id, "oauth_url": oauth_url}
+
+
+def check_plex_pin(pin_id: int) -> Optional[str]:
+    # Check if a PIN has been claimed. Returns the authToken if yes, None if pending.
+    code = _pending_pins.get(pin_id)
+
+    headers = _plex_headers()
+    params = {}
+    if code:
+        params["code"] = code
+
+    resp = requests.get(
+        f"{PLEX_PINS_URL}/{pin_id}",
+        headers=headers,
+        params=params,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    auth_token = data.get("authToken")
+    if auth_token:
+        _pending_pins.pop(pin_id, None)
+        return auth_token
+    return None
+
+
+def get_plex_user_info(plex_token: str) -> Dict[str, Any]:
+    # Get Plex account info from a user's auth token.
+    account = MyPlexAccount(token=plex_token)
+    return {
+        "plex_id": account.id,
+        "username": account.title or account.username,
+        "email": account.email,
+        "thumb": account.thumb,
+    }
+
+
+def validate_server_access(
+    user_plex_token: str,
+    admin_plex_token: str,
+    server_machine_id: str,
+) -> Dict[str, Any]:
+    # Check if a Plex user has access to the configured server.
+    # Returns user info dict with "allowed" and "is_owner" flags.
+    user_account = MyPlexAccount(token=user_plex_token)
+    user_info = {
+        "plex_id": user_account.id,
+        "username": user_account.title or user_account.username,
+        "email": user_account.email,
+        "thumb": user_account.thumb,
+    }
+
+    admin_account = MyPlexAccount(token=admin_plex_token)
+
+    # Server owner check
+    if user_account.id == admin_account.id:
+        return {**user_info, "allowed": True, "is_owner": True}
+
+    # Shared user check — look through admin's friend list
+    try:
+        for friend in admin_account.users():
+            if friend.id == user_account.id:
+                for server in friend.servers:
+                    if server.machineIdentifier == server_machine_id:
+                        return {**user_info, "allowed": True, "is_owner": False}
+                # User is a friend but doesn't have this server shared
+                break
+    except Exception:
+        logger.exception("Failed to check shared users for server access")
+
+    return {**user_info, "allowed": False, "is_owner": False}

--- a/homescreen_hero/web/routers/analytics.py
+++ b/homescreen_hero/web/routers/analytics.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from ...core.auth import get_current_user
+from ...core.auth import CurrentUser, get_current_user, require_admin
 from ...core.config.loader import load_config
 from ...core.db.analytics import (
     get_collection_analytics_history,
@@ -125,7 +125,7 @@ class HourlyConcurrentOut(BaseModel):
 def get_analytics(
     collection_name: Optional[str] = None,
     limit: int = 50,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[CollectionAnalyticsOut]:
     """
     Get analytics history for collections.
@@ -169,7 +169,7 @@ def get_top_collections(
     limit: int = 10,
     since_rotation_id: Optional[int] = None,
     media_type: Optional[str] = None,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[TopCollectionOut]:
     """
     Get top performing collections by play count.
@@ -207,7 +207,7 @@ def get_top_collections(
 @router.get("/rotation/{rotation_id}", response_model=List[CollectionAnalyticsOut])
 def get_rotation_analytics_endpoint(
     rotation_id: int,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[CollectionAnalyticsOut]:
     """
     Get analytics for a specific rotation.
@@ -246,7 +246,7 @@ def get_rotation_analytics_endpoint(
 
 @router.post("/collect", response_model=AnalyticsCollectionResponse)
 def trigger_analytics_collection(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> AnalyticsCollectionResponse:
     """
     Manually trigger analytics collection for all active collections.
@@ -307,7 +307,7 @@ def trigger_analytics_collection(
 def get_most_active_users(
     limit: int = 10,
     query_days: int = 30,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[ActiveUserOut]:
     """
     Get most active users by watch time and play count.
@@ -414,7 +414,7 @@ def get_most_active_users(
 
 @router.get("/activity/current", response_model=CurrentActivityOut)
 def get_current_activity(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> CurrentActivityOut:
     """
     Get current active streams on Plex server.
@@ -519,7 +519,7 @@ def get_current_activity(
 @router.get("/graph/plays-by-hour", response_model=List[HourlyPlaysOut])
 def get_plays_by_hour(
     query_days: int = 30,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[HourlyPlaysOut]:
     """
     Get play counts grouped by hour of day for graphing.
@@ -620,7 +620,7 @@ def get_plays_by_hour(
 @router.get("/graph/plays-by-date", response_model=List[DailyPlaysOut])
 def get_plays_by_date(
     query_days: int = 30,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[DailyPlaysOut]:
     """
     Get play counts grouped by date for graphing.
@@ -693,7 +693,7 @@ def get_plays_by_date(
 @router.get("/graph/concurrent-by-date", response_model=List[DailyConcurrentOut])
 def get_concurrent_by_date(
     query_days: int = 30,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[DailyConcurrentOut]:
     """
     Get peak concurrent viewer counts by date.
@@ -806,7 +806,7 @@ def get_concurrent_by_date(
 
 @router.get("/graph/concurrent-by-hour", response_model=List[HourlyConcurrentOut])
 def get_concurrent_by_hour(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[HourlyConcurrentOut]:
     """
     Get peak concurrent viewer counts by hour for the last 24 hours.

--- a/homescreen_hero/web/routers/auth.py
+++ b/homescreen_hero/web/routers/auth.py
@@ -505,7 +505,7 @@ async def get_login_posters() -> PosterResponse:
                 token = config.plex.token
                 actual_url = f"{base_url}{thumb_path}?X-Plex-Token={token}"
 
-                logger.debug(f"Poster {idx}: base_url={base_url}, thumb_path={thumb_path}, final_url={actual_url}")
+                logger.debug(f"Poster {idx}: base_url={base_url}, thumb_path={thumb_path}")
 
                 # Store in a simple dict cache (this should be Redis or similar in production)
                 if not hasattr(get_login_posters, '_poster_cache'):
@@ -549,8 +549,8 @@ def proxy_poster(poster_id: int):
         )
 
     except requests.RequestException as exc:
-        logger.error(f"Failed to fetch poster {poster_id} from URL {poster_url}: {exc}")
+        logger.error(f"Failed to fetch poster {poster_id}: {exc}")
         raise HTTPException(status_code=500, detail="Failed to fetch poster")
     except Exception as exc:
-        logger.error(f"Unexpected error fetching poster {poster_id} from URL {poster_url}: {exc}")
+        logger.error(f"Unexpected error fetching poster {poster_id}: {exc}")
         raise HTTPException(status_code=500, detail="Failed to fetch poster")

--- a/homescreen_hero/web/routers/auth.py
+++ b/homescreen_hero/web/routers/auth.py
@@ -3,25 +3,31 @@ from __future__ import annotations
 import random
 import logging
 import requests
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import List, Optional
+from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel
 
 from homescreen_hero.core.auth import (
+    CurrentUser,
     create_access_token,
     get_current_user,
     verify_password,
 )
 from homescreen_hero.core.config.loader import load_config
+from homescreen_hero.core.db.base import session_scope
+from homescreen_hero.core.db.models import User
 from homescreen_hero.core.integrations.plex_client import get_plex_server
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+
+# --- Request/Response models ---
 
 class LoginRequest(BaseModel):
     username: str
@@ -32,22 +38,102 @@ class LoginResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     username: str
+    role: str = "admin"
+    thumb: Optional[str] = None
 
 
 class UserResponse(BaseModel):
     username: str
     auth_enabled: bool
+    method: Optional[str] = None
+    role: str = "admin"
+    thumb: Optional[str] = None
 
+
+class AuthConfigResponse(BaseModel):
+    auth_enabled: bool
+    method: Optional[str] = None
+
+
+class PlexPinRequest(BaseModel):
+    forward_url: str
+
+
+class PlexPinResponse(BaseModel):
+    pin_id: int
+    oauth_url: str
+
+
+class PlexCallbackRequest(BaseModel):
+    pin_id: int
+
+
+# --- DB helpers ---
+
+def _upsert_plex_user(
+    plex_id: int,
+    username: str,
+    email: str | None,
+    thumb: str | None,
+    role: str,
+) -> User:
+    # Create or update a user by plex_id. Never downgrades admin to user.
+    with session_scope() as db:
+        user = db.query(User).filter(User.plex_id == plex_id).first()
+        if user:
+            user.plex_username = username
+            user.plex_email = email
+            user.plex_thumb = thumb
+            user.last_login_at = datetime.utcnow()
+            # Don't downgrade admin
+            if role == "admin":
+                user.role = "admin"
+        else:
+            user = User(
+                plex_id=plex_id,
+                plex_username=username,
+                plex_email=email,
+                plex_thumb=thumb,
+                role=role,
+                last_login_at=datetime.utcnow(),
+            )
+            db.add(user)
+        db.flush()
+        db.expunge(user)
+        return user
+
+
+# --- Auth config endpoint ---
+
+@router.get("/config", response_model=AuthConfigResponse)
+async def get_auth_config() -> AuthConfigResponse:
+    # Public endpoint — tells the frontend what auth method is configured.
+    config = load_config()
+    if not config.auth or not config.auth.enabled:
+        return AuthConfigResponse(auth_enabled=False)
+    return AuthConfigResponse(
+        auth_enabled=True,
+        method=config.auth.method,
+    )
+
+
+# --- Password login ---
 
 @router.post("/login", response_model=LoginResponse)
 async def login(request: LoginRequest) -> LoginResponse:
     config = load_config()
 
-    # Check if auth is configured and enabled
     if not config.auth or not config.auth.enabled:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Authentication is not enabled",
+        )
+
+    # Reject password login if method is plex-only
+    if config.auth.method == "plex":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Password login is not enabled. Use Plex authentication.",
         )
 
     # Verify username
@@ -57,11 +143,8 @@ async def login(request: LoginRequest) -> LoginResponse:
             detail="Incorrect username or password",
         )
 
-    # Verify password
-    # Check if the configured password is already hashed or plaintext
+    # Verify password (supports both hashed and plaintext)
     stored_password = config.auth.password
-
-    # If stored password looks like a hash, verify against hash
     if stored_password.startswith("$2b$") or stored_password.startswith("$2a$"):
         if not verify_password(request.password, stored_password):
             raise HTTPException(
@@ -69,37 +152,185 @@ async def login(request: LoginRequest) -> LoginResponse:
                 detail="Incorrect username or password",
             )
     else:
-        # Stored password is plaintext (not recommended, but we'll support it)
         if request.password != stored_password:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Incorrect username or password",
             )
 
-    # Create JWT token
+    # Create JWT token (password users are always admin)
     expires_delta = timedelta(days=config.auth.token_expire_days)
     access_token = create_access_token(
         username=request.username,
         secret_key=config.auth.secret_key,
         expires_delta=expires_delta,
+        user_id=0,
+        role="admin",
     )
 
     return LoginResponse(
         access_token=access_token,
         username=request.username,
+        role="admin",
     )
 
+
+# --- Plex OAuth ---
+
+@router.post("/plex/pin", response_model=PlexPinResponse)
+async def create_plex_login_pin(request: PlexPinRequest, http_request: Request) -> PlexPinResponse:
+    # Initiate Plex OAuth — creates a PIN and returns the OAuth URL.
+    config = load_config()
+
+    if not config.auth or not config.auth.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Authentication is not enabled",
+        )
+
+    if config.auth.method == "password":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Plex login is not enabled. Use password authentication.",
+        )
+
+    # Validate forward_url is same-origin to prevent open redirect via Plex
+    parsed_forward = urlparse(request.forward_url)
+    request_origin = urlparse(str(http_request.base_url))
+    if parsed_forward.netloc and parsed_forward.netloc != request_origin.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="forward_url must match the application origin",
+        )
+
+    from homescreen_hero.core.integrations.plex_auth import create_plex_pin
+
+    try:
+        result = create_plex_pin(request.forward_url)
+        return PlexPinResponse(pin_id=result["pin_id"], oauth_url=result["oauth_url"])
+    except Exception:
+        logger.exception("Failed to create Plex OAuth PIN")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to connect to Plex.tv. Please try again later.",
+        )
+
+
+@router.post("/plex/callback", response_model=LoginResponse)
+async def plex_oauth_callback(request: PlexCallbackRequest) -> LoginResponse:
+    # Complete Plex OAuth — checks if the PIN was claimed, validates server access,
+    # and issues a JWT token.
+    config = load_config()
+
+    if not config.auth or not config.auth.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Authentication is not enabled",
+        )
+
+    if config.auth.method == "password":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Plex login is not enabled. Use password authentication.",
+        )
+
+    from homescreen_hero.core.integrations.plex_auth import (
+        check_plex_pin,
+        validate_server_access,
+    )
+
+    # Check if the PIN has been claimed
+    try:
+        plex_token = check_plex_pin(request.pin_id)
+    except Exception:
+        logger.exception("Failed to check Plex PIN status")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to connect to Plex.tv. Please try again later.",
+        )
+
+    if not plex_token:
+        return Response(
+            content='{"status": "pending"}',
+            status_code=200,
+            media_type="application/json",
+        )
+
+    # Validate server access
+    try:
+        server = get_plex_server(config)
+        machine_id = server.machineIdentifier
+        result = validate_server_access(plex_token, config.plex.token, machine_id)
+    except Exception:
+        logger.exception("Failed to validate Plex server access")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to verify server access. Please try again.",
+        )
+
+    if not result["allowed"]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have access to this Plex server",
+        )
+
+    # Create/update user in DB
+    role = "admin" if result["is_owner"] else "user"
+    user = _upsert_plex_user(
+        plex_id=result["plex_id"],
+        username=result["username"],
+        email=result.get("email"),
+        thumb=result.get("thumb"),
+        role=role,
+    )
+
+    # Issue JWT
+    expires_delta = timedelta(days=config.auth.token_expire_days)
+    access_token = create_access_token(
+        username=user.plex_username,
+        secret_key=config.auth.secret_key,
+        expires_delta=expires_delta,
+        user_id=user.id,
+        role=user.role,
+    )
+
+    return LoginResponse(
+        access_token=access_token,
+        username=user.plex_username,
+        role=user.role,
+        thumb=user.plex_thumb,
+    )
+
+
+# --- User info ---
 
 @router.get("/me", response_model=UserResponse)
-async def get_me(current_user: str = Depends(get_current_user)) -> UserResponse:
+async def get_me(current_user: CurrentUser = Depends(get_current_user)) -> UserResponse:
     config = load_config()
     auth_enabled = config.auth is not None and config.auth.enabled
+    method = config.auth.method if config.auth and config.auth.enabled else None
+
+    # Try to get thumb from DB if this is a Plex user
+    thumb = None
+    if current_user.id > 0:
+        try:
+            with session_scope() as db:
+                user = db.query(User).filter(User.id == current_user.id).first()
+                if user:
+                    thumb = user.plex_thumb
+        except Exception:
+            pass
 
     return UserResponse(
-        username=current_user,
+        username=current_user.username,
         auth_enabled=auth_enabled,
+        method=method,
+        role=current_user.role,
+        thumb=thumb,
     )
 
+
+# --- Login page posters ---
 
 class PosterResponse(BaseModel):
     posters: List[str]

--- a/homescreen_hero/web/routers/auth.py
+++ b/homescreen_hero/web/routers/auth.py
@@ -15,6 +15,7 @@ from homescreen_hero.core.auth import (
     CurrentUser,
     create_access_token,
     get_current_user,
+    require_admin,
     verify_password,
 )
 from homescreen_hero.core.config.loader import load_config
@@ -55,6 +56,26 @@ class AuthConfigResponse(BaseModel):
     method: Optional[str] = None
 
 
+class UserListItem(BaseModel):
+    id: int
+    plex_username: Optional[str] = None
+    plex_email: Optional[str] = None
+    plex_thumb: Optional[str] = None
+    role: str
+    status: str
+    created_at: datetime
+    last_login_at: Optional[datetime] = None
+
+
+class UserListResponse(BaseModel):
+    users: List[UserListItem]
+
+
+class UserUpdateRequest(BaseModel):
+    role: Optional[str] = None
+    status: Optional[str] = None
+
+
 class PlexPinRequest(BaseModel):
     forward_url: str
 
@@ -76,8 +97,10 @@ def _upsert_plex_user(
     email: str | None,
     thumb: str | None,
     role: str,
+    status: str = "approved",
 ) -> User:
     # Create or update a user by plex_id. Never downgrades admin to user.
+    # Status is only set on creation — existing users keep their current status.
     with session_scope() as db:
         user = db.query(User).filter(User.plex_id == plex_id).first()
         if user:
@@ -95,6 +118,7 @@ def _upsert_plex_user(
                 plex_email=email,
                 plex_thumb=thumb,
                 role=role,
+                status=status,
                 last_login_at=datetime.utcnow(),
             )
             db.add(user)
@@ -194,9 +218,15 @@ async def create_plex_login_pin(request: PlexPinRequest, http_request: Request) 
             detail="Plex login is not enabled. Use password authentication.",
         )
 
-    # Validate forward_url is same-origin to prevent open redirect via Plex
+    # Validate forward_url is same-origin to prevent open redirect via Plex.
+    # Use the Origin header (sent by browsers on POST) so this works behind
+    # proxies and when the frontend dev server is on a different port.
     parsed_forward = urlparse(request.forward_url)
-    request_origin = urlparse(str(http_request.base_url))
+    origin_header = http_request.headers.get("origin")
+    if origin_header:
+        request_origin = urlparse(origin_header)
+    else:
+        request_origin = urlparse(str(http_request.base_url))
     if parsed_forward.netloc and parsed_forward.netloc != request_origin.netloc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -276,13 +306,27 @@ async def plex_oauth_callback(request: PlexCallbackRequest) -> LoginResponse:
 
     # Create/update user in DB
     role = "admin" if result["is_owner"] else "user"
+
+    # Server owners are always approved; regular users depend on auto_approve setting
+    auto_approve = config.auth.auto_approve_users if config.auth else True
+    initial_status = "approved" if (role == "admin" or auto_approve) else "pending"
+
     user = _upsert_plex_user(
         plex_id=result["plex_id"],
         username=result["username"],
         email=result.get("email"),
         thumb=result.get("thumb"),
         role=role,
+        status=initial_status,
     )
+
+    # Don't issue a token for pending users
+    if user.status == "pending":
+        return Response(
+            content='{"status": "pending_approval", "message": "Your account is pending admin approval."}',
+            status_code=200,
+            media_type="application/json",
+        )
 
     # Issue JWT
     expires_delta = timedelta(days=config.auth.token_expire_days)
@@ -328,6 +372,86 @@ async def get_me(current_user: CurrentUser = Depends(get_current_user)) -> UserR
         role=current_user.role,
         thumb=thumb,
     )
+
+
+# --- User management (admin only) ---
+
+@router.get("/users", response_model=UserListResponse)
+async def list_users(
+    current_user: CurrentUser = Depends(require_admin),
+) -> UserListResponse:
+    with session_scope() as db:
+        users = db.query(User).order_by(User.created_at.desc()).all()
+        items = [
+            UserListItem(
+                id=u.id,
+                plex_username=u.plex_username,
+                plex_email=u.plex_email,
+                plex_thumb=u.plex_thumb,
+                role=u.role,
+                status=u.status,
+                created_at=u.created_at,
+                last_login_at=u.last_login_at,
+            )
+            for u in users
+        ]
+    return UserListResponse(users=items)
+
+
+@router.patch("/users/{user_id}")
+async def update_user(
+    user_id: int,
+    payload: UserUpdateRequest,
+    current_user: CurrentUser = Depends(require_admin),
+):
+    if current_user.id == user_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot modify your own account",
+        )
+
+    with session_scope() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        if payload.role is not None:
+            if payload.role not in ("admin", "user"):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Role must be 'admin' or 'user'",
+                )
+            user.role = payload.role
+
+        if payload.status is not None:
+            if payload.status not in ("approved", "pending"):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Status must be 'approved' or 'pending'",
+                )
+            user.status = payload.status
+
+    return {"ok": True}
+
+
+@router.delete("/users/{user_id}")
+async def delete_user(
+    user_id: int,
+    current_user: CurrentUser = Depends(require_admin),
+):
+    if current_user.id == user_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete your own account",
+        )
+
+    with session_scope() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        db.delete(user)
+
+    return {"ok": True}
 
 
 # --- Login page posters ---

--- a/homescreen_hero/web/routers/collections.py
+++ b/homescreen_hero/web/routers/collections.py
@@ -12,7 +12,7 @@ from cachetools import TTLCache
 
 from homescreen_hero.core.config.loader import load_config
 from homescreen_hero.core.config.schema import HealthResponse
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.db.history import init_db
 from homescreen_hero.core.db.tools import list_rotations
 from homescreen_hero.core.db.pinning import (
@@ -223,13 +223,13 @@ def invalidate_collections_cache():
 
 
 @router.get("/cache-version", response_model=CacheVersionResponse)
-def get_cache_version(_current_user: str = Depends(get_current_user)) -> CacheVersionResponse:
+def get_cache_version(_current_user: CurrentUser = Depends(require_admin)) -> CacheVersionResponse:
     """Get the current cache version to check if client-side cache should be invalidated."""
     return CacheVersionResponse(version=_cache_version)
 
 
 @router.post("/invalidate-cache")
-def invalidate_cache_endpoint(_current_user: str = Depends(get_current_user)) -> dict:
+def invalidate_cache_endpoint(_current_user: CurrentUser = Depends(require_admin)) -> dict:
     """API endpoint to invalidate client-side collections cache."""
     new_version = invalidate_collections_cache()
     return {"success": True, "version": new_version}
@@ -238,7 +238,7 @@ def invalidate_cache_endpoint(_current_user: str = Depends(get_current_user)) ->
 # Return the collections currently featured on the Plex home screen
 @router.get("/active", response_model=ActiveCollectionsResponse)
 def get_active_collections(
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> ActiveCollectionsResponse:
     init_db()
     config = load_config()
@@ -322,7 +322,7 @@ def get_active_collections(
 # Return all collections from the Plex library with their metadata, including active status.
 @router.get("/all", response_model=AllCollectionsResponse)
 def get_all_collections(
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> AllCollectionsResponse:
     init_db()
 
@@ -383,7 +383,7 @@ class GroupPostersResponse(BaseModel):
 @router.get("/group-posters", response_model=GroupPostersResponse)
 async def get_group_posters(
     collection_names: str,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> GroupPostersResponse:
     try:
         config = load_config()
@@ -508,7 +508,7 @@ class LibrariesResponse(BaseModel):
 
 @router.get("/libraries", response_model=LibrariesResponse)
 def get_available_libraries(
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> LibrariesResponse:
     """Get all available Plex library sections."""
     config = load_config()
@@ -547,7 +547,7 @@ def get_available_libraries(
 def get_collection_details(
     library: str,
     collection_title: str,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> CollectionDetailResponse:
     """Get detailed information about a specific collection, including all items."""
     config = load_config()
@@ -654,7 +654,7 @@ def search_library_items(
     query: Optional[str] = None,
     collection_title: Optional[str] = None,
     limit: int = 50,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> LibrarySearchResponse:
     config = load_config()
     server = get_plex_server(config)
@@ -718,7 +718,7 @@ def add_item_to_collection(
     library: str,
     collection_title: str,
     request: AddItemRequest,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     config = load_config()
     server = get_plex_server(config)
@@ -760,7 +760,7 @@ def remove_item_from_collection(
     library: str,
     collection_title: str,
     request: RemoveItemRequest,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     config = load_config()
     server = get_plex_server(config)
@@ -801,7 +801,7 @@ def remove_item_from_collection(
 @router.post("/create")
 def create_collection(
     request: CreateCollectionRequest,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     config = load_config()
     server = get_plex_server(config)
@@ -869,7 +869,7 @@ def update_collection(
     library: str,
     collection_title: str,
     request: UpdateCollectionRequest,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     config = load_config()
     server = get_plex_server(config)
@@ -958,7 +958,7 @@ def update_collection(
 def delete_collection(
     library: str,
     collection_title: str,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     config = load_config()
     server = get_plex_server(config)
@@ -1003,7 +1003,7 @@ async def upload_collection_poster(
     collection_title: str,
     file: Optional[UploadFile] = File(None),
     url: Optional[str] = Form(None),
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     """
     Upload a custom poster to a Plex collection.
@@ -1095,7 +1095,7 @@ async def upload_item_poster(
     rating_key: str,
     file: Optional[UploadFile] = File(None),
     url: Optional[str] = Form(None),
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     """
     Upload a custom poster to a Plex library item (movie or show).
@@ -1177,7 +1177,7 @@ async def upload_item_poster(
 
 @router.get("/pinned", response_model=PinnedCollectionsResponse)
 def get_pinned_collections_endpoint(
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> PinnedCollectionsResponse:
     init_db()
     pinned = get_pinned_collections()
@@ -1197,7 +1197,7 @@ def get_pinned_collections_endpoint(
 @router.post("/toggle-pin", response_model=TogglePinResponse)
 def toggle_pin_collection_endpoint(
     request: TogglePinRequest,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> TogglePinResponse:
     init_db()
     currently_pinned = is_collection_pinned(request.collection_name)
@@ -1275,7 +1275,7 @@ def toggle_pin_collection_endpoint(
 @router.post("/reorder", response_model=ReorderResponse)
 def reorder_collections_endpoint(
     request: ReorderCollectionsRequest,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> ReorderResponse:
     init_db()
     try:

--- a/homescreen_hero/web/routers/config/groups.py
+++ b/homescreen_hero/web/routers/config/groups.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.config.loader import (
     CONFIG_ENV_VAR,
     get_config_path,
@@ -38,7 +38,7 @@ router = APIRouter()
 # ========================================================================
 
 @router.get("/groups", response_model=list[CollectionGroupConfig])
-def list_groups(current_user: str = Depends(get_current_user)) -> list[CollectionGroupConfig]:
+def list_groups(current_user: CurrentUser = Depends(require_admin)) -> list[CollectionGroupConfig]:
     # Return list of all configured collection groups
     try:
         config = load_config()
@@ -52,7 +52,7 @@ def list_groups(current_user: str = Depends(get_current_user)) -> list[Collectio
 @router.post("/groups", response_model=ConfigSaveResponse)
 def create_group(
     payload: CollectionGroupPayload,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Append new collection group to config.yaml
     try:
@@ -85,7 +85,7 @@ def create_group(
 def update_group(
     index: int,
     payload: CollectionGroupPayload,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Replace existing collection group at given index in config.yaml
     try:
@@ -118,7 +118,7 @@ def update_group(
 @router.delete("/groups/{index}", response_model=ConfigSaveResponse)
 def delete_group(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Remove collection group at given index from config.yaml
     try:
@@ -152,7 +152,7 @@ def delete_group(
 @router.post("/groups/reorder", response_model=ConfigSaveResponse)
 def reorder_groups(
     payload: GroupReorderRequest,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Update display_order for each group based on the provided name ordering
     try:
@@ -190,7 +190,7 @@ def reorder_groups(
 # ========================================================================
 
 @router.get("/group-sources", response_model=CollectionSourcesResponse)
-def list_group_sources(current_user: str = Depends(get_current_user)) -> CollectionSourcesResponse:
+def list_group_sources(current_user: CurrentUser = Depends(require_admin)) -> CollectionSourcesResponse:
     # Return list of all available Plex collections and configured Trakt/Letterboxd sources
     try:
         config = load_config()
@@ -292,7 +292,7 @@ def list_group_sources(current_user: str = Depends(get_current_user)) -> Collect
 # ========================================================================
 
 @router.get("/validate", response_model=List[GroupValidationResult])
-def validate_config_groups(current_user: str = Depends(get_current_user)) -> List[GroupValidationResult]:
+def validate_config_groups(current_user: CurrentUser = Depends(require_admin)) -> List[GroupValidationResult]:
     # Validate configured collection groups against Plex collections
     config = load_config()
     server = get_plex_server(config)

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -420,9 +420,11 @@ class BackupStatusResponse(BaseModel):
     modified_at: Optional[str] = None
 
 
-class AuthMethodResponse(BaseModel):
+class AuthSettingsResponse(BaseModel):
     method: Literal["password", "plex", "both"]
+    auto_approve_users: bool
 
 
-class AuthMethodSaveRequest(BaseModel):
+class AuthSettingsSaveRequest(BaseModel):
     method: Literal["password", "plex", "both"]
+    auto_approve_users: bool

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -418,3 +418,11 @@ class ConfigImportResponse(BaseModel):
 class BackupStatusResponse(BaseModel):
     exists: bool
     modified_at: Optional[str] = None
+
+
+class AuthMethodResponse(BaseModel):
+    method: Literal["password", "plex", "both"]
+
+
+class AuthMethodSaveRequest(BaseModel):
+    method: Literal["password", "plex", "both"]

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -38,8 +38,8 @@ from .schemas import (
     SeerrConfigSaveRequest,
     RotationConfigSaveRequest,
     DisplaySettingsSaveRequest,
-    AuthMethodResponse,
-    AuthMethodSaveRequest,
+    AuthSettingsResponse,
+    AuthSettingsSaveRequest,
 )
 
 router = APIRouter()
@@ -635,13 +635,14 @@ def save_display_settings(
 # AUTH METHOD
 # ========================================================================
 
-@router.get("/auth-method", response_model=AuthMethodResponse)
-def get_auth_method(current_user: str = Depends(get_current_user)) -> AuthMethodResponse:
-    # Return the currently configured auth method
+@router.get("/auth-method", response_model=AuthSettingsResponse)
+def get_auth_settings(current_user: str = Depends(get_current_user)) -> AuthSettingsResponse:
+    # Return the currently configured auth settings
     try:
         config = load_config()
         method = config.auth.method if config.auth else "password"
-        return AuthMethodResponse(method=method)
+        auto_approve = config.auth.auto_approve_users if config.auth else True
+        return AuthSettingsResponse(method=method, auto_approve_users=auto_approve)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive
@@ -649,17 +650,18 @@ def get_auth_method(current_user: str = Depends(get_current_user)) -> AuthMethod
 
 
 @router.post("/auth-method", response_model=ConfigSaveResponse)
-def save_auth_method(
-    payload: AuthMethodSaveRequest,
+def save_auth_settings(
+    payload: AuthSettingsSaveRequest,
     current_user: str = Depends(get_current_user),
 ) -> ConfigSaveResponse:
-    # Update only auth.method in config.yaml, preserving all other auth settings
+    # Update auth settings in config.yaml, preserving sensitive fields
     try:
         data = load_config_mapping()
 
         auth_section = data.get("auth") if isinstance(data.get("auth"), dict) else {}
         auth_section = dict(auth_section)
         auth_section["method"] = payload.method
+        auth_section["auto_approve_users"] = payload.auto_approve_users
 
         data["auth"] = auth_section
         save_config_mapping(data)

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -21,6 +21,7 @@ from homescreen_hero.core.config.schema import (
     TautulliSettings,
     SeerrSettings,
     DisplaySettings,
+    AuthSettings,
 )
 from homescreen_hero.core.scheduler import update_rotation_schedule
 
@@ -37,6 +38,8 @@ from .schemas import (
     SeerrConfigSaveRequest,
     RotationConfigSaveRequest,
     DisplaySettingsSaveRequest,
+    AuthMethodResponse,
+    AuthMethodSaveRequest,
 )
 
 router = APIRouter()
@@ -619,6 +622,54 @@ def save_display_settings(
             path=str(config_path),
             env_override=CONFIG_ENV_VAR in os.environ,
             message="Display settings saved.",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ========================================================================
+# AUTH METHOD
+# ========================================================================
+
+@router.get("/auth-method", response_model=AuthMethodResponse)
+def get_auth_method(current_user: str = Depends(get_current_user)) -> AuthMethodResponse:
+    # Return the currently configured auth method
+    try:
+        config = load_config()
+        method = config.auth.method if config.auth else "password"
+        return AuthMethodResponse(method=method)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/auth-method", response_model=ConfigSaveResponse)
+def save_auth_method(
+    payload: AuthMethodSaveRequest,
+    current_user: str = Depends(get_current_user),
+) -> ConfigSaveResponse:
+    # Update only auth.method in config.yaml, preserving all other auth settings
+    try:
+        data = load_config_mapping()
+
+        auth_section = data.get("auth") if isinstance(data.get("auth"), dict) else {}
+        auth_section = dict(auth_section)
+        auth_section["method"] = payload.method
+
+        data["auth"] = auth_section
+        save_config_mapping(data)
+
+        config_path = get_config_path()
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message="Auth method saved.",
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -4,7 +4,7 @@ import os
 
 from fastapi import APIRouter, HTTPException, Depends
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, require_admin
 from homescreen_hero.core.config.loader import (
     CONFIG_ENV_VAR,
     get_config_path,
@@ -50,7 +50,7 @@ router = APIRouter()
 # ========================================================================
 
 @router.get("/plex", response_model=PlexSettings)
-def get_plex_settings(current_user: str = Depends(get_current_user)) -> PlexSettings:
+def get_plex_settings(_current_user: CurrentUser = Depends(require_admin)) -> PlexSettings:
     # Return the currently configured Plex settings
     try:
         config = load_config()
@@ -64,7 +64,7 @@ def get_plex_settings(current_user: str = Depends(get_current_user)) -> PlexSett
 @router.post("/plex", response_model=ConfigSaveResponse)
 def save_plex_settings(
     payload: PlexConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only Plex settings in config.yaml while preserving other keys
     try:
@@ -113,7 +113,7 @@ def save_plex_settings(
 # ========================================================================
 
 @router.get("/trakt", response_model=TraktSettings)
-def get_trakt_settings(current_user: str = Depends(get_current_user)) -> TraktSettings:
+def get_trakt_settings(_current_user: CurrentUser = Depends(require_admin)) -> TraktSettings:
     # Return the currently configured Trakt settings
     try:
         config = load_config()
@@ -127,7 +127,7 @@ def get_trakt_settings(current_user: str = Depends(get_current_user)) -> TraktSe
 @router.post("/trakt", response_model=ConfigSaveResponse)
 def save_trakt_settings(
     payload: TraktConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only Trakt settings in config.yaml while preserving other keys
     try:
@@ -173,7 +173,7 @@ def save_trakt_settings(
 # ========================================================================
 
 @router.get("/letterboxd", response_model=LetterboxdSettings)
-def get_letterboxd_settings(current_user: str = Depends(get_current_user)) -> LetterboxdSettings:
+def get_letterboxd_settings(_current_user: CurrentUser = Depends(require_admin)) -> LetterboxdSettings:
     # Return the currently configured Letterboxd settings
     try:
         config = load_config()
@@ -187,7 +187,7 @@ def get_letterboxd_settings(current_user: str = Depends(get_current_user)) -> Le
 @router.post("/letterboxd", response_model=ConfigSaveResponse)
 def save_letterboxd_settings(
     payload: LetterboxdConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only Letterboxd settings in config.yaml while preserving other keys
     try:
@@ -221,7 +221,7 @@ def save_letterboxd_settings(
 # ========================================================================
 
 @router.get("/mdblist", response_model=MDBListSettings)
-def get_mdblist_settings(current_user: str = Depends(get_current_user)) -> MDBListSettings:
+def get_mdblist_settings(_current_user: CurrentUser = Depends(require_admin)) -> MDBListSettings:
     # Return the currently configured MDBList settings
     try:
         config = load_config()
@@ -237,7 +237,7 @@ def get_mdblist_settings(current_user: str = Depends(get_current_user)) -> MDBLi
 @router.post("/mdblist", response_model=ConfigSaveResponse)
 def save_mdblist_settings(
     payload: MDBListConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only MDBList settings in config.yaml while preserving other keys
     try:
@@ -283,7 +283,7 @@ def save_mdblist_settings(
 # ========================================================================
 
 @router.get("/anilist", response_model=AniListSettings)
-def get_anilist_settings(current_user: str = Depends(get_current_user)) -> AniListSettings:
+def get_anilist_settings(_current_user: CurrentUser = Depends(require_admin)) -> AniListSettings:
     # Return the currently configured AniList settings
     try:
         config = load_config()
@@ -299,7 +299,7 @@ def get_anilist_settings(current_user: str = Depends(get_current_user)) -> AniLi
 @router.post("/anilist", response_model=ConfigSaveResponse)
 def save_anilist_settings(
     payload: AniListConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only AniList settings in config.yaml while preserving other keys
     try:
@@ -333,7 +333,7 @@ def save_anilist_settings(
 # ========================================================================
 
 @router.get("/mal", response_model=MALSettings)
-def get_mal_settings(current_user: str = Depends(get_current_user)) -> MALSettings:
+def get_mal_settings(_current_user: CurrentUser = Depends(require_admin)) -> MALSettings:
     # Return the currently configured MAL settings
     try:
         config = load_config()
@@ -349,7 +349,7 @@ def get_mal_settings(current_user: str = Depends(get_current_user)) -> MALSettin
 @router.post("/mal", response_model=ConfigSaveResponse)
 def save_mal_settings(
     payload: MALConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only MAL settings in config.yaml while preserving other keys
     try:
@@ -394,7 +394,7 @@ def save_mal_settings(
 # ========================================================================
 
 @router.get("/tautulli", response_model=TautulliSettings)
-def get_tautulli_settings(current_user: str = Depends(get_current_user)) -> TautulliSettings:
+def get_tautulli_settings(_current_user: CurrentUser = Depends(require_admin)) -> TautulliSettings:
     # Return the currently configured Tautulli settings
     try:
         config = load_config()
@@ -416,7 +416,7 @@ def get_tautulli_settings(current_user: str = Depends(get_current_user)) -> Taut
 @router.post("/tautulli", response_model=ConfigSaveResponse)
 def save_tautulli_settings(
     payload: TautulliConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only Tautulli settings in config.yaml while preserving other keys
     try:
@@ -464,7 +464,7 @@ def save_tautulli_settings(
 # ========================================================================
 
 @router.get("/seerr", response_model=SeerrSettings)
-def get_seerr_settings(current_user: str = Depends(get_current_user)) -> SeerrSettings:
+def get_seerr_settings(_current_user: CurrentUser = Depends(require_admin)) -> SeerrSettings:
     # Return the currently configured Seerr settings
     try:
         config = load_config()
@@ -484,7 +484,7 @@ def get_seerr_settings(current_user: str = Depends(get_current_user)) -> SeerrSe
 @router.post("/seerr", response_model=ConfigSaveResponse)
 def save_seerr_settings(
     payload: SeerrConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only Seerr settings in config.yaml while preserving other keys
     try:
@@ -530,7 +530,7 @@ def save_seerr_settings(
 # ========================================================================
 
 @router.get("/rotation", response_model=RotationSettings)
-def get_rotation_settings(current_user: str = Depends(get_current_user)) -> RotationSettings:
+def get_rotation_settings(_current_user: CurrentUser = Depends(require_admin)) -> RotationSettings:
     # Return all rotation scheduler configuration settings
     try:
         config = load_config()
@@ -544,7 +544,7 @@ def get_rotation_settings(current_user: str = Depends(get_current_user)) -> Rota
 @router.post("/rotation", response_model=ConfigSaveResponse)
 def save_rotation_settings(
     payload: RotationConfigSaveRequest,
-    current_user: str = Depends(get_current_user)
+    _current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Update only global rotation settings while preserving other config keys
     try:
@@ -594,7 +594,7 @@ def save_rotation_settings(
 # ========================================================================
 
 @router.get("/display", response_model=DisplaySettings)
-def get_display_settings(current_user: str = Depends(get_current_user)) -> DisplaySettings:
+def get_display_settings(_current_user: CurrentUser = Depends(require_admin)) -> DisplaySettings:
     # Return the currently configured display settings
     try:
         config = load_config()
@@ -608,7 +608,7 @@ def get_display_settings(current_user: str = Depends(get_current_user)) -> Displ
 @router.post("/display", response_model=ConfigSaveResponse)
 def save_display_settings(
     payload: DisplaySettingsSaveRequest,
-    current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Update display settings in config.yaml while preserving other keys
     try:
@@ -636,7 +636,7 @@ def save_display_settings(
 # ========================================================================
 
 @router.get("/auth-method", response_model=AuthSettingsResponse)
-def get_auth_settings(current_user: str = Depends(get_current_user)) -> AuthSettingsResponse:
+def get_auth_settings(_current_user: CurrentUser = Depends(require_admin)) -> AuthSettingsResponse:
     # Return the currently configured auth settings
     try:
         config = load_config()
@@ -652,7 +652,7 @@ def get_auth_settings(current_user: str = Depends(get_current_user)) -> AuthSett
 @router.post("/auth-method", response_model=ConfigSaveResponse)
 def save_auth_settings(
     payload: AuthSettingsSaveRequest,
-    current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Update auth settings in config.yaml, preserving sensitive fields
     try:

--- a/homescreen_hero/web/routers/config/setup.py
+++ b/homescreen_hero/web/routers/config/setup.py
@@ -9,7 +9,7 @@ import yaml
 from fastapi import APIRouter, HTTPException, Depends, UploadFile, File, Query
 from fastapi.responses import Response
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.config.loader import (
     CONFIG_ENV_VAR,
     get_config_path,
@@ -53,7 +53,7 @@ router = APIRouter()
 
 @router.get("/file", response_model=ConfigFileResponse)
 def read_config_file(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigFileResponse:
     # Return the current configuration file contents
     try:
@@ -68,7 +68,7 @@ def read_config_file(
 @router.post("/file", response_model=ConfigSaveResponse)
 def save_config(
     payload: ConfigUpdateRequest,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Validate and persist configuration updates provided as YAML text
     try:
@@ -94,7 +94,7 @@ def save_config(
 
 @router.get("/export")
 def export_config(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> Response:
     # Download the current config.yaml as a file attachment
     try:
@@ -117,7 +117,7 @@ def export_config(
 def import_config(
     file: UploadFile = File(...),
     validate_only: bool = Query(False),
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ):
     # Import a config.yaml file, optionally just validating without applying
     MAX_CONFIG_SIZE = 1_048_576  # 1 MB
@@ -194,7 +194,7 @@ def import_config(
 
 @router.get("/backup-status", response_model=BackupStatusResponse)
 def get_backup_status(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> BackupStatusResponse:
     # Check if a .bak backup file exists and when it was last modified
     backup_path = get_config_path().with_suffix(".yaml.bak")
@@ -208,7 +208,7 @@ def get_backup_status(
 
 @router.post("/revert", response_model=ConfigImportResponse)
 def revert_config(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigImportResponse:
     # Revert to the most recent .bak backup, backing up the current config first
     config_path = get_config_path()
@@ -423,12 +423,14 @@ def quick_start_setup(payload: QuickStartRequest) -> ConfigSaveResponse:
         if config_status.is_configured:
             try:
                 config = load_config()
-                # If auth is enabled and configured, reject the request
-                if config.auth.enabled and config.auth.password:
+                # If auth is enabled, reject — covers password, plex, and both modes
+                if config.auth and config.auth.enabled:
                     raise HTTPException(
                         status_code=403,
                         detail="Configuration is protected. Use the settings page to modify configuration."
                     )
+            except HTTPException:
+                raise
             except Exception:
                 # If we can't load config, allow the setup to proceed
                 pass

--- a/homescreen_hero/web/routers/config/sources.py
+++ b/homescreen_hero/web/routers/config/sources.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Depends
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.config.loader import (
     CONFIG_ENV_VAR,
     get_config_path,
@@ -66,7 +66,7 @@ router = APIRouter()
 # ========================================================================
 
 @router.get("/trakt/sources", response_model=list[TraktSource])
-def list_trakt_sources(current_user: str = Depends(get_current_user)) -> list[TraktSource]:
+def list_trakt_sources(current_user: CurrentUser = Depends(require_admin)) -> list[TraktSource]:
     # Return list of all configured Trakt sources
     try:
         config = load_config()
@@ -80,7 +80,7 @@ def list_trakt_sources(current_user: str = Depends(get_current_user)) -> list[Tr
 @router.post("/trakt/sources", response_model=ConfigSaveResponse)
 def create_trakt_source(
     payload: TraktSourcePayload,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Append new Trakt source to config.yaml
     try:
@@ -121,7 +121,7 @@ def create_trakt_source(
 def update_trakt_source(
     index: int,
     payload: TraktSourcePayload,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Replace existing Trakt source at given index in config.yaml
     try:
@@ -159,7 +159,7 @@ def update_trakt_source(
 @router.delete("/trakt/sources/{index}", response_model=ConfigSaveResponse)
 def delete_trakt_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Remove Trakt source at given index from config.yaml
     try:
@@ -197,7 +197,7 @@ def delete_trakt_source(
 
 @router.get("/trakt/sources/status", response_model=list[TraktSourceStatus])
 def get_trakt_sources_status(
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[TraktSourceStatus]:
     # Return sync status for each configured Trakt source.
     try:
@@ -231,7 +231,7 @@ def get_trakt_sources_status(
 @router.post("/trakt/sources/{index}/sync", response_model=TraktSyncResponse)
 def sync_trakt_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> TraktSyncResponse:
     # Manually sync a specific Trakt source to Plex collection.
     try:
@@ -296,7 +296,7 @@ def sync_trakt_source(
 @router.get("/trakt/sources/{index}/missing", response_model=list[TraktMissingItemOut])
 def get_missing_items_for_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[TraktMissingItemOut]:
     # Get items from a Trakt list that weren't found in Plex.
     try:
@@ -345,7 +345,7 @@ def get_missing_items_for_source(
 # ========================================================================
 
 @router.get("/letterboxd/sources", response_model=list[LetterboxdSource])
-def list_letterboxd_sources(current_user: str = Depends(get_current_user)) -> list[LetterboxdSource]:
+def list_letterboxd_sources(current_user: CurrentUser = Depends(require_admin)) -> list[LetterboxdSource]:
     # Return list of all configured Letterboxd sources
     try:
         config = load_config()
@@ -359,7 +359,7 @@ def list_letterboxd_sources(current_user: str = Depends(get_current_user)) -> li
 @router.post("/letterboxd/sources", response_model=ConfigSaveResponse)
 def create_letterboxd_source(
     payload: LetterboxdSourcePayload,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Append new Letterboxd source to config.yaml
     try:
@@ -400,7 +400,7 @@ def create_letterboxd_source(
 def update_letterboxd_source(
     index: int,
     payload: LetterboxdSourcePayload,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Replace existing Letterboxd source at given index in config.yaml
     try:
@@ -438,7 +438,7 @@ def update_letterboxd_source(
 @router.delete("/letterboxd/sources/{index}", response_model=ConfigSaveResponse)
 def delete_letterboxd_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Remove Letterboxd source at given index from config.yaml
     try:
@@ -476,7 +476,7 @@ def delete_letterboxd_source(
 
 @router.get("/letterboxd/sources/status", response_model=list[LetterboxdSourceStatus])
 def get_letterboxd_sources_status(
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[LetterboxdSourceStatus]:
     # Return sync status for each configured Letterboxd source.
     try:
@@ -510,7 +510,7 @@ def get_letterboxd_sources_status(
 @router.post("/letterboxd/sources/{index}/sync", response_model=LetterboxdSyncResponse)
 def sync_letterboxd_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> LetterboxdSyncResponse:
     # Manually sync a specific Letterboxd source to Plex collection.
     try:
@@ -574,7 +574,7 @@ def sync_letterboxd_source(
 @router.get("/letterboxd/sources/{index}/missing", response_model=list[LetterboxdMissingItemOut])
 def get_missing_items_for_letterboxd_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[LetterboxdMissingItemOut]:
     # Get items from a Letterboxd list that weren't found in Plex.
     try:
@@ -621,7 +621,7 @@ def get_missing_items_for_letterboxd_source(
 # ========================================================================
 
 @router.get("/mdblist/sources", response_model=list[MDBListSource])
-def list_mdblist_sources(current_user: str = Depends(get_current_user)) -> list[MDBListSource]:
+def list_mdblist_sources(current_user: CurrentUser = Depends(require_admin)) -> list[MDBListSource]:
     # Return list of all configured MDBList sources
     try:
         config = load_config()
@@ -635,7 +635,7 @@ def list_mdblist_sources(current_user: str = Depends(get_current_user)) -> list[
 @router.post("/mdblist/sources", response_model=ConfigSaveResponse)
 def create_mdblist_source(
     payload: MDBListSourcePayload,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Append new MDBList source to config.yaml
     try:
@@ -676,7 +676,7 @@ def create_mdblist_source(
 def update_mdblist_source(
     index: int,
     payload: MDBListSourcePayload,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Replace existing MDBList source at given index in config.yaml
     try:
@@ -714,7 +714,7 @@ def update_mdblist_source(
 @router.delete("/mdblist/sources/{index}", response_model=ConfigSaveResponse)
 def delete_mdblist_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Remove MDBList source at given index from config.yaml
     try:
@@ -752,7 +752,7 @@ def delete_mdblist_source(
 
 @router.get("/mdblist/sources/status", response_model=list[MDBListSourceStatus])
 def get_mdblist_sources_status(
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[MDBListSourceStatus]:
     # Return sync status for each configured MDBList source.
     try:
@@ -786,7 +786,7 @@ def get_mdblist_sources_status(
 @router.post("/mdblist/sources/{index}/sync", response_model=MDBListSyncResponse)
 def sync_mdblist_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> MDBListSyncResponse:
     # Manually sync a specific MDBList source to Plex collection.
     try:
@@ -850,7 +850,7 @@ def sync_mdblist_source(
 @router.get("/mdblist/sources/{index}/missing", response_model=list[MDBListMissingItemOut])
 def get_missing_items_for_mdblist_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[MDBListMissingItemOut]:
     # Get items from an MDBList list that weren't found in Plex.
     try:
@@ -901,7 +901,7 @@ def get_missing_items_for_mdblist_source(
 @router.get("/anilist/user-lists")
 def get_anilist_user_lists(
     username: str,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ):
     # Fetch list names for an AniList user (for the dropdown)
     from homescreen_hero.core.integrations.anilist_client import AniListClient, AniListConfig
@@ -920,7 +920,7 @@ def get_anilist_user_lists(
 
 
 @router.get("/anilist/sources", response_model=list[AniListSource])
-def list_anilist_sources(current_user: str = Depends(get_current_user)) -> list[AniListSource]:
+def list_anilist_sources(current_user: CurrentUser = Depends(require_admin)) -> list[AniListSource]:
     # Return list of all configured AniList sources
     try:
         config = load_config()
@@ -934,7 +934,7 @@ def list_anilist_sources(current_user: str = Depends(get_current_user)) -> list[
 @router.post("/anilist/sources", response_model=ConfigSaveResponse)
 def create_anilist_source(
     payload: AniListSourcePayload,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Append new AniList source to config.yaml
     try:
@@ -975,7 +975,7 @@ def create_anilist_source(
 def update_anilist_source(
     index: int,
     payload: AniListSourcePayload,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Replace existing AniList source at given index in config.yaml
     try:
@@ -1013,7 +1013,7 @@ def update_anilist_source(
 @router.delete("/anilist/sources/{index}", response_model=ConfigSaveResponse)
 def delete_anilist_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Remove AniList source at given index from config.yaml
     try:
@@ -1051,7 +1051,7 @@ def delete_anilist_source(
 
 @router.get("/anilist/sources/status", response_model=list[AniListSourceStatus])
 def get_anilist_sources_status(
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[AniListSourceStatus]:
     # Return sync status for each configured AniList source.
     try:
@@ -1085,7 +1085,7 @@ def get_anilist_sources_status(
 @router.post("/anilist/sources/{index}/sync", response_model=AniListSyncResponse)
 def sync_anilist_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> AniListSyncResponse:
     # Manually sync a specific AniList source to Plex collection.
     try:
@@ -1149,7 +1149,7 @@ def sync_anilist_source(
 @router.get("/anilist/sources/{index}/missing", response_model=list[AniListMissingItemOut])
 def get_missing_items_for_anilist_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[AniListMissingItemOut]:
     # Get items from an AniList list that weren't found in Plex.
     try:
@@ -1198,7 +1198,7 @@ def get_missing_items_for_anilist_source(
 # ========================================================================
 
 @router.get("/mal/sources", response_model=list[MALSource])
-def list_mal_sources(current_user: str = Depends(get_current_user)) -> list[MALSource]:
+def list_mal_sources(current_user: CurrentUser = Depends(require_admin)) -> list[MALSource]:
     # Return list of all configured MAL sources
     try:
         config = load_config()
@@ -1212,7 +1212,7 @@ def list_mal_sources(current_user: str = Depends(get_current_user)) -> list[MALS
 @router.post("/mal/sources", response_model=ConfigSaveResponse)
 def create_mal_source(
     payload: MALSourcePayload,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Append new MAL source to config.yaml
     try:
@@ -1253,7 +1253,7 @@ def create_mal_source(
 def update_mal_source(
     index: int,
     payload: MALSourcePayload,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ConfigSaveResponse:
     # Replace existing MAL source at given index in config.yaml
     try:
@@ -1291,7 +1291,7 @@ def update_mal_source(
 @router.delete("/mal/sources/{index}", response_model=ConfigSaveResponse)
 def delete_mal_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> ConfigSaveResponse:
     # Remove MAL source at given index from config.yaml
     try:
@@ -1329,7 +1329,7 @@ def delete_mal_source(
 
 @router.get("/mal/sources/status", response_model=list[MALSourceStatus])
 def get_mal_sources_status(
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[MALSourceStatus]:
     # Return sync status for each configured MAL source.
     try:
@@ -1363,7 +1363,7 @@ def get_mal_sources_status(
 @router.post("/mal/sources/{index}/sync", response_model=MALSyncResponse)
 def sync_mal_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> MALSyncResponse:
     # Manually sync a specific MAL source to Plex collection.
     try:
@@ -1427,7 +1427,7 @@ def sync_mal_source(
 @router.get("/mal/sources/{index}/missing", response_model=list[MALMissingItemOut])
 def get_missing_items_for_mal_source(
     index: int,
-    current_user: str = Depends(get_current_user)
+    current_user: CurrentUser = Depends(require_admin)
 ) -> list[MALMissingItemOut]:
     # Get items from a MAL list that weren't found in Plex.
     try:

--- a/homescreen_hero/web/routers/history.py
+++ b/homescreen_hero/web/routers/history.py
@@ -5,7 +5,7 @@ from typing import List
 
 from fastapi import APIRouter, HTTPException, Depends
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.config.schema import (
     ClearHistoryResponse,
     CollectionUsageOut,
@@ -57,7 +57,7 @@ def get_usage() -> List[CollectionUsageOut]:
 
 # Clear all rotation history and usage statistics from database
 @router.post("/clear", response_model=ClearHistoryResponse)
-def clear_history_endpoint(current_user: str = Depends(get_current_user)) -> ClearHistoryResponse:
+def clear_history_endpoint(current_user: CurrentUser = Depends(require_admin)) -> ClearHistoryResponse:
     try:
         logger.warning("Clearing rotation history on request")
         clear_history()

--- a/homescreen_hero/web/routers/integrations.py
+++ b/homescreen_hero/web/routers/integrations.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from ...core.auth import get_current_user
+from ...core.auth import CurrentUser, get_current_user, require_admin
 from .health import (
     _check_config,
     _check_trakt,
@@ -52,7 +52,7 @@ class IntegrationsHealthOut(BaseModel):
 
 @router.get("/health", response_model=IntegrationsHealthOut)
 def get_integrations_health(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> IntegrationsHealthOut:
     # Get health status for all configured integrations
         

--- a/homescreen_hero/web/routers/logs.py
+++ b/homescreen_hero/web/routers/logs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse, PlainTextResponse
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.logging_config import LOG_FILE
 
 router = APIRouter(prefix="/logs", tags=["logs"])
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/logs", tags=["logs"])
 @router.get("/tail", response_class=PlainTextResponse)
 def tail_logs(
     lines: int = 200,
-    _current_user: str = Depends(get_current_user),
+    _current_user: CurrentUser = Depends(require_admin),
 ) -> PlainTextResponse:
     try:
         path = LOG_FILE
@@ -32,7 +32,7 @@ def tail_logs(
 
 
 @router.get("/download")
-def download_logs(_current_user: str = Depends(get_current_user)):
+def download_logs(_current_user: CurrentUser = Depends(require_admin)):
     if not LOG_FILE.exists():
         raise HTTPException(status_code=404, detail="Log file not found.")
 

--- a/homescreen_hero/web/routers/rotation.py
+++ b/homescreen_hero/web/routers/rotation.py
@@ -6,7 +6,7 @@ from typing import Optional
 from fastapi import APIRouter, Form, HTTPException, Path, Depends
 from pydantic import BaseModel
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.service import (
     apply_simulation,
     run_rotation_once,
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/rotate")
 
 # Trigger a dry-run rotation and return the execution details as JSON, without touching Plex
 @router.post("/dry-run", response_model=RotationExecution)
-def rotate_dry_run(current_user: str = Depends(get_current_user)) -> RotationExecution:
+def rotate_dry_run(current_user: CurrentUser = Depends(require_admin)) -> RotationExecution:
     try:
         logger.info("Handling /rotate/dry-run request")
         execution = run_rotation_once(dry_run=True)
@@ -37,7 +37,7 @@ def rotate_dry_run(current_user: str = Depends(get_current_user)) -> RotationExe
 
 # Trigger an immediate rotation and return the execution details as JSON
 @router.post("/rotate-now", response_model=RotationExecution)
-def rotate_now(current_user: str = Depends(get_current_user)) -> RotationExecution:
+def rotate_now(current_user: CurrentUser = Depends(require_admin)) -> RotationExecution:
     try:
         logger.info("Handling /rotate-now request")
         execution = run_rotation_once(dry_run=False)
@@ -51,7 +51,7 @@ def rotate_now(current_user: str = Depends(get_current_user)) -> RotationExecuti
 
 # Simulate a rotation and return the simulation details as JSON, without touching Plex
 @router.post("/simulate-next", response_model=RotationExecution)
-def simulate_next_rotation(current_user: str = Depends(get_current_user)) -> RotationExecution:
+def simulate_next_rotation(current_user: CurrentUser = Depends(require_admin)) -> RotationExecution:
     try:
         logger.info("Handling /simulate-next request")
         execution = simulate_rotation_once()
@@ -65,7 +65,7 @@ def simulate_next_rotation(current_user: str = Depends(get_current_user)) -> Rot
 @router.post("/use-simulation/{simulation_id}", response_model=RotationExecution)
 def use_simulation(
     simulation_id: int = Path(..., description="ID of the previously simulated rotation"),
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> RotationExecution:
     try:
         logger.info("Applying simulation %s", simulation_id)
@@ -85,7 +85,7 @@ def use_simulation(
 @router.post("/use-simulation-form", response_model=RotationExecution)
 def use_simulation_form(
     simulation_id: int = Form(...),
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> RotationExecution:
     try:
         execution = apply_simulation(simulation_id)
@@ -107,7 +107,7 @@ class SchedulerStatusResponse(BaseModel):
 
 #Get the current scheduler status including next scheduled rotation time.
 @router.get("/scheduler-status", response_model=SchedulerStatusResponse)
-def get_scheduler_status(current_user: str = Depends(get_current_user)) -> SchedulerStatusResponse:
+def get_scheduler_status(current_user: CurrentUser = Depends(require_admin)) -> SchedulerStatusResponse:
     try:
         config = load_config()
 
@@ -139,7 +139,7 @@ class SyncResponse(BaseModel):
 
 # Manually sync all third party sources without running a rotation.
 @router.post("/sync-all", response_model=SyncResponse)
-def sync_all(current_user: str = Depends(get_current_user)) -> SyncResponse:
+def sync_all(current_user: CurrentUser = Depends(require_admin)) -> SyncResponse:
     try:
         logger.info("Handling /sync-all request")
         sync_all_sources()

--- a/homescreen_hero/web/routers/seerr.py
+++ b/homescreen_hero/web/routers/seerr.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 from homescreen_hero.core.config.loader import load_config
 from homescreen_hero.core.integrations.seerr_client import get_seerr_client
 
@@ -186,7 +186,7 @@ def get_seerr_requests(
     take: int = 5,
     skip: int = 0,
     filter: Optional[str] = None,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> SeerrRequestsResponse:
     # Get recent Seerr requests with optional status filter
     # filter values: "all", "pending", "approved", "available", "processing", etc.
@@ -295,7 +295,7 @@ def get_seerr_requests(
 @router.post("/requests/{request_id}/approve")
 def approve_seerr_request(
     request_id: int,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     # Approve a pending Seerr request
     try:
@@ -337,7 +337,7 @@ def approve_seerr_request(
 @router.post("/requests/{request_id}/decline")
 def decline_seerr_request(
     request_id: int,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     # Decline a pending Seerr request
     try:
@@ -379,7 +379,7 @@ def decline_seerr_request(
 @router.delete("/requests/{request_id}")
 def delete_seerr_request(
     request_id: int,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> dict:
     # Delete a Seerr request
     try:
@@ -421,7 +421,7 @@ def delete_seerr_request(
 @router.get("/requests/{request_id}", response_model=SeerrRequestDetail)
 def get_seerr_request_detail(
     request_id: int,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> SeerrRequestDetail:
     # Get detailed info for a single Seerr request
     try:
@@ -543,7 +543,7 @@ def get_seerr_request_detail(
 def search_seerr(
     query: str,
     page: int = 1,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> SeerrSearchResponse:
     # Search Overseerr for movies and TV shows
     try:
@@ -612,7 +612,7 @@ def search_seerr(
 
 @router.get("/services", response_model=ServicesResponse)
 def get_seerr_services(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> ServicesResponse:
     # Get available Radarr/Sonarr services with quality profiles
     try:
@@ -691,7 +691,7 @@ def get_seerr_services(
 @router.get("/tv/{tmdb_id}/seasons", response_model=List[SeasonInfo])
 def get_tv_seasons(
     tmdb_id: int,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> List[SeasonInfo]:
     # Get season info for a TV show
     try:
@@ -758,7 +758,7 @@ def get_tv_seasons(
 @router.post("/requests/new", response_model=CreateRequestResponse)
 def create_seerr_request(
     body: CreateRequestBody,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> CreateRequestResponse:
     # Create a new media request
     try:

--- a/homescreen_hero/web/routers/tools.py
+++ b/homescreen_hero/web/routers/tools.py
@@ -19,7 +19,7 @@ from homescreen_hero.core.integrations.plex_client import (
     get_server_for_user,
 )
 from homescreen_hero.core.integrations.tautulli_client import get_tautulli_client
-from homescreen_hero.core.auth import get_current_user
+from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
 
 
 logger = logging.getLogger(__name__)
@@ -176,7 +176,7 @@ class CopyWatchHistoryApplyResponse(BaseModel):
 def get_recent_media(
     library: str = "all",
     limit: int = 50,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> SearchMediaResponse:
     """Get recently added movies and shows, sorted by added_at descending."""
     config = load_config()
@@ -244,7 +244,7 @@ def search_media(
     query: str,
     library: str = "all",
     limit: int = 50,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> SearchMediaResponse:
     """Search for movies and shows across enabled libraries."""
     config = load_config()
@@ -313,7 +313,7 @@ def search_media(
 @router.post("/update-added-at", response_model=UpdateAddedAtResponse)
 def update_added_at(
     request: UpdateAddedAtRequest,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> UpdateAddedAtResponse:
     """Update the addedAt date for one or more media items."""
     config = load_config()
@@ -356,7 +356,7 @@ def search_shows(
     query: str,
     library: str = "all",
     limit: int = 50,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> SearchShowsResponse:
     """Search for TV shows with episode watch counts."""
     config = load_config()
@@ -418,7 +418,7 @@ def search_shows(
 @router.post("/mark-unwatched", response_model=MarkUnwatchedResponse)
 def mark_unwatched(
     request: MarkUnwatchedRequest,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> MarkUnwatchedResponse:
     """Mark all episodes of selected TV shows as unwatched."""
     config = load_config()
@@ -681,7 +681,7 @@ def _get_unwatched_items(
 @router.post("/unwatched-report", response_model=UnwatchedReportResponse)
 def generate_unwatched_report(
     request: UnwatchedReportRequest,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> UnwatchedReportResponse:
     # Generate a paginated report of unwatched items
     config = load_config()
@@ -727,7 +727,7 @@ def generate_unwatched_report(
 @router.post("/unwatched-report/export")
 def export_unwatched_report(
     request: UnwatchedReportRequest,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> Response:
     # Export unwatched report as CSV
     config = load_config()
@@ -798,7 +798,7 @@ def export_unwatched_report(
 
 @router.get("/home-users", response_model=HomeUsersResponse)
 def get_home_users_endpoint(
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> HomeUsersResponse:
     # Get list of Plex Home users available for watch history operations
     config = load_config()
@@ -816,7 +816,7 @@ def get_home_users_endpoint(
 @router.post("/copy-watch-history/preview", response_model=CopyWatchHistoryPreviewResponse)
 def preview_copy_watch_history(
     request: CopyWatchHistoryPreviewRequest,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> CopyWatchHistoryPreviewResponse:
     # Preview what would be changed when copying watch history
     config = load_config()
@@ -904,7 +904,7 @@ def preview_copy_watch_history(
 @router.post("/copy-watch-history/apply", response_model=CopyWatchHistoryApplyResponse)
 def apply_copy_watch_history(
     request: CopyWatchHistoryApplyRequest,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ) -> CopyWatchHistoryApplyResponse:
     # Apply watch history copy from source to target user
     config = load_config()
@@ -1004,7 +1004,7 @@ def apply_copy_watch_history(
 async def apply_copy_watch_history_stream(
     request: CopyWatchHistoryApplyRequest,
     req: Request,
-    current_user: str = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_admin),
 ):
     # SSE streaming version of apply - sends progress updates
     config = load_config()


### PR DESCRIPTION
## Feature: Plex Authentication + User Management

### Summary
Adds **Plex OAuth** login so users can sign in with their Plex account. The app verifies they have access to the configured server, and admins can manage users from the Settings page. All existing endpoints are admin-only, non-admin users just land on the _under-construction_ page.

### Major Changes
- Plex OAuth login flow with sign in with Plex, server access validation, and JWT token issuance
- User model and database table tracking Plex identity, role (admin/user), and approval status
- User management panel on Settings page to approve/deny users, change roles, and delete accounts
- ProtectedRoute supports role-based routing, with a placeholder user landing page for non-admin users

### Minor Changes
- `auto_approve_users` config option for controlling whether new users need admin approval
- Auth method configured via `auth.method`: `"password"`, `"plex"`, or `"both"` (default: `password`)

### Notes
- Local login is for the admin only. Regular users will only be able to login with their Plex accounts for the time being (no user specific functionality has been implemented yet however)