### PR TITLE
Feature: Smart Groups

### DIFF
--- a/homescreen-hero-ui/src/components/CollapsibleFormSection.tsx
+++ b/homescreen-hero-ui/src/components/CollapsibleFormSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { ChevronRight, type LucideIcon } from "lucide-react";
 
 interface CollapsibleFormSectionProps {
@@ -20,14 +20,10 @@ export default function CollapsibleFormSection({
     defaultExpanded = false,
     expanded,
 }: CollapsibleFormSectionProps) {
-    const [isExpanded, setIsExpanded] = useState(expanded ?? defaultExpanded);
-
-    // Sync with controlled prop when it changes
-    useEffect(() => {
-        if (expanded !== undefined) {
-            setIsExpanded(expanded);
-        }
-    }, [expanded]);
+    const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
+    const isControlled = expanded !== undefined;
+    const isExpanded = isControlled ? expanded : internalExpanded;
+    const setIsExpanded = isControlled ? () => {} : setInternalExpanded;
 
     return (
         <section className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 shadow-lg shadow-primary/5">

--- a/homescreen-hero-ui/src/components/SeerrCarouselCard.tsx
+++ b/homescreen-hero-ui/src/components/SeerrCarouselCard.tsx
@@ -61,7 +61,7 @@ function SkeletonItem() {
 
 export default function SeerrCarouselCard({ loading }: { loading?: boolean }) {
     const [requests, setRequests] = useState<SeerrRequest[]>([]);
-    const [_totalResults, setTotalResults] = useState(0);
+    const [, setTotalResults] = useState(0);
     const [requestsLoading, setRequestsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [seerrEnabled, setSeerrEnabled] = useState<boolean | null>(null);

--- a/homescreen-hero-ui/src/components/SeerrNewRequestModal.tsx
+++ b/homescreen-hero-ui/src/components/SeerrNewRequestModal.tsx
@@ -119,7 +119,7 @@ export default function SeerrNewRequestModal({
             }
 
             const results = await Promise.all(promises);
-            const servicesData: ServicesResponse = results[0];
+            const servicesData = results[0] as ServicesResponse;
             setServices(servicesData);
 
             // Set default service and profile
@@ -135,7 +135,7 @@ export default function SeerrNewRequestModal({
 
             // Handle seasons for TV
             if (result.mediaType === "tv" && results[1]) {
-                const seasonsData: SeasonInfo[] = results[1];
+                const seasonsData = results[1] as SeasonInfo[];
                 setSeasons(seasonsData);
                 // Pre-select all seasons
                 setSelectedSeasons(seasonsData.map((s) => s.seasonNumber));

--- a/homescreen-hero-ui/src/components/SeerrNewRequestModal.tsx
+++ b/homescreen-hero-ui/src/components/SeerrNewRequestModal.tsx
@@ -71,8 +71,8 @@ export default function SeerrNewRequestModal({
     onRequestCreated,
     seerrBaseUrl,
 }: Props) {
-    const [_mediaDetail, setMediaDetail] = useState<MediaDetail | null>(null);
-    const [_services, setServices] = useState<ServicesResponse | null>(null);
+    const [, setMediaDetail] = useState<MediaDetail | null>(null);
+    const [, setServices] = useState<ServicesResponse | null>(null);
     const [seasons, setSeasons] = useState<SeasonInfo[]>([]);
     const [selectedSeasons, setSelectedSeasons] = useState<number[]>([]);
     const [selectedService, setSelectedService] = useState<ServiceInfo | null>(null);
@@ -105,7 +105,7 @@ export default function SeerrNewRequestModal({
 
         try {
             // Load media details, services, and seasons (for TV) in parallel
-            const promises: Promise<any>[] = [
+            const promises: Promise<unknown>[] = [
                 fetchWithAuth(`/api/admin/seerr/services`).then((r) => r.json()),
             ];
 

--- a/homescreen-hero-ui/src/components/Toast.tsx
+++ b/homescreen-hero-ui/src/components/Toast.tsx
@@ -10,7 +10,10 @@ type ToastProps = {
 
 export default function Toast({ message, type, onClose, duration = 3000 }: ToastProps) {
     const onCloseRef = useRef(onClose);
-    onCloseRef.current = onClose;
+
+    useEffect(() => {
+        onCloseRef.current = onClose;
+    });
 
     useEffect(() => {
         const timer = setTimeout(() => onCloseRef.current(), duration);

--- a/homescreen-hero-ui/src/components/integrations/MALIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/MALIntegration.tsx
@@ -60,6 +60,42 @@ function capitalize(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+function MaxItemsStepper({ value, onChange, disabled }: { value: number; onChange: (v: number) => void; disabled: boolean }) {
+    return (
+        <div className="flex items-center rounded-lg border border-slate-700 bg-slate-950 overflow-hidden">
+            <span className="pl-2.5 text-xs text-slate-500 whitespace-nowrap select-none">Max</span>
+            <button
+                type="button"
+                disabled={disabled || value <= 10}
+                onClick={() => onChange(Math.max(10, value - 10))}
+                className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+                <Minus className="h-3.5 w-3.5" />
+            </button>
+            <input
+                type="number"
+                min={10}
+                max={500}
+                step={10}
+                value={value}
+                onChange={(e) => onChange(Number(e.target.value) || 0)}
+                onBlur={() => onChange(Math.max(10, Math.min(500, value || 100)))}
+                disabled={disabled}
+                className="w-10 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                title="Max items"
+            />
+            <button
+                type="button"
+                disabled={disabled || value >= 500}
+                onClick={() => onChange(Math.min(500, value + 10))}
+                className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+                <Plus className="h-3.5 w-3.5" />
+            </button>
+        </div>
+    );
+}
+
 export function MALIntegration() {
     const { enabledLibraries } = usePlexLibraries();
 
@@ -204,41 +240,6 @@ export function MALIntegration() {
     }, [canAddSeasonal, season, seasonYear, seasonCollectionName, seasonPlexLibrary, seasonMaxItems, integration]);
 
     const formDisabled = integration.savingSource || integration.loadingSources;
-
-    // Reusable max items stepper
-    const MaxItemsStepper = ({ value, onChange, disabled }: { value: number; onChange: (v: number) => void; disabled: boolean }) => (
-        <div className="flex items-center rounded-lg border border-slate-700 bg-slate-950 overflow-hidden">
-            <span className="pl-2.5 text-xs text-slate-500 whitespace-nowrap select-none">Max</span>
-            <button
-                type="button"
-                disabled={disabled || value <= 10}
-                onClick={() => onChange(Math.max(10, value - 10))}
-                className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-                <Minus className="h-3.5 w-3.5" />
-            </button>
-            <input
-                type="number"
-                min={10}
-                max={500}
-                step={10}
-                value={value}
-                onChange={(e) => onChange(Number(e.target.value) || 0)}
-                onBlur={() => onChange(Math.max(10, Math.min(500, value || 100)))}
-                disabled={disabled}
-                className="w-10 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                title="Max items"
-            />
-            <button
-                type="button"
-                disabled={disabled || value >= 500}
-                onClick={() => onChange(Math.min(500, value + 10))}
-                className="flex items-center justify-center h-9 w-8 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-                <Plus className="h-3.5 w-3.5" />
-            </button>
-        </div>
-    );
 
     return (
         <div className="space-y-4">

--- a/homescreen-hero-ui/src/components/ui/button.tsx
+++ b/homescreen-hero-ui/src/components/ui/button.tsx
@@ -50,4 +50,5 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants };

--- a/homescreen-hero-ui/src/index.css
+++ b/homescreen-hero-ui/src/index.css
@@ -325,3 +325,19 @@ select option {
     transform: translateY(-8px) scale(0.98);
     transition: all 0.2s ease-out;
 }
+
+/* ===== Preview Poster Animations ===== */
+@keyframes poster-enter {
+    from {
+        opacity: 0;
+        transform: scale(0.92);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.preview-poster-enter {
+    animation: poster-enter 0.35s ease-out both;
+}

--- a/homescreen-hero-ui/src/index.css
+++ b/homescreen-hero-ui/src/index.css
@@ -303,3 +303,25 @@ select option {
 .edit-mode-widget:hover {
     animation: none;
 }
+
+/* ===== Rule Card Animations ===== */
+@keyframes rule-card-in {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.rule-card-enter {
+    animation: rule-card-in 0.2s ease-out;
+}
+
+.rule-card-exit {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+    transition: all 0.2s ease-out;
+}

--- a/homescreen-hero-ui/src/main.tsx
+++ b/homescreen-hero-ui/src/main.tsx
@@ -10,6 +10,7 @@ import SettingsPage from "./pages/SettingsPage";
 import IntegrationsPage from "./pages/IntegrationsPage";
 import GroupsPage from "./pages/GroupsPage";
 import GroupDetailPage from "./pages/GroupDetailPage";
+import SmartGroupDetailPage from "./pages/SmartGroupDetailPage";
 import LoginPage from "./pages/LoginPage";
 import QuickStartPage from "./pages/QuickStartPage";
 import { ThemeProvider } from "./utils/theme";
@@ -50,6 +51,8 @@ const router = createBrowserRouter([
       { path: "/", element: <DashboardPage /> },
       { path: "/dashboard", element: <Navigate to="/" replace /> },
       { path: "/groups", element: <GroupsPage /> },
+      { path: "/groups/smart/new", element: <SmartGroupDetailPage /> },
+      { path: "/groups/smart/:groupId", element: <SmartGroupDetailPage /> },
       { path: "/groups/:groupId", element: <GroupDetailPage /> },
       { path: "/collections", element: <CollectionsPage /> },
       { path: "/collections/:library/:collectionTitle", element: <CollectionDetailPage /> },

--- a/homescreen-hero-ui/src/pages/CollectionDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/CollectionDetailPage.tsx
@@ -182,7 +182,7 @@ export default function CollectionDetailPage() {
 
             // Reload collection and search results
             await Promise.all([loadCollectionDetails(), searchLibrary(searchQuery)]);
-        } catch (err) {
+        } catch {
             setToast({ message: "Failed to add items", type: "error" });
         } finally {
             setAdding(false);
@@ -214,7 +214,7 @@ export default function CollectionDetailPage() {
             setToast({ message: data.message || "Item removed successfully!", type: "success" });
 
             await loadCollectionDetails();
-        } catch (err) {
+        } catch {
             setToast({ message: "Failed to remove item", type: "error" });
         }
     };
@@ -329,7 +329,7 @@ export default function CollectionDetailPage() {
                 // Just reload to show changes
                 await loadCollectionDetails();
             }
-        } catch (err) {
+        } catch {
             setToast({ message: "Failed to update collection", type: "error" });
         } finally {
             setUpdating(false);
@@ -388,7 +388,7 @@ export default function CollectionDetailPage() {
             setToast({ message: "Poster updated successfully!", type: "success" });
             closeItemPosterModal();
             await loadCollectionDetails();
-        } catch (err) {
+        } catch {
             setToast({ message: "Failed to upload poster", type: "error" });
         } finally {
             setUploadingItemPoster(false);

--- a/homescreen-hero-ui/src/pages/DashboardPage.tsx
+++ b/homescreen-hero-ui/src/pages/DashboardPage.tsx
@@ -164,11 +164,12 @@ export default function Dashboard() {
     };
 
     const plex = health.plex;
+    const plexDetails = plex?.details as { server_name?: string; libraries?: unknown[]; enabled_count?: number } | undefined;
 
-    const plexServerName = plex?.details?.server_name ?? plex?.server_name ?? "Plex";
-    const plexLibraries = plex?.details?.libraries;
+    const plexServerName = plexDetails?.server_name ?? "Plex";
+    const plexLibraries = plexDetails?.libraries;
     const plexLibraryInfo = plexLibraries
-        ? `${plex?.details?.enabled_count ?? plexLibraries.length} ${plexLibraries.length === 1 ? 'library' : 'libraries'}`
+        ? `${plexDetails?.enabled_count ?? plexLibraries.length} ${plexLibraries.length === 1 ? 'library' : 'libraries'}`
         : null;
     const plexDetail = [plexServerName, plexLibraryInfo]
         .filter((value): value is string => Boolean(value))

--- a/homescreen-hero-ui/src/pages/DashboardPage.tsx
+++ b/homescreen-hero-ui/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo, useRef } from "react";
 import { DndContext, rectIntersection, DragOverlay } from "@dnd-kit/core";
-import type { DragEndEvent, DragStartEvent, DragOverEvent } from "@dnd-kit/core";
+import type { DragStartEvent, DragOverEvent } from "@dnd-kit/core";
 import { Lock, Unlock, ChevronDown, Users } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../utils/auth";
@@ -30,7 +30,7 @@ type RotationHistoryItem = {
     featured_collections: string[];
 };
 
-type HealthComponent = { ok: boolean; error?: string;[k: string]: any };
+type HealthComponent = { ok: boolean; error?: string;[k: string]: unknown };
 
 type RotationExecution = {
     rotation: {
@@ -159,7 +159,7 @@ export default function Dashboard() {
     };
 
     // Handle drag end - just clear the active state
-    const handleDragEnd = (_event: DragEndEvent) => {
+    const handleDragEnd = () => {
         setActiveId(null);
     };
 

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -74,7 +74,6 @@ export default function GroupDetailPage() {
     const [selectedIndex, setSelectedIndex] = useState<number | "new">("new");
     const [form, setForm] = useState<CollectionGroup>(emptyGroup);
     const [loading, setLoading] = useState(true);
-    const [saving, setSaving] = useState(false);
     const [deleting, setDeleting] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -104,9 +103,7 @@ export default function GroupDetailPage() {
 
     useEffect(() => {
         if (groupId === "new") {
-            setSelectedIndex("new");
-            setForm(emptyGroup);
-            savedFormRef.current = "";
+            navigate("/groups", { replace: true });
             return;
         }
 
@@ -202,11 +199,11 @@ export default function GroupDetailPage() {
         };
     }, [form, selectedIndex, autoSave]);
 
-    const resetToNew = () => {
+    const goToGroupsList = () => {
         flushAutoSave();
         setMessage(null);
         setError(null);
-        navigate("/groups/new", { replace: true });
+        navigate("/groups", { replace: true });
     };
 
     const onSelectGroup = (index: number) => {
@@ -299,45 +296,6 @@ export default function GroupDetailPage() {
         setCurrentPage(1);
     }, [sourceFilter, searchQuery]);
 
-    const createGroup = async () => {
-        try {
-            setSaving(true);
-            setError(null);
-            setMessage(null);
-
-            const payload: CollectionGroup = {
-                ...form,
-                date_range:
-                    form.date_range && form.date_range.start && form.date_range.end
-                        ? form.date_range
-                        : null,
-            };
-
-            const r = await fetchWithAuth("/api/admin/config/groups", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(payload),
-            });
-
-            const text = await r.text();
-            if (!r.ok) throw new Error(text || "Failed to create group");
-
-            const resp = JSON.parse(text) as ConfigSaveResponse;
-            setMessage(resp.message);
-
-            const nextGroups = await fetchWithAuth("/api/admin/config/groups").then((res) => res.json());
-            setGroups(nextGroups);
-            const targetIndex = nextGroups.length - 1;
-            if (targetIndex >= 0) {
-                navigate(`/groups/${targetIndex}`);
-            }
-        } catch (e) {
-            setError(String(e));
-        } finally {
-            setSaving(false);
-        }
-    };
-
     const deleteGroup = async () => {
         if (selectedIndex === "new") return;
         if (debounceRef.current) {
@@ -361,7 +319,7 @@ export default function GroupDetailPage() {
             if (nextGroups.length) {
                 navigate(`/groups/0`, { replace: true });
             } else {
-                resetToNew();
+                goToGroupsList();
             }
         } catch (e) {
             setError(String(e));
@@ -392,7 +350,7 @@ export default function GroupDetailPage() {
 
                 <div className="flex items-start justify-between gap-4">
                     <div>
-                        {renaming && selectedIndex !== "new" ? (
+                        {renaming ? (
                             <input
                                 autoFocus
                                 value={form.name}
@@ -405,17 +363,16 @@ export default function GroupDetailPage() {
                         ) : (
                             <div className="relative flex items-center gap-3">
                                 <span
-                                    onClick={selectedIndex !== "new" ? () => setRenaming(true) : undefined}
-                                    className={`text-3xl font-black tracking-tight text-white ${selectedIndex !== "new" ? "hover:text-slate-200 cursor-text transition-colors" : ""}`}
+                                    onClick={() => setRenaming(true)}
+                                    className="text-3xl font-black tracking-tight text-white hover:text-slate-200 cursor-text transition-colors"
                                 >
-                                    {selectedIndex === "new" ? "Create New Group" : form.name || "Untitled Group"}
+                                    {form.name || "Untitled Group"}
                                 </span>
                                 {groups.length > 0 && (
                                     <Listbox
                                         value={selectedIndex}
                                         onChange={(val: number | "new") => {
-                                            if (val === "new") resetToNew();
-                                            else onSelectGroup(val);
+                                            if (typeof val === "number") onSelectGroup(val);
                                         }}
                                     >
                                         <div>
@@ -451,20 +408,11 @@ export default function GroupDetailPage() {
                                                         </Listbox.Option>
                                                     );
                                                 })}
-                                                <div className="border-t border-slate-700/50 mt-1 pt-1">
-                                                    <Listbox.Option
-                                                        value="new"
-                                                        className="cursor-pointer px-4 py-2.5 hover:bg-slate-700 data-[selected]:bg-primary/15 flex items-center gap-2 text-slate-300"
-                                                    >
-                                                        <Plus className="h-4 w-4" />
-                                                        <span className="text-sm font-semibold">Create new group</span>
-                                                    </Listbox.Option>
-                                                </div>
                                             </Listbox.Options>
                                         </div>
                                     </Listbox>
                                 )}
-                                {selectedIndex !== "new" && (() => {
+                                {(() => {
                                     const status = getGroupStatus(form);
                                     const pillStyles = {
                                         active: "bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/25",
@@ -494,11 +442,6 @@ export default function GroupDetailPage() {
                                 })()}
                             </div>
                         )}
-                        {selectedIndex === "new" && (
-                            <p className="text-slate-400 text-sm mt-1">
-                                Configure content sources, rotation schedules, and display rules for your homescreen.
-                            </p>
-                        )}
                     </div>
 
                     <div className="flex items-center gap-2">
@@ -510,27 +453,14 @@ export default function GroupDetailPage() {
                             <SlidersHorizontal className="h-4 w-4 text-primary" />
                             Group Settings
                         </button>
-                        {selectedIndex !== "new" && (
-                            <button
-                                type="button"
-                                onClick={() => setShowDeleteConfirm(true)}
-                                disabled={deleting}
-                                className="flex items-center justify-center p-2 rounded-lg border border-slate-700 bg-slate-900 text-slate-400 hover:border-red-500/50 hover:text-red-400 transition-all duration-200 disabled:opacity-50"
-                            >
-                                {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-                            </button>
-                        )}
-                        {selectedIndex === "new" && (
-                            <button
-                                type="button"
-                                onClick={createGroup}
-                                disabled={saving}
-                                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-bold shadow-lg shadow-primary/30 hover:shadow-primary/40 transition-all duration-200 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-                                Create Group
-                            </button>
-                        )}
+                        <button
+                            type="button"
+                            onClick={() => setShowDeleteConfirm(true)}
+                            disabled={deleting}
+                            className="flex items-center justify-center p-2 rounded-lg border border-slate-700 bg-slate-900 text-slate-400 hover:border-red-500/50 hover:text-red-400 transition-all duration-200 disabled:opacity-50"
+                        >
+                            {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                        </button>
                     </div>
                 </div>
             </div>
@@ -541,17 +471,6 @@ export default function GroupDetailPage() {
                     <p className="text-sm whitespace-pre-wrap">{error}</p>
                 </div>
             ) : null}
-
-            {/* Group Name (new groups only) */}
-            {selectedIndex === "new" && (
-                <input
-                    type="text"
-                    value={form.name}
-                    onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-                    className="px-4 py-2.5 bg-slate-800/60 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
-                    placeholder="Group Name (Required)"
-                />
-            )}
 
             {/* Content Sources Section */}
             <section className="rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 shadow-lg shadow-primary/5 p-6 space-y-6">

--- a/homescreen-hero-ui/src/pages/GroupsPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupsPage.tsx
@@ -474,6 +474,30 @@ export default function GroupsPage() {
         }
     };
 
+    const toggleEnabled = async (index: number) => {
+        const target = groups[index];
+        if (!target) return;
+
+        // Optimistic update — flip locally first to avoid full re-render flash
+        setGroups((prev) => prev.map((g, i) => i === index ? { ...g, enabled: !g.enabled } : g));
+
+        try {
+            const payload = { ...target, enabled: !target.enabled };
+            const r = await fetchWithAuth(`/api/admin/config/groups/${index}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+            if (!r.ok) {
+                // Revert on failure
+                setGroups((prev) => prev.map((g, i) => i === index ? { ...g, enabled: target.enabled } : g));
+                throw new Error(await r.text() || "Failed to update group");
+            }
+        } catch (e) {
+            setError(String(e));
+        }
+    };
+
     const handleDelete = async (index: number) => {
         const target = groups[index];
         if (!target) return;
@@ -786,13 +810,17 @@ export default function GroupsPage() {
                                                         onClick={() => navigate(group.smart ? `/groups/smart/${originalIndex}` : `/groups/${originalIndex}`)}
                                                         className="group flex flex-1 items-center gap-4 rounded-xl border border-slate-800/60 bg-slate-900/50 px-4 py-3 hover:border-slate-700 hover:bg-slate-900/80 transition-all duration-200 cursor-pointer"
                                                     >
-                                                        <span className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${statusStyles[status]}`}>
+                                                        <button
+                                                            type="button"
+                                                            onClick={(e) => { e.stopPropagation(); toggleEnabled(originalIndex); }}
+                                                            disabled={processingIndex === originalIndex}
+                                                            className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-all duration-200 hover:brightness-125 disabled:opacity-60 ${statusStyles[status]}`}
+                                                        >
                                                             {statusLabels[status]}
-                                                        </span>
+                                                        </button>
                                                         {group.smart && (
-                                                            <span className="shrink-0 rounded-full bg-primary/20 text-primary border border-primary/30 px-2.5 py-0.5 text-xs font-semibold flex items-center gap-1">
+                                                            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/20 text-primary border border-primary/30">
                                                                 <Sparkles className="h-3 w-3" />
-                                                                Smart
                                                             </span>
                                                         )}
 
@@ -861,30 +889,36 @@ export default function GroupsPage() {
                                                 >
                                                     <div className="relative">
                                                         {renderCover(group, index)}
-                                                        {(() => {
-                                                            const status = getGroupStatus(group);
-                                                            const statusStyles = {
-                                                                active: 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 shadow-lg shadow-emerald-500/20',
-                                                                scheduled: 'bg-amber-500/20 text-amber-400 border border-amber-500/30 shadow-lg shadow-amber-500/20',
-                                                                disabled: 'bg-slate-500/20 text-slate-400 border border-slate-500/30 shadow-lg shadow-slate-500/20',
-                                                            };
-                                                            const statusLabels = {
-                                                                active: 'Active',
-                                                                scheduled: 'Scheduled',
-                                                                disabled: 'Disabled',
-                                                            };
-                                                            return (
-                                                                <div className={`absolute left-3 top-3 rounded-full px-3 py-1 text-xs font-semibold backdrop-blur-sm transition-all duration-200 ${statusStyles[status]}`}>
-                                                                    {statusLabels[status]}
+                                                        <div className="absolute left-3 top-3 flex items-center gap-1.5">
+                                                            {(() => {
+                                                                const status = getGroupStatus(group);
+                                                                const statusStyles = {
+                                                                    active: 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 shadow-lg shadow-emerald-500/20',
+                                                                    scheduled: 'bg-amber-500/20 text-amber-400 border border-amber-500/30 shadow-lg shadow-amber-500/20',
+                                                                    disabled: 'bg-slate-500/20 text-slate-400 border border-slate-500/30 shadow-lg shadow-slate-500/20',
+                                                                };
+                                                                const statusLabels = {
+                                                                    active: 'Active',
+                                                                    scheduled: 'Scheduled',
+                                                                    disabled: 'Disabled',
+                                                                };
+                                                                return (
+                                                                    <button
+                                                                        type="button"
+                                                                        onClick={(e) => { e.stopPropagation(); toggleEnabled(originalIndex); }}
+                                                                        disabled={processingIndex === originalIndex}
+                                                                        className={`rounded-full px-3 py-1 text-xs font-semibold backdrop-blur-sm transition-all duration-200 hover:brightness-125 disabled:opacity-60 ${statusStyles[status]}`}
+                                                                    >
+                                                                        {statusLabels[status]}
+                                                                    </button>
+                                                                );
+                                                            })()}
+                                                            {group.smart && (
+                                                                <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-primary border border-primary/30 backdrop-blur-sm">
+                                                                    <Sparkles className="h-3 w-3" />
                                                                 </div>
-                                                            );
-                                                        })()}
-                                                        {group.smart && (
-                                                            <div className="absolute left-3 top-11 rounded-full bg-primary/20 text-primary border border-primary/30 backdrop-blur-sm px-3 py-1 text-xs font-semibold flex items-center gap-1">
-                                                                <Sparkles className="h-3 w-3" />
-                                                                Smart
-                                                            </div>
-                                                        )}
+                                                            )}
+                                                        </div>
                                                         {(group.date_range?.start || group.date_range?.end) && (
                                                             <div className="absolute right-12 top-3 rounded-full bg-slate-900/80 backdrop-blur-sm px-3 py-1 text-xs font-semibold text-slate-100 border border-slate-700/50">
                                                                 {group.date_range?.start ? new Date(group.date_range.start).toLocaleDateString('en', { month: '2-digit', day: '2-digit' }) : '??/??'}

--- a/homescreen-hero-ui/src/pages/GroupsPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupsPage.tsx
@@ -44,6 +44,14 @@ import { CSS } from "@dnd-kit/utilities";
 import GroupCoverMosaic from "../components/GroupCoverMosaic";
 import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogCloseButton,
+} from "../components/ui/dialog";
+import {
     Sheet,
     SheetContent,
     SheetHeader,
@@ -53,6 +61,7 @@ import {
     SheetCloseButton,
 } from "../components/ui/sheet";
 import { getGroupStatus } from "../utils/dates";
+import { Sparkles } from "lucide-react";
 
 type DateRange = {
     start: string;
@@ -68,6 +77,8 @@ type CollectionGroup = {
     min_gap_rotations: number;
     display_order: number;
     date_range?: DateRange | null;
+    smart?: boolean;
+    rules?: unknown[];
     collections: string[];
 };
 
@@ -190,6 +201,9 @@ export default function GroupsPage() {
     const [libraries, setLibraries] = useState<PlexLibrary[]>([]);
     const [savingAutoRotate, setSavingAutoRotate] = useState(false);
     const [rotationSettings, setRotationSettings] = useState<RotationSettings | null>(null);
+
+    // Group type picker dialog
+    const [showTypePicker, setShowTypePicker] = useState(false);
 
     // Display settings state
     const [displaySettings, setDisplaySettings] = useState<DisplaySettings>({ group_display_mode: "grouped" });
@@ -765,17 +779,25 @@ export default function GroupsPage() {
                                                     </div>
                                                 ) : (
                                                     <div
-                                                        onClick={() => navigate(`/groups/${originalIndex}`)}
+                                                        onClick={() => navigate(group.smart ? `/groups/smart/${originalIndex}` : `/groups/${originalIndex}`)}
                                                         className="group flex flex-1 items-center gap-4 rounded-xl border border-slate-800/60 bg-slate-900/50 px-4 py-3 hover:border-slate-700 hover:bg-slate-900/80 transition-all duration-200 cursor-pointer"
                                                     >
                                                         <span className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${statusStyles[status]}`}>
                                                             {statusLabels[status]}
                                                         </span>
+                                                        {group.smart && (
+                                                            <span className="shrink-0 rounded-full bg-primary/20 text-primary border border-primary/30 px-2.5 py-0.5 text-xs font-semibold flex items-center gap-1">
+                                                                <Sparkles className="h-3 w-3" />
+                                                                Smart
+                                                            </span>
+                                                        )}
 
                                                         <span className="text-sm font-semibold text-white truncate">
                                                             {group.name || "Untitled group"}
                                                         </span>
-                                                        <span className="text-xs text-slate-500 shrink-0">{group.collections.length} collections</span>
+                                                        <span className="text-xs text-slate-500 shrink-0">
+                                                            {group.smart ? `${group.rules?.length || 0} rules` : `${group.collections.length} collections`}
+                                                        </span>
 
                                                         {(group.date_range?.start || group.date_range?.end) && (
                                                             <span className="hidden sm:inline-flex rounded-full bg-slate-800 px-2.5 py-0.5 text-xs text-slate-300 border border-slate-700/50 shrink-0">
@@ -811,7 +833,7 @@ export default function GroupsPage() {
                                     })}
                                     {!searchTerm && (
                                         <div
-                                            onClick={() => navigate('/groups/new')}
+                                            onClick={() => setShowTypePicker(true)}
                                             className="group flex items-center gap-3 rounded-xl border-2 border-dashed border-slate-700/50 hover:border-primary/40 hover:bg-slate-800/30 px-4 py-3 ml-8 transition-all duration-300 cursor-pointer"
                                         >
                                             <Plus className="h-4 w-4 text-slate-500 group-hover:text-primary transition-colors shrink-0" />
@@ -830,7 +852,7 @@ export default function GroupsPage() {
                                         return (
                                             <SortableGroupCard key={group.name} id={group.name} viewMode="cards">
                                                 <div
-                                                    onClick={() => navigate(`/groups/${originalIndex}`)}
+                                                    onClick={() => navigate(group.smart ? `/groups/smart/${originalIndex}` : `/groups/${originalIndex}`)}
                                                     className="group relative overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-900/50 shadow-md hover:shadow-xl hover:border-slate-700 transition-all duration-300 cursor-pointer"
                                                 >
                                                     <div className="relative">
@@ -853,6 +875,12 @@ export default function GroupsPage() {
                                                                 </div>
                                                             );
                                                         })()}
+                                                        {group.smart && (
+                                                            <div className="absolute left-3 top-11 rounded-full bg-primary/20 text-primary border border-primary/30 backdrop-blur-sm px-3 py-1 text-xs font-semibold flex items-center gap-1">
+                                                                <Sparkles className="h-3 w-3" />
+                                                                Smart
+                                                            </div>
+                                                        )}
                                                         {(group.date_range?.start || group.date_range?.end) && (
                                                             <div className="absolute right-12 top-3 rounded-full bg-slate-900/80 backdrop-blur-sm px-3 py-1 text-xs font-semibold text-slate-100 border border-slate-700/50">
                                                                 {group.date_range?.start ? new Date(group.date_range.start).toLocaleDateString('en', { month: '2-digit', day: '2-digit' }) : '??/??'}
@@ -915,7 +943,7 @@ export default function GroupsPage() {
                                     })}
                                     {!searchTerm && (
                                         <div
-                                            onClick={() => navigate('/groups/new')}
+                                            onClick={() => setShowTypePicker(true)}
                                             className="group flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-slate-700/50 hover:border-primary/40 hover:bg-slate-800/30 transition-all duration-300 cursor-pointer"
                                             style={{ minHeight: '190px' }}
                                         >
@@ -935,7 +963,7 @@ export default function GroupsPage() {
                 ) : !searchTerm ? (
                     viewMode === "list" ? (
                         <div
-                            onClick={() => navigate('/groups/new')}
+                            onClick={() => setShowTypePicker(true)}
                             className="group flex items-center gap-3 rounded-xl border-2 border-dashed border-slate-700/50 hover:border-primary/40 hover:bg-slate-800/30 px-4 py-3 ml-8 transition-all duration-300 cursor-pointer"
                         >
                             <Plus className="h-4 w-4 text-slate-500 group-hover:text-primary transition-colors shrink-0" />
@@ -947,7 +975,7 @@ export default function GroupsPage() {
                     ) : (
                         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
                             <div
-                                onClick={() => navigate('/groups/new')}
+                                onClick={() => setShowTypePicker(true)}
                                 className="group flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-slate-700/50 hover:border-primary/40 hover:bg-slate-800/30 transition-all duration-300 cursor-pointer"
                                 style={{ minHeight: '190px' }}
                             >
@@ -1232,6 +1260,47 @@ export default function GroupsPage() {
                     setConfirmDelete(null);
                 }}
             />
+
+            {/* Group type picker dialog */}
+            <Dialog open={showTypePicker} onOpenChange={setShowTypePicker}>
+                <DialogContent className="max-w-lg">
+                    <DialogHeader>
+                        <div>
+                            <DialogTitle>Create New Group</DialogTitle>
+                            <DialogDescription>Choose how this group will manage its collections.</DialogDescription>
+                        </div>
+                        <DialogCloseButton />
+                    </DialogHeader>
+                    <div className="p-6 grid grid-cols-2 gap-4">
+                        <button
+                            type="button"
+                            onClick={() => { setShowTypePicker(false); navigate("/groups/new"); }}
+                            className="group flex flex-col items-center gap-3 rounded-xl border-2 border-slate-700/50 bg-slate-800/30 p-6 hover:border-primary/40 hover:bg-primary/5 transition-all duration-200 cursor-pointer"
+                        >
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-slate-400 group-hover:bg-primary/20 group-hover:text-primary transition-all duration-200">
+                                <Layers className="h-6 w-6" />
+                            </div>
+                            <div className="text-center">
+                                <p className="text-sm font-semibold text-white">Basic Group</p>
+                                <p className="text-xs text-slate-400 mt-1">Manually select which collections to include</p>
+                            </div>
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => { setShowTypePicker(false); navigate("/groups/smart/new"); }}
+                            className="group flex flex-col items-center gap-3 rounded-xl border-2 border-slate-700/50 bg-slate-800/30 p-6 hover:border-primary/40 hover:bg-primary/5 transition-all duration-200 cursor-pointer"
+                        >
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-slate-400 group-hover:bg-primary/20 group-hover:text-primary transition-all duration-200">
+                                <Sparkles className="h-6 w-6" />
+                            </div>
+                            <div className="text-center">
+                                <p className="text-sm font-semibold text-white">Smart Group</p>
+                                <p className="text-xs text-slate-400 mt-1">Automatically include collections matching your rules</p>
+                            </div>
+                        </button>
+                    </div>
+                </DialogContent>
+            </Dialog>
 
             {/* Success toast */}
             {message && (

--- a/homescreen-hero-ui/src/pages/GroupsPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupsPage.tsx
@@ -204,6 +204,10 @@ export default function GroupsPage() {
 
     // Group type picker dialog
     const [showTypePicker, setShowTypePicker] = useState(false);
+    const [newGroupType, setNewGroupType] = useState<"basic" | "smart" | null>(null);
+    const [newGroupName, setNewGroupName] = useState("");
+    const [creatingGroup, setCreatingGroup] = useState(false);
+    const [createError, setCreateError] = useState<string | null>(null);
 
     // Display settings state
     const [displaySettings, setDisplaySettings] = useState<DisplaySettings>({ group_display_mode: "grouped" });
@@ -1262,43 +1266,122 @@ export default function GroupsPage() {
             />
 
             {/* Group type picker dialog */}
-            <Dialog open={showTypePicker} onOpenChange={setShowTypePicker}>
+            <Dialog open={showTypePicker} onOpenChange={(open) => {
+                setShowTypePicker(open);
+                if (!open) { setNewGroupType(null); setNewGroupName(""); setCreateError(null); }
+            }}>
                 <DialogContent className="max-w-lg">
                     <DialogHeader>
                         <div>
-                            <DialogTitle>Create New Group</DialogTitle>
-                            <DialogDescription>Choose how this group will manage its collections.</DialogDescription>
+                            <DialogTitle>{newGroupType ? "Name Your Group" : "Create New Group"}</DialogTitle>
+                            <DialogDescription>{newGroupType ? "Give your group a name to get started." : "Choose how this group will manage its collections."}</DialogDescription>
                         </div>
                         <DialogCloseButton />
                     </DialogHeader>
-                    <div className="p-6 grid grid-cols-2 gap-4">
-                        <button
-                            type="button"
-                            onClick={() => { setShowTypePicker(false); navigate("/groups/new"); }}
-                            className="group flex flex-col items-center gap-3 rounded-xl border-2 border-slate-700/50 bg-slate-800/30 p-6 hover:border-primary/40 hover:bg-primary/5 transition-all duration-200 cursor-pointer"
-                        >
-                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-slate-400 group-hover:bg-primary/20 group-hover:text-primary transition-all duration-200">
-                                <Layers className="h-6 w-6" />
+                    {!newGroupType ? (
+                        <div className="p-6 grid grid-cols-2 gap-4">
+                            <button
+                                type="button"
+                                onClick={() => setNewGroupType("basic")}
+                                className="group flex flex-col items-center gap-3 rounded-xl border-2 border-slate-700/50 bg-slate-800/30 p-6 hover:border-primary/40 hover:bg-primary/5 transition-all duration-200 cursor-pointer"
+                            >
+                                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-slate-400 group-hover:bg-primary/20 group-hover:text-primary transition-all duration-200">
+                                    <Layers className="h-6 w-6" />
+                                </div>
+                                <div className="text-center">
+                                    <p className="text-sm font-semibold text-white">Basic Group</p>
+                                    <p className="text-xs text-slate-400 mt-1">Manually select which collections to include</p>
+                                </div>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setNewGroupType("smart")}
+                                className="group flex flex-col items-center gap-3 rounded-xl border-2 border-slate-700/50 bg-slate-800/30 p-6 hover:border-primary/40 hover:bg-primary/5 transition-all duration-200 cursor-pointer"
+                            >
+                                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-slate-400 group-hover:bg-primary/20 group-hover:text-primary transition-all duration-200">
+                                    <Sparkles className="h-6 w-6" />
+                                </div>
+                                <div className="text-center">
+                                    <p className="text-sm font-semibold text-white">Smart Group</p>
+                                    <p className="text-xs text-slate-400 mt-1">Automatically include collections matching your rules</p>
+                                </div>
+                            </button>
+                        </div>
+                    ) : (
+                        <div className="p-6 space-y-4">
+                            <div className="flex items-center gap-2 text-sm text-slate-400">
+                                {newGroupType === "smart" ? <Sparkles className="h-4 w-4 text-primary" /> : <Layers className="h-4 w-4 text-primary" />}
+                                <span className="capitalize">{newGroupType} Group</span>
+                                <button type="button" onClick={() => { setNewGroupType(null); setNewGroupName(""); setCreateError(null); }} className="ml-auto text-xs text-slate-500 hover:text-slate-300 transition-colors">Change</button>
                             </div>
-                            <div className="text-center">
-                                <p className="text-sm font-semibold text-white">Basic Group</p>
-                                <p className="text-xs text-slate-400 mt-1">Manually select which collections to include</p>
+                            <input
+                                autoFocus
+                                type="text"
+                                value={newGroupName}
+                                onChange={(e) => { setNewGroupName(e.target.value); setCreateError(null); }}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter" && newGroupName.trim() && !creatingGroup) {
+                                        e.preventDefault();
+                                        document.getElementById("create-group-btn")?.click();
+                                    }
+                                }}
+                                placeholder="e.g. Horror Collections, Trakt Lists..."
+                                className="w-full px-4 py-3 bg-slate-900 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70 text-sm"
+                            />
+                            {createError && (
+                                <p className="text-sm text-red-400">{createError}</p>
+                            )}
+                            <div className="flex justify-end gap-3">
+                                <button
+                                    type="button"
+                                    onClick={() => { setShowTypePicker(false); setNewGroupType(null); setNewGroupName(""); setCreateError(null); }}
+                                    className="px-4 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-white transition-colors"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    id="create-group-btn"
+                                    type="button"
+                                    disabled={!newGroupName.trim() || creatingGroup}
+                                    onClick={async () => {
+                                        try {
+                                            setCreatingGroup(true);
+                                            setCreateError(null);
+                                            const isSmart = newGroupType === "smart";
+                                            const payload = isSmart
+                                                ? { name: newGroupName.trim(), enabled: true, smart: true, rules: [{ field: "library", operator: "is", values: [] }], min_picks: 0, max_picks: 1, weight: 1, min_gap_rotations: 0, display_order: 0, visibility_home: true, visibility_shared: false, visibility_recommended: false, date_range: null, collections: [] }
+                                                : { name: newGroupName.trim(), enabled: true, min_picks: 0, max_picks: 1, weight: 1, min_gap_rotations: 0, display_order: 0, visibility_home: true, visibility_shared: false, visibility_recommended: false, date_range: null, collections: [] };
+                                            const r = await fetchWithAuth("/api/admin/config/groups", {
+                                                method: "POST",
+                                                headers: { "Content-Type": "application/json" },
+                                                body: JSON.stringify(payload),
+                                            });
+                                            if (!r.ok) {
+                                                const text = await r.text();
+                                                throw new Error(text || "Failed to create group");
+                                            }
+                                            const nextGroups = await fetchWithAuth("/api/admin/config/groups").then((res) => res.json());
+                                            const targetIndex = nextGroups.length - 1;
+                                            setShowTypePicker(false);
+                                            setNewGroupType(null);
+                                            setNewGroupName("");
+                                            if (targetIndex >= 0) {
+                                                navigate(isSmart ? `/groups/smart/${targetIndex}` : `/groups/${targetIndex}`);
+                                            }
+                                        } catch (e) {
+                                            setCreateError(String(e));
+                                        } finally {
+                                            setCreatingGroup(false);
+                                        }
+                                    }}
+                                    className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-bold shadow-lg shadow-primary/30 hover:shadow-primary/40 transition-all duration-200 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {creatingGroup ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                                    Create Group
+                                </button>
                             </div>
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => { setShowTypePicker(false); navigate("/groups/smart/new"); }}
-                            className="group flex flex-col items-center gap-3 rounded-xl border-2 border-slate-700/50 bg-slate-800/30 p-6 hover:border-primary/40 hover:bg-primary/5 transition-all duration-200 cursor-pointer"
-                        >
-                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-slate-400 group-hover:bg-primary/20 group-hover:text-primary transition-all duration-200">
-                                <Sparkles className="h-6 w-6" />
-                            </div>
-                            <div className="text-center">
-                                <p className="text-sm font-semibold text-white">Smart Group</p>
-                                <p className="text-xs text-slate-400 mt-1">Automatically include collections matching your rules</p>
-                            </div>
-                        </button>
-                    </div>
+                        </div>
+                    )}
                 </DialogContent>
             </Dialog>
 

--- a/homescreen-hero-ui/src/pages/NotFoundPage.tsx
+++ b/homescreen-hero-ui/src/pages/NotFoundPage.tsx
@@ -1,7 +1,7 @@
 import { Link, useRouteError } from "react-router-dom";
 
 export default function NotFoundPage() {
-    const error = useRouteError() as any;
+    const error = useRouteError() as { status?: number } | null;
 
     return (
         <div style={{ padding: "2rem" }}>

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -617,8 +617,8 @@ export default function SettingsPage() {
             }
 
             setLines(nextLines);
-        } catch (e: any) {
-            setLogsError(e?.message ?? "Failed to load logs");
+        } catch (e: unknown) {
+            setLogsError(e instanceof Error ? e.message : "Failed to load logs");
         } finally {
             if (showLoading) setLoadingLogs(false);
         }
@@ -663,8 +663,8 @@ export default function SettingsPage() {
             a.download = "homescreen_hero.log";
             a.click();
             URL.revokeObjectURL(url);
-        } catch (e: any) {
-            setLogsError(e?.message ?? "Failed to download logs");
+        } catch (e: unknown) {
+            setLogsError(e instanceof Error ? e.message : "Failed to download logs");
         }
     }
 
@@ -685,8 +685,8 @@ export default function SettingsPage() {
             a.click();
             URL.revokeObjectURL(url);
             setBackupToast({ message: "Configuration exported successfully.", type: "success" });
-        } catch (e: any) {
-            setBackupToast({ message: e?.message ?? "Failed to export configuration.", type: "error" });
+        } catch (e: unknown) {
+            setBackupToast({ message: e instanceof Error ? e.message : "Failed to export configuration.", type: "error" });
         } finally {
             setExporting(false);
         }
@@ -710,8 +710,8 @@ export default function SettingsPage() {
             } else {
                 setValidationResult({ ok: true, message: data.message });
             }
-        } catch (e: any) {
-            setBackupToast({ message: e?.message ?? "Validation request failed.", type: "error" });
+        } catch (e: unknown) {
+            setBackupToast({ message: e instanceof Error ? e.message : "Validation request failed.", type: "error" });
         } finally {
             setValidating(false);
         }
@@ -736,8 +736,8 @@ export default function SettingsPage() {
             setSelectedFile(null);
             setValidationResult(null);
             if (fileInputRef.current) fileInputRef.current.value = "";
-        } catch (e: any) {
-            setBackupToast({ message: e?.message ?? "Failed to import configuration.", type: "error" });
+        } catch (e: unknown) {
+            setBackupToast({ message: e instanceof Error ? e.message : "Failed to import configuration.", type: "error" });
         } finally {
             setImporting(false);
         }
@@ -766,8 +766,8 @@ export default function SettingsPage() {
             }
             setBackupToast({ message: data.message, type: "success" });
             fetchBackupStatus();
-        } catch (e: any) {
-            setBackupToast({ message: e?.message ?? "Failed to revert configuration.", type: "error" });
+        } catch (e: unknown) {
+            setBackupToast({ message: e instanceof Error ? e.message : "Failed to revert configuration.", type: "error" });
         } finally {
             setReverting(false);
         }

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -7,12 +7,13 @@ import {
     CalendarRange,
     Check,
     ChevronDown,
+    CircleDot,
     Compass,
     Home,
-    Lightbulb,
     Loader2,
     Minus,
     Plus,
+    Search,
     Share2,
     SlidersHorizontal,
     Sparkles,
@@ -64,8 +65,13 @@ type FilterOptions = {
     libraries: string[];
 };
 
+type PreviewCollection = {
+    name: string;
+    poster_url: string | null;
+};
+
 type PreviewResult = {
-    collections: string[];
+    collections: PreviewCollection[];
     count: number;
 };
 
@@ -104,20 +110,11 @@ const OPERATORS_BY_FIELD: Record<string, { value: string; label: string }[]> = {
 
 const SOURCE_OPTIONS = ["plex", "trakt", "letterboxd", "mdblist", "anilist", "mal"];
 
-const SOURCE_COLORS: Record<string, string> = {
-    plex: "bg-[#e5a00d]/20 text-[#e5a00d] border-[#e5a00d]/30",
-    trakt: "bg-[#af35a3]/20 text-[#af35a3] border-[#af35a3]/30",
-    letterboxd: "bg-[#00a63d]/20 text-[#00a63d] border-[#00a63d]/30",
-    mdblist: "bg-[#4284c9]/20 text-[#4284c9] border-[#4284c9]/30",
-    anilist: "bg-[#02a9ff]/20 text-[#02a9ff] border-[#02a9ff]/30",
-    mal: "bg-[#2e51a2]/20 text-[#2e51a2] border-[#2e51a2]/30",
-};
-
 const emptyForm: SmartGroupForm = {
     name: "",
     enabled: true,
     smart: true,
-    rules: [{ field: "label", operator: "includes", values: [] }],
+    rules: [{ field: "library", operator: "is", values: [] }],
     min_picks: 0,
     max_picks: 1,
     weight: 1,
@@ -138,9 +135,7 @@ export default function SmartGroupDetailPage() {
     const isNew = groupId === undefined || groupId === "new";
 
     const [form, setForm] = useState<SmartGroupForm>(emptyForm);
-    const [groups, setGroups] = useState<SmartGroupForm[]>([]);
-    const [loading, setLoading] = useState(!isNew);
-    const [saving, setSaving] = useState(false);
+    const [loading, setLoading] = useState(true);
     const [deleting, setDeleting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [autoSaveError, setAutoSaveError] = useState<string | null>(null);
@@ -152,12 +147,18 @@ export default function SmartGroupDetailPage() {
 
     // Filter options for rule builder dropdowns
     const [filterOptions, setFilterOptions] = useState<FilterOptions>({ labels: [], sources: [], libraries: [] });
+    const [labelSearches, setLabelSearches] = useState<Record<number, string>>({});
+
+    // Rule card animations
+    const [animatingIn, setAnimatingIn] = useState<number | null>(null);
+    const [removingIndex, setRemovingIndex] = useState<number | null>(null);
 
     // Live preview
     const [preview, setPreview] = useState<PreviewResult | null>(null);
     const [previewLoading, setPreviewLoading] = useState(false);
     const [previewExpanded, setPreviewExpanded] = useState(false);
     const previewDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+    const [loadedPreviewPosters, setLoadedPreviewPosters] = useState<Record<string, boolean>>({});
 
     // Auto-save refs
     const savedFormRef = useRef<string>("");
@@ -175,12 +176,11 @@ export default function SmartGroupDetailPage() {
     }, []);
 
     useEffect(() => {
-        if (isNew) return;
+        if (isNew) { navigate("/groups", { replace: true }); return; }
         setLoading(true);
         fetchWithAuth("/api/admin/config/groups")
             .then((r) => r.json())
             .then((allGroups: SmartGroupForm[]) => {
-                setGroups(allGroups);
                 const idx = Number(groupId);
                 if (idx >= 0 && idx < allGroups.length) {
                     setForm(allGroups[idx]);
@@ -189,21 +189,12 @@ export default function SmartGroupDetailPage() {
             })
             .catch((e) => setError(String(e)))
             .finally(() => setLoading(false));
-    }, [groupId, isNew]);
+    }, [groupId, isNew, navigate]);
 
     // ─── Live preview ───────────────────────────────────────────
 
     useEffect(() => {
         if (previewDebounceRef.current) clearTimeout(previewDebounceRef.current);
-
-        // Only preview if there are rules with values
-        const hasRules = form.rules.some((r) =>
-            r.field === "item_count" ? r.values.length > 0 : r.values.length > 0
-        );
-        if (!hasRules) {
-            setPreview(null);
-            return;
-        }
 
         previewDebounceRef.current = setTimeout(async () => {
             setPreviewLoading(true);
@@ -294,35 +285,6 @@ export default function SmartGroupDetailPage() {
 
     // ─── Actions ────────────────────────────────────────────────
 
-    const createGroup = async () => {
-        try {
-            setSaving(true);
-            setError(null);
-            const payload = {
-                ...form,
-                date_range: form.date_range?.start && form.date_range?.end ? form.date_range : null,
-            };
-            const r = await fetchWithAuth("/api/admin/config/groups", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(payload),
-            });
-            const text = await r.text();
-            if (!r.ok) throw new Error(text || "Failed to create group");
-
-            const nextGroups = await fetchWithAuth("/api/admin/config/groups").then((res) => res.json());
-            const targetIndex = nextGroups.length - 1;
-            if (targetIndex >= 0) {
-                setMessage("Smart group created");
-                navigate(`/groups/smart/${targetIndex}`);
-            }
-        } catch (e) {
-            setError(String(e));
-        } finally {
-            setSaving(false);
-        }
-    };
-
     const deleteGroup = async () => {
         if (selectedIndex === "new") return;
         try {
@@ -357,17 +319,24 @@ export default function SmartGroupDetailPage() {
     };
 
     const addRule = () => {
+        setAnimatingIn(form.rules.length);
         setForm((prev) => ({
             ...prev,
-            rules: [...prev.rules, { field: "label", operator: "includes", values: [] }],
+            rules: [...prev.rules, { field: "library", operator: "is", values: [] }],
         }));
+        setTimeout(() => setAnimatingIn(null), 250);
     };
 
     const removeRule = (index: number) => {
-        setForm((prev) => ({
-            ...prev,
-            rules: prev.rules.filter((_, i) => i !== index),
-        }));
+        if (removingIndex !== null) return;
+        setRemovingIndex(index);
+        setTimeout(() => {
+            setForm((prev) => ({
+                ...prev,
+                rules: prev.rules.filter((_, i) => i !== index),
+            }));
+            setRemovingIndex(null);
+        }, 200);
     };
 
     const toggleRuleValue = (ruleIndex: number, value: string) => {
@@ -435,8 +404,12 @@ export default function SmartGroupDetailPage() {
         );
     }
 
+    const hasRuleValues = form.rules.some((r) => r.values.length > 0);
+    const previewCollections = preview?.collections ?? [];
+    const visiblePreviewCollections = previewExpanded ? previewCollections : previewCollections.slice(0, 8);
+
     return (
-        <div className="mx-auto max-w-5xl space-y-6 p-6">
+        <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
             {/* Header */}
             <div className="flex flex-col gap-4">
                 <button
@@ -449,7 +422,7 @@ export default function SmartGroupDetailPage() {
 
                 <div className="flex items-start justify-between gap-4">
                     <div className="flex items-center gap-3">
-                        {renaming && selectedIndex !== "new" ? (
+                        {renaming ? (
                             <input
                                 autoFocus
                                 value={form.name}
@@ -462,16 +435,16 @@ export default function SmartGroupDetailPage() {
                         ) : (
                             <>
                                 <span
-                                    onClick={selectedIndex !== "new" ? () => setRenaming(true) : undefined}
-                                    className={`text-3xl font-black tracking-tight text-white ${selectedIndex !== "new" ? "hover:text-slate-200 cursor-text transition-colors" : ""}`}
+                                    onClick={() => setRenaming(true)}
+                                    className="text-3xl font-black tracking-tight text-white hover:text-slate-200 cursor-text transition-colors"
                                 >
-                                    {isNew ? "Create Smart Group" : form.name || "Untitled Group"}
+                                    {form.name || "Untitled Group"}
                                 </span>
                                 <span className="shrink-0 rounded-full bg-primary/20 text-primary border border-primary/30 px-2.5 py-0.5 text-xs font-semibold flex items-center gap-1">
                                     <Sparkles className="h-3 w-3" />
                                     Smart
                                 </span>
-                                {selectedIndex !== "new" && (() => {
+                                {(() => {
                                     const status = getGroupStatus(form);
                                     const pillStyles = {
                                         active: "bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/25",
@@ -512,44 +485,17 @@ export default function SmartGroupDetailPage() {
                             <SlidersHorizontal className="h-4 w-4 text-primary" />
                             Group Settings
                         </button>
-                        {selectedIndex !== "new" && (
-                            <button
-                                type="button"
-                                onClick={() => setShowDeleteConfirm(true)}
-                                disabled={deleting}
-                                className="flex items-center justify-center p-2 rounded-lg border border-slate-700 bg-slate-900 text-slate-400 hover:border-red-500/50 hover:text-red-400 transition-all duration-200 disabled:opacity-50"
-                            >
-                                {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-                            </button>
-                        )}
-                        {isNew && (
-                            <button
-                                type="button"
-                                onClick={createGroup}
-                                disabled={saving || !form.name.trim() || form.rules.length === 0}
-                                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-bold shadow-lg shadow-primary/30 hover:shadow-primary/40 transition-all duration-200 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-                                Create Group
-                            </button>
-                        )}
+                        <button
+                            type="button"
+                            onClick={() => setShowDeleteConfirm(true)}
+                            disabled={deleting}
+                            className="flex items-center justify-center p-2 rounded-lg border border-slate-700 bg-slate-900 text-slate-400 hover:border-red-500/50 hover:text-red-400 transition-all duration-200 disabled:opacity-50"
+                        >
+                            {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                        </button>
                     </div>
                 </div>
             </div>
-
-            {/* Name input for new groups */}
-            {isNew && (
-                <div className="space-y-2">
-                    <label className="text-sm font-medium text-white">Group Name</label>
-                    <input
-                        type="text"
-                        value={form.name}
-                        onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
-                        placeholder="e.g. Horror Collections, Trakt Lists..."
-                        className="w-full px-4 py-3 bg-slate-900 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70 text-sm"
-                    />
-                </div>
-            )}
 
             {/* Error / auto-save status */}
             {error && (
@@ -558,195 +504,307 @@ export default function SmartGroupDetailPage() {
             {autoSaveError && (
                 <div className="rounded-xl border border-amber-500/30 bg-amber-950/50 px-4 py-3 text-sm text-amber-200">Auto-save failed: {autoSaveError}</div>
             )}
-
-            {/* Rule Builder */}
-            <section className="space-y-4">
-                <div className="flex items-center justify-between">
-                    <div>
-                        <h2 className="text-lg font-bold text-white">Rules</h2>
-                        <p className="text-xs text-slate-400 mt-0.5">Collections matching <span className="text-slate-300 font-medium">all</span> rules will be included.</p>
+            <div className="grid gap-6 xl:gap-0 xl:divide-x xl:divide-slate-800/70 xl:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)]">
+                {/* Rule Builder */}
+                <section className="space-y-4 xl:pr-6">
+                    <div className="space-y-2">
+                        <h2 className="text-lg font-bold text-slate-100">Rules</h2>
+                        <p className="text-xs text-slate-400">Collections matching <span className="text-slate-200 font-medium">all</span> rules will be included.</p>
                     </div>
-                </div>
 
-                <div className="space-y-3">
-                    {form.rules.map((rule, i) => (
-                        <div key={i} className="rounded-xl border border-slate-800/60 bg-slate-900/50 p-4 space-y-3">
-                            <div className="flex items-center gap-3">
-                                <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider w-16 shrink-0">
-                                    {i === 0 ? "Where" : "And"}
-                                </span>
-
-                                {/* Field selector */}
-                                <Listbox value={rule.field} onChange={(val) => updateRule(i, { field: val as SmartGroupRule["field"] })}>
-                                    <div className="relative w-36">
-                                        <Listbox.Button className="flex items-center justify-between w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white hover:bg-slate-750 focus:outline-none focus:ring-2 focus:ring-primary/70">
-                                            <span>{FIELD_OPTIONS.find((f) => f.value === rule.field)?.label}</span>
-                                            <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
-                                        </Listbox.Button>
-                                        <Listbox.Options className="absolute z-20 mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg">
-                                            {FIELD_OPTIONS.map((opt) => (
-                                                <Listbox.Option key={opt.value} value={opt.value} className="cursor-pointer px-3 py-2 text-sm text-white hover:bg-slate-700 data-[selected]:bg-primary data-[selected]:font-semibold">
-                                                    {opt.label}
-                                                </Listbox.Option>
-                                            ))}
-                                        </Listbox.Options>
+                    <div className="space-y-3">
+                        {form.rules.map((rule, i) => (
+                            <div key={i} className={`${animatingIn === i ? 'rule-card-enter' : ''} ${removingIndex === i ? 'rule-card-exit' : ''}`}>
+                                {i > 0 && (
+                                    <div className="flex items-center gap-3 pb-3 -mt-1">
+                                        <div className="flex-1 border-t border-slate-700/50" />
+                                        <span className="text-[11px] font-bold uppercase tracking-widest text-slate-500">and</span>
+                                        <div className="flex-1 border-t border-slate-700/50" />
                                     </div>
-                                </Listbox>
-
-                                {/* Operator selector */}
-                                <Listbox value={rule.operator} onChange={(val) => updateRule(i, { operator: val })}>
-                                    <div className="relative w-44">
-                                        <Listbox.Button className="flex items-center justify-between w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white hover:bg-slate-750 focus:outline-none focus:ring-2 focus:ring-primary/70">
-                                            <span>{OPERATORS_BY_FIELD[rule.field]?.find((o) => o.value === rule.operator)?.label}</span>
-                                            <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
-                                        </Listbox.Button>
-                                        <Listbox.Options className="absolute z-20 mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg">
-                                            {OPERATORS_BY_FIELD[rule.field]?.map((opt) => (
-                                                <Listbox.Option key={opt.value} value={opt.value} className="cursor-pointer px-3 py-2 text-sm text-white hover:bg-slate-700 data-[selected]:bg-primary data-[selected]:font-semibold">
-                                                    {opt.label}
-                                                </Listbox.Option>
-                                            ))}
-                                        </Listbox.Options>
-                                    </div>
-                                </Listbox>
-
-                                <div className="flex-1" />
-
-                                {/* Remove rule */}
-                                {form.rules.length > 1 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => removeRule(i)}
-                                        className="p-1.5 rounded-lg text-slate-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                                    >
-                                        <X className="h-4 w-4" />
-                                    </button>
                                 )}
-                            </div>
+                            <div className="space-y-3 rounded-xl border border-blue-500/15 bg-[#0f1d35]/85 p-4 shadow-[inset_0_0_0_1px_rgba(30,64,175,0.14)]">
+                                <div className="flex flex-wrap items-center gap-3 sm:flex-nowrap">
+                                    {/* Field selector */}
+                                    <Listbox value={rule.field} onChange={(val) => updateRule(i, { field: val as SmartGroupRule["field"] })}>
+                                        <div className="relative w-full sm:w-36 shrink-0">
+                                            <Listbox.Button className="flex items-center justify-between w-full rounded-lg border border-slate-500/40 bg-slate-700/40 px-3 py-2 text-sm text-slate-100 hover:bg-slate-700/55 focus:outline-none focus:ring-2 focus:ring-slate-400/45">
+                                                <span>{FIELD_OPTIONS.find((f) => f.value === rule.field)?.label}</span>
+                                                <ChevronDown className="h-3.5 w-3.5 text-slate-300/80" />
+                                            </Listbox.Button>
+                                            <Listbox.Options className="absolute z-20 mt-1 w-full rounded-lg border border-slate-500/40 bg-slate-800/95 py-1 shadow-lg">
+                                                {FIELD_OPTIONS.map((opt) => (
+                                                    <Listbox.Option key={opt.value} value={opt.value} className="cursor-pointer px-3 py-2 text-sm text-slate-100 hover:bg-slate-700/70 data-[selected]:bg-slate-600/80 data-[selected]:font-semibold">
+                                                        {opt.label}
+                                                    </Listbox.Option>
+                                                ))}
+                                            </Listbox.Options>
+                                        </div>
+                                    </Listbox>
 
-                            {/* Value input — varies by field type */}
-                            {rule.field === "item_count" ? (
-                                <div className="flex items-center gap-2 ml-[76px]">
-                                    <input
-                                        type="number"
-                                        min={0}
-                                        value={rule.values[0] ?? ""}
-                                        onChange={(e) => {
-                                            const v = e.target.value === "" ? [] : [Number(e.target.value)];
-                                            updateRule(i, { values: v });
-                                        }}
-                                        placeholder="10"
-                                        className="w-24 px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                                    />
-                                    <span className="text-xs text-slate-400">items</span>
-                                </div>
-                            ) : rule.field === "name" ? (
-                                <div className="ml-[76px] space-y-2">
-                                    <div className="flex flex-wrap gap-2">
-                                        {(rule.values as string[]).map((v, vi) => (
-                                            <span key={vi} className="flex items-center gap-1 rounded-full bg-primary/20 text-primary border border-primary/30 px-3 py-1 text-xs font-medium">
-                                                {v}
-                                                <button type="button" onClick={() => {
-                                                    const newVals = [...rule.values];
-                                                    newVals.splice(vi, 1);
-                                                    updateRule(i, { values: newVals });
-                                                }}>
-                                                    <X className="h-3 w-3" />
-                                                </button>
-                                            </span>
-                                        ))}
-                                    </div>
-                                    <input
-                                        type="text"
-                                        placeholder="Type a keyword and press Enter"
-                                        onKeyDown={(e) => {
-                                            if (e.key === "Enter" && e.currentTarget.value.trim()) {
-                                                updateRule(i, { values: [...rule.values, e.currentTarget.value.trim()] });
-                                                e.currentTarget.value = "";
-                                            }
-                                        }}
-                                        className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
-                                    />
-                                </div>
-                            ) : (
-                                <div className="ml-[76px] flex flex-wrap gap-2">
-                                    {getValueOptions(rule.field).map((opt) => {
-                                        const isSelected = rule.values.includes(opt);
-                                        const colorClass = rule.field === "source" && SOURCE_COLORS[opt];
-                                        return (
-                                            <button
-                                                key={opt}
-                                                type="button"
-                                                onClick={() => toggleRuleValue(i, opt)}
-                                                className={`rounded-full px-3 py-1 text-xs font-medium border transition-all duration-200 ${
-                                                    isSelected
-                                                        ? colorClass || "bg-primary/20 text-primary border-primary/30"
-                                                        : "bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600 hover:text-slate-300"
-                                                }`}
-                                            >
-                                                {opt}
-                                            </button>
-                                        );
-                                    })}
-                                    {getValueOptions(rule.field).length === 0 && (
-                                        <p className="text-xs text-slate-500 italic">No options available</p>
+                                    {/* Operator selector */}
+                                    <Listbox value={rule.operator} onChange={(val) => updateRule(i, { operator: val })}>
+                                        <div className="relative w-full sm:w-44 shrink-0">
+                                            <Listbox.Button className="flex items-center justify-between w-full rounded-lg border border-slate-500/40 bg-slate-700/40 px-3 py-2 text-sm text-slate-100 hover:bg-slate-700/55 focus:outline-none focus:ring-2 focus:ring-slate-400/45">
+                                                <span>{OPERATORS_BY_FIELD[rule.field]?.find((o) => o.value === rule.operator)?.label}</span>
+                                                <ChevronDown className="h-3.5 w-3.5 text-slate-300/80" />
+                                            </Listbox.Button>
+                                            <Listbox.Options className="absolute z-20 mt-1 w-full rounded-lg border border-slate-500/40 bg-slate-800/95 py-1 shadow-lg">
+                                                {OPERATORS_BY_FIELD[rule.field]?.map((opt) => (
+                                                    <Listbox.Option key={opt.value} value={opt.value} className="cursor-pointer px-3 py-2 text-sm text-slate-100 hover:bg-slate-700/70 data-[selected]:bg-slate-600/80 data-[selected]:font-semibold">
+                                                        {opt.label}
+                                                    </Listbox.Option>
+                                                ))}
+                                            </Listbox.Options>
+                                        </div>
+                                    </Listbox>
+
+                                    {/* Remove rule */}
+                                    {form.rules.length > 1 && (
+                                        <button
+                                            type="button"
+                                            onClick={() => removeRule(i)}
+                                            className="shrink-0 sm:ml-auto rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-red-500/15 hover:text-red-300"
+                                        >
+                                            <X className="h-4 w-4" />
+                                        </button>
                                     )}
                                 </div>
-                            )}
-                        </div>
-                    ))}
-                </div>
 
-                <button
-                    type="button"
-                    onClick={addRule}
-                    className="flex items-center gap-2 rounded-lg border border-dashed border-slate-700/50 px-4 py-2.5 text-sm text-slate-400 hover:text-primary hover:border-primary/40 transition-all duration-200"
-                >
-                    <Plus className="h-4 w-4" />
-                    Add Rule
-                </button>
-            </section>
+                                {/* Value input varies by field type */}
+                                {rule.field === "item_count" ? (
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            type="number"
+                                            min={0}
+                                            value={rule.values[0] ?? ""}
+                                            onChange={(e) => {
+                                                const v = e.target.value === "" ? [] : [Number(e.target.value)];
+                                                updateRule(i, { values: v });
+                                            }}
+                                            placeholder="10"
+                                            className="w-24 rounded-lg border border-blue-400/25 bg-[#102140] px-3 py-2 text-sm text-blue-100 placeholder-blue-200/35 focus:outline-none focus:ring-2 focus:ring-blue-500/55 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                                        />
+                                        <span className="text-xs text-slate-400">items</span>
+                                    </div>
+                                ) : rule.field === "name" ? (
+                                    <div className="space-y-2 rounded-xl border border-blue-400/15 bg-[#0d1a31] px-3 pb-3 pt-2">
+                                        {(rule.values as string[]).length > 0 && (
+                                            <div className="flex flex-wrap gap-2.5">
+                                                {(rule.values as string[]).map((v, vi) => (
+                                                    <span key={vi} className="flex items-center gap-1.5 rounded-lg border border-blue-400/25 bg-blue-500/10 px-3 py-1.5 text-xs font-medium text-blue-200">
+                                                        {v}
+                                                        <button type="button" onClick={() => {
+                                                            const newVals = [...rule.values];
+                                                            newVals.splice(vi, 1);
+                                                            updateRule(i, { values: newVals });
+                                                        }}>
+                                                            <X className="h-3 w-3" />
+                                                        </button>
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        )}
+                                        <div className="relative">
+                                            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                                            <input
+                                                type="text"
+                                                placeholder="Type a keyword, then hit Enter"
+                                                onKeyDown={(e) => {
+                                                    if (e.key === "Enter" && e.currentTarget.value.trim()) {
+                                                        updateRule(i, { values: [...rule.values, e.currentTarget.value.trim()] });
+                                                        e.currentTarget.value = "";
+                                                    }
+                                                }}
+                                                className="w-full border-b border-blue-400/20 bg-transparent py-2 pl-9 pr-2 text-sm text-blue-100 placeholder-blue-200/35 focus:border-blue-400/50 focus:outline-none"
+                                            />
+                                        </div>
+                                    </div>
+                                ) : (
+                                    (() => {
+                                        const allOptions = getValueOptions(rule.field);
+                                        const showSearch = rule.field === "label" && allOptions.length >= 6;
+                                        const searchText = (labelSearches[i] ?? "").toLowerCase();
+                                        const selected = allOptions.filter((opt) => rule.values.includes(opt));
+                                        const unselected = allOptions.filter((opt) => !rule.values.includes(opt));
+                                        const filteredUnselected = showSearch && searchText
+                                            ? unselected.filter((opt) => opt.toLowerCase().includes(searchText))
+                                            : unselected;
 
-            {/* Live Preview */}
-            <section className="rounded-xl border border-slate-800/60 bg-slate-900/50 p-4 space-y-3">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                        <h3 className="text-sm font-semibold text-white">Matching Collections</h3>
-                        {previewLoading ? (
-                            <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
-                        ) : preview ? (
-                            <span className="rounded-full bg-primary/20 text-primary border border-primary/30 px-2.5 py-0.5 text-xs font-bold">
-                                {preview.count}
-                            </span>
-                        ) : null}
-                    </div>
-                    {preview && preview.count > 0 && (
-                        <button
-                            type="button"
-                            onClick={() => setPreviewExpanded(!previewExpanded)}
-                            className="text-xs text-slate-400 hover:text-white transition-colors"
-                        >
-                            {previewExpanded ? "Collapse" : "Show all"}
-                        </button>
-                    )}
-                </div>
+                                        return (
+                                            <div className="space-y-2">
+                                                {/* Selected pills — always visible */}
+                                                {showSearch && selected.length > 0 && (
+                                                    <div className="flex flex-wrap gap-2">
+                                                        {selected.map((opt) => (
+                                                            <button
+                                                                key={opt}
+                                                                type="button"
+                                                                onClick={() => toggleRuleValue(i, opt)}
+                                                                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium border transition-all duration-200 bg-blue-500/20 text-blue-100 border-blue-300/40"
+                                                            >
+                                                                {opt}
+                                                                <X className="h-3 w-3" />
+                                                            </button>
+                                                        ))}
+                                                    </div>
+                                                )}
 
-                {!preview || preview.count === 0 ? (
-                    <p className="text-xs text-slate-500 italic">
-                        {form.rules.some((r) => r.values.length > 0)
-                            ? "No collections match these rules."
-                            : "Add values to your rules to see matching collections."}
-                    </p>
-                ) : (
-                    <div className={`flex flex-wrap gap-2 ${!previewExpanded && preview.count > 10 ? "max-h-20 overflow-hidden" : ""}`}>
-                        {preview.collections.map((name) => (
-                            <span key={name} className="rounded-full bg-slate-800 border border-slate-700 px-3 py-1 text-xs text-slate-300">
-                                {name}
-                            </span>
+                                                {/* Search input for labels with 10+ options */}
+                                                {showSearch && (
+                                                    <div className="relative">
+                                                        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                                                        <input
+                                                            type="text"
+                                                            value={labelSearches[i] ?? ""}
+                                                            onChange={(e) => setLabelSearches((prev) => ({ ...prev, [i]: e.target.value }))}
+                                                            placeholder="Filter labels…"
+                                                            className="w-full rounded-lg border border-blue-400/20 bg-[#0d1a31] py-2 pl-9 pr-2 text-sm text-blue-100 placeholder-blue-200/35 focus:border-blue-400/50 focus:outline-none"
+                                                        />
+                                                    </div>
+                                                )}
+
+                                                {/* Unselected pills (filtered when searching) */}
+                                                <div className="flex flex-wrap gap-2">
+                                                    {/* When not using search layout, show selected inline */}
+                                                    {!showSearch && selected.map((opt) => (
+                                                        <button
+                                                            key={opt}
+                                                            type="button"
+                                                            onClick={() => toggleRuleValue(i, opt)}
+                                                            className="rounded-lg px-3 py-1.5 text-xs font-medium border transition-all duration-200 bg-blue-500/20 text-blue-100 border-blue-300/40"
+                                                        >
+                                                            {opt}
+                                                        </button>
+                                                    ))}
+                                                    {filteredUnselected.map((opt) => (
+                                                        <button
+                                                            key={opt}
+                                                            type="button"
+                                                            onClick={() => toggleRuleValue(i, opt)}
+                                                            className="rounded-lg px-3 py-1.5 text-xs font-medium border transition-all duration-200 bg-[#102140] text-blue-200/70 border-blue-500/20 hover:border-blue-300/35 hover:text-blue-100"
+                                                        >
+                                                            {opt}
+                                                        </button>
+                                                    ))}
+                                                    {allOptions.length === 0 && (
+                                                        <p className="text-xs text-slate-500 italic">No options available</p>
+                                                    )}
+                                                    {showSearch && searchText && filteredUnselected.length === 0 && (
+                                                        <p className="text-xs text-slate-500 italic">No labels match "{labelSearches[i]}"</p>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        );
+                                    })()
+                                )}
+                            </div>
+                            </div>
                         ))}
                     </div>
-                )}
-            </section>
+
+                    <button
+                        type="button"
+                        onClick={addRule}
+                        className="flex w-full items-center gap-2 rounded-lg border border-blue-400/20 bg-[#0f1d35]/55 px-3 py-2.5 text-sm font-medium text-blue-200/90 transition-colors hover:bg-blue-500/10 hover:text-blue-100"
+                    >
+                        <CircleDot className="h-4 w-4" />
+                        Add Rule
+                    </button>
+                </section>
+
+                {/* Live Preview */}
+                <section className="space-y-4 xl:sticky xl:top-6 xl:pl-6 h-fit">
+                    <div className="space-y-1">
+                        <div className="flex items-center justify-between gap-3">
+                            <h3 className="text-base font-semibold text-white">Live Preview</h3>
+                            {previewLoading && <Loader2 className="h-4 w-4 animate-spin text-slate-400" />}
+                        </div>
+                        <p className="text-xs text-slate-400">
+                            {previewLoading ? (
+                                "Updating…"
+                            ) : preview ? (
+                                <>
+                                    <span className="text-primary font-bold">{preview.count}</span>
+                                    {" "}{preview.count === 1 ? "collection matches" : "collections match"} your rules
+                                </>
+                            ) : (
+                                "Configure rules to see matching collections"
+                            )}
+                        </p>
+                    </div>
+
+                    {!preview ? (
+                        <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+                            {Array.from({ length: 8 }).map((_, idx) => (
+                                <div key={idx} className="relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950 aspect-[2/3]">
+                                    <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-800 via-slate-700/70 to-slate-800" />
+                                </div>
+                            ))}
+                        </div>
+                    ) : preview.count === 0 ? (
+                        <div className="rounded-xl border border-dashed border-slate-700/70 bg-slate-950/50 px-4 py-6 text-center">
+                            <p className="text-sm text-slate-300">
+                                {hasRuleValues ? "No collections match these rules." : "Add values to your rules to see matching collections."}
+                            </p>
+                        </div>
+                    ) : (
+                        <>
+                            <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+                                {visiblePreviewCollections.map((col) => {
+                                    const posterLoaded = !col.poster_url || loadedPreviewPosters[col.name];
+                                    return (
+                                        <div key={col.name} className="group relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950 aspect-[2/3]">
+                                            {col.poster_url ? (
+                                                <>
+                                                    {!posterLoaded && (
+                                                        <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-800 via-slate-700/70 to-slate-800" />
+                                                    )}
+                                                    <img
+                                                        src={col.poster_url}
+                                                        alt={col.name}
+                                                        className={`h-full w-full object-cover transition-all duration-300 group-hover:scale-105 ${
+                                                            posterLoaded ? "opacity-100" : "opacity-0"
+                                                        }`}
+                                                        onLoad={() => {
+                                                            setLoadedPreviewPosters((prev) => (prev[col.name] ? prev : { ...prev, [col.name]: true }));
+                                                        }}
+                                                        onError={() => {
+                                                            setLoadedPreviewPosters((prev) => (prev[col.name] ? prev : { ...prev, [col.name]: true }));
+                                                        }}
+                                                    />
+                                                </>
+                                            ) : (
+                                                <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-800 to-slate-950 text-[11px] text-slate-400">
+                                                    No Poster
+                                                </div>
+                                            )}
+                                            <div className="absolute inset-x-0 bottom-0 flex items-end bg-gradient-to-t from-black/80 via-black/40 to-transparent p-2 pt-8 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                                                <span className="text-[11px] font-medium leading-tight text-white line-clamp-2">{col.name}</span>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+
+                            {preview.count > 8 && (
+                                <div className="flex justify-center pt-1">
+                                    <button
+                                        type="button"
+                                        onClick={() => setPreviewExpanded(!previewExpanded)}
+                                        aria-expanded={previewExpanded}
+                                        className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3.5 py-2 text-sm font-medium text-slate-200 transition-all duration-200 hover:border-slate-500 hover:bg-slate-700/80 hover:text-white focus:outline-none focus:ring-2 focus:ring-primary/40"
+                                    >
+                                        <ChevronDown className={`h-4 w-4 transition-transform ${previewExpanded ? "rotate-180" : ""}`} />
+                                        {previewExpanded
+                                            ? "Show fewer posters"
+                                            : `Show more posters (${preview.count - visiblePreviewCollections.length} more)`}
+                                    </button>
+                                </div>
+                            )}
+                        </>
+                    )}
+                </section>
+            </div>
 
             {/* Group Settings Sheet */}
             <Sheet open={settingsOpen} onOpenChange={setSettingsOpen}>
@@ -896,3 +954,5 @@ export default function SmartGroupDetailPage() {
         </div>
     );
 }
+
+

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -159,6 +159,7 @@ export default function SmartGroupDetailPage() {
     const [previewExpanded, setPreviewExpanded] = useState(false);
     const previewDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
     const [loadedPreviewPosters, setLoadedPreviewPosters] = useState<Record<string, boolean>>({});
+    const [previewRevision, setPreviewRevision] = useState(0);
 
     // Auto-save refs
     const savedFormRef = useRef<string>("");
@@ -207,6 +208,8 @@ export default function SmartGroupDetailPage() {
                 if (r.ok) {
                     const data = await r.json();
                     setPreview(data);
+                    setPreviewRevision((r) => r + 1);
+                    setLoadedPreviewPosters({});
                 }
             } catch {
                 // Preview is non-critical
@@ -748,17 +751,21 @@ export default function SmartGroupDetailPage() {
                             ))}
                         </div>
                     ) : preview.count === 0 ? (
-                        <div className="rounded-xl border border-dashed border-slate-700/70 bg-slate-950/50 px-4 py-6 text-center">
+                        <div className={`rounded-xl border border-dashed border-slate-700/70 bg-slate-950/50 px-4 py-6 text-center transition-opacity duration-300 ${previewLoading ? "opacity-50" : "opacity-100"}`}>
                             <p className="text-sm text-slate-300">
                                 {hasRuleValues ? "No collections match these rules." : "Add values to your rules to see matching collections."}
                             </p>
                         </div>
                     ) : (
-                        <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
-                            {visiblePreviewCollections.map((col) => {
+                        <div className={`grid grid-cols-2 gap-2.5 sm:grid-cols-4 transition-opacity duration-300 ${previewLoading ? "opacity-40" : "opacity-100"}`}>
+                            {visiblePreviewCollections.map((col, idx) => {
                                 const posterLoaded = !col.poster_url || loadedPreviewPosters[col.name];
                                 return (
-                                    <div key={col.name} className="group relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950 aspect-[2/3]">
+                                    <div
+                                        key={`${previewRevision}-${col.name}`}
+                                        className="preview-poster-enter group relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950 aspect-[2/3]"
+                                        style={{ animationDelay: `${idx * 40}ms` }}
+                                    >
                                         {col.poster_url ? (
                                             <>
                                                 {!posterLoaded && (
@@ -796,7 +803,8 @@ export default function SmartGroupDetailPage() {
                                     type="button"
                                     onClick={() => setPreviewExpanded(!previewExpanded)}
                                     aria-expanded={previewExpanded}
-                                    className="group relative overflow-hidden rounded-lg border border-slate-700/50 aspect-[2/3] cursor-pointer transition-all duration-300 hover:border-primary/60 hover:shadow-xl hover:shadow-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/40"
+                                    className="preview-poster-enter group relative overflow-hidden rounded-lg border border-slate-700/50 aspect-[2/3] cursor-pointer transition-all duration-300 hover:border-primary/60 hover:shadow-xl hover:shadow-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/40"
+                                    style={{ animationDelay: `${visiblePreviewCollections.length * 40}ms` }}
                                 >
                                     {/* Layered background for depth */}
                                     <div className="absolute inset-0 bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -406,7 +406,14 @@ export default function SmartGroupDetailPage() {
 
     const hasRuleValues = form.rules.some((r) => r.values.length > 0);
     const previewCollections = preview?.collections ?? [];
-    const visiblePreviewCollections = previewExpanded ? previewCollections : previewCollections.slice(0, 8);
+    const PREVIEW_LIMIT = 8;
+    const hasOverflow = previewCollections.length > PREVIEW_LIMIT;
+    // When collapsed with overflow, show 7 posters + the "+N" tile to fill the grid
+    const visiblePreviewCollections = previewExpanded
+        ? previewCollections
+        : hasOverflow
+            ? previewCollections.slice(0, PREVIEW_LIMIT - 1)
+            : previewCollections;
 
     return (
         <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
@@ -440,9 +447,8 @@ export default function SmartGroupDetailPage() {
                                 >
                                     {form.name || "Untitled Group"}
                                 </span>
-                                <span className="shrink-0 rounded-full bg-primary/20 text-primary border border-primary/30 px-2.5 py-0.5 text-xs font-semibold flex items-center gap-1">
-                                    <Sparkles className="h-3 w-3" />
-                                    Smart
+                                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/20 text-primary border border-primary/30">
+                                    <Sparkles className="h-3.5 w-3.5" />
                                 </span>
                                 {(() => {
                                     const status = getGroupStatus(form);
@@ -748,60 +754,84 @@ export default function SmartGroupDetailPage() {
                             </p>
                         </div>
                     ) : (
-                        <>
-                            <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
-                                {visiblePreviewCollections.map((col) => {
-                                    const posterLoaded = !col.poster_url || loadedPreviewPosters[col.name];
-                                    return (
-                                        <div key={col.name} className="group relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950 aspect-[2/3]">
-                                            {col.poster_url ? (
-                                                <>
-                                                    {!posterLoaded && (
-                                                        <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-800 via-slate-700/70 to-slate-800" />
-                                                    )}
-                                                    <img
-                                                        src={col.poster_url}
-                                                        alt={col.name}
-                                                        className={`h-full w-full object-cover transition-all duration-300 group-hover:scale-105 ${
-                                                            posterLoaded ? "opacity-100" : "opacity-0"
-                                                        }`}
-                                                        onLoad={() => {
-                                                            setLoadedPreviewPosters((prev) => (prev[col.name] ? prev : { ...prev, [col.name]: true }));
-                                                        }}
-                                                        onError={() => {
-                                                            setLoadedPreviewPosters((prev) => (prev[col.name] ? prev : { ...prev, [col.name]: true }));
-                                                        }}
-                                                    />
-                                                </>
-                                            ) : (
-                                                <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-800 to-slate-950 text-[11px] text-slate-400">
-                                                    No Poster
-                                                </div>
-                                            )}
-                                            <div className="absolute inset-x-0 bottom-0 flex items-end bg-gradient-to-t from-black/80 via-black/40 to-transparent p-2 pt-8 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                                                <span className="text-[11px] font-medium leading-tight text-white line-clamp-2">{col.name}</span>
+                        <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+                            {visiblePreviewCollections.map((col) => {
+                                const posterLoaded = !col.poster_url || loadedPreviewPosters[col.name];
+                                return (
+                                    <div key={col.name} className="group relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950 aspect-[2/3]">
+                                        {col.poster_url ? (
+                                            <>
+                                                {!posterLoaded && (
+                                                    <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-800 via-slate-700/70 to-slate-800" />
+                                                )}
+                                                <img
+                                                    src={col.poster_url}
+                                                    alt={col.name}
+                                                    className={`h-full w-full object-cover transition-all duration-300 group-hover:scale-105 ${
+                                                        posterLoaded ? "opacity-100" : "opacity-0"
+                                                    }`}
+                                                    onLoad={() => {
+                                                        setLoadedPreviewPosters((prev) => (prev[col.name] ? prev : { ...prev, [col.name]: true }));
+                                                    }}
+                                                    onError={() => {
+                                                        setLoadedPreviewPosters((prev) => (prev[col.name] ? prev : { ...prev, [col.name]: true }));
+                                                    }}
+                                                />
+                                            </>
+                                        ) : (
+                                            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-800 to-slate-950 text-[11px] text-slate-400">
+                                                No Poster
                                             </div>
+                                        )}
+                                        <div className="absolute inset-x-0 bottom-0 flex items-end bg-gradient-to-t from-black/80 via-black/40 to-transparent p-2 pt-8 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                                            <span className="text-[11px] font-medium leading-tight text-white line-clamp-2">{col.name}</span>
                                         </div>
-                                    );
-                                })}
-                            </div>
+                                    </div>
+                                );
+                            })}
 
-                            {preview.count > 8 && (
-                                <div className="flex justify-center pt-1">
-                                    <button
-                                        type="button"
-                                        onClick={() => setPreviewExpanded(!previewExpanded)}
-                                        aria-expanded={previewExpanded}
-                                        className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3.5 py-2 text-sm font-medium text-slate-200 transition-all duration-200 hover:border-slate-500 hover:bg-slate-700/80 hover:text-white focus:outline-none focus:ring-2 focus:ring-primary/40"
-                                    >
-                                        <ChevronDown className={`h-4 w-4 transition-transform ${previewExpanded ? "rotate-180" : ""}`} />
-                                        {previewExpanded
-                                            ? "Show fewer posters"
-                                            : `Show more posters (${preview.count - visiblePreviewCollections.length} more)`}
-                                    </button>
-                                </div>
+                            {/* Overflow tile: blends into the grid as the last poster slot */}
+                            {hasOverflow && (
+                                <button
+                                    type="button"
+                                    onClick={() => setPreviewExpanded(!previewExpanded)}
+                                    aria-expanded={previewExpanded}
+                                    className="group relative overflow-hidden rounded-lg border border-slate-700/50 aspect-[2/3] cursor-pointer transition-all duration-300 hover:border-primary/60 hover:shadow-xl hover:shadow-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/40"
+                                >
+                                    {/* Layered background for depth */}
+                                    <div className="absolute inset-0 bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />
+                                    <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-primary/[0.07] via-transparent to-transparent" />
+                                    <div className="absolute inset-0 opacity-[0.03]" style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg width=\'6\' height=\'6\' viewBox=\'0 0 6 6\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Ccircle cx=\'1\' cy=\'1\' r=\'0.6\' fill=\'%23fff\'/%3E%3C/svg%3E")' }} />
+
+                                    {/* Decorative border glow on hover */}
+                                    <div className="absolute inset-0 rounded-lg opacity-0 transition-opacity duration-300 group-hover:opacity-100 bg-gradient-to-br from-primary/10 via-transparent to-primary/5" />
+
+                                    <div className="relative flex h-full w-full flex-col items-center justify-center gap-2">
+                                        {previewExpanded ? (
+                                            <>
+                                                <div className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-600/50 bg-slate-800/80 transition-all duration-300 group-hover:border-primary/40 group-hover:bg-primary/10">
+                                                    <ChevronDown className="h-4 w-4 rotate-180 text-slate-400 transition-colors group-hover:text-primary" />
+                                                </div>
+                                                <span className="text-xs font-medium text-slate-400 transition-colors group-hover:text-slate-200">
+                                                    Show less
+                                                </span>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <div className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-600/40 bg-slate-800/60 transition-all duration-300 group-hover:border-primary/40 group-hover:bg-primary/10 group-hover:scale-110">
+                                                    <span className="text-lg font-bold text-slate-100 transition-colors group-hover:text-primary">
+                                                        +{preview.count - visiblePreviewCollections.length}
+                                                    </span>
+                                                </div>
+                                                <span className="text-[11px] font-medium uppercase tracking-wider text-slate-500 transition-colors group-hover:text-slate-300">
+                                                    collections
+                                                </span>
+                                            </>
+                                        )}
+                                    </div>
+                                </button>
                             )}
-                        </>
+                        </div>
                     )}
                 </section>
             </div>

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -1,0 +1,898 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { fetchWithAuth } from "../utils/api";
+import { getGroupStatus } from "../utils/dates";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+    ArrowLeft,
+    CalendarRange,
+    Check,
+    ChevronDown,
+    Compass,
+    Home,
+    Lightbulb,
+    Loader2,
+    Minus,
+    Plus,
+    Share2,
+    SlidersHorizontal,
+    Sparkles,
+    Trash2,
+    X,
+} from "lucide-react";
+import { Listbox } from "@headlessui/react";
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+    SheetBody,
+    SheetCloseButton,
+} from "../components/ui/sheet";
+import { ConfirmDialog } from "../components/ui/confirm-dialog";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+type DateRange = { start: string; end: string };
+
+type SmartGroupRule = {
+    field: "label" | "source" | "library" | "name" | "item_count";
+    operator: string;
+    values: (string | number)[];
+};
+
+type SmartGroupForm = {
+    name: string;
+    enabled: boolean;
+    smart: true;
+    rules: SmartGroupRule[];
+    min_picks: number;
+    max_picks: number;
+    weight: number;
+    min_gap_rotations: number;
+    display_order: number;
+    visibility_home: boolean;
+    visibility_shared: boolean;
+    visibility_recommended: boolean;
+    date_range?: DateRange | null;
+    collections: string[];
+};
+
+type FilterOptions = {
+    labels: string[];
+    sources: string[];
+    libraries: string[];
+};
+
+type PreviewResult = {
+    collections: string[];
+    count: number;
+};
+
+// ─── Constants ───────────────────────────────────────────────────────
+
+const FIELD_OPTIONS: { value: SmartGroupRule["field"]; label: string }[] = [
+    { value: "label", label: "Label" },
+    { value: "source", label: "Source" },
+    { value: "library", label: "Library" },
+    { value: "name", label: "Name" },
+    { value: "item_count", label: "Item Count" },
+];
+
+const OPERATORS_BY_FIELD: Record<string, { value: string; label: string }[]> = {
+    label: [
+        { value: "includes", label: "includes any of" },
+        { value: "excludes", label: "excludes all of" },
+    ],
+    source: [
+        { value: "is", label: "is" },
+        { value: "is_not", label: "is not" },
+    ],
+    library: [
+        { value: "is", label: "is" },
+        { value: "is_not", label: "is not" },
+    ],
+    name: [
+        { value: "contains", label: "contains" },
+        { value: "not_contains", label: "does not contain" },
+    ],
+    item_count: [
+        { value: "gte", label: "at least" },
+        { value: "lte", label: "at most" },
+    ],
+};
+
+const SOURCE_OPTIONS = ["plex", "trakt", "letterboxd", "mdblist", "anilist", "mal"];
+
+const SOURCE_COLORS: Record<string, string> = {
+    plex: "bg-[#e5a00d]/20 text-[#e5a00d] border-[#e5a00d]/30",
+    trakt: "bg-[#af35a3]/20 text-[#af35a3] border-[#af35a3]/30",
+    letterboxd: "bg-[#00a63d]/20 text-[#00a63d] border-[#00a63d]/30",
+    mdblist: "bg-[#4284c9]/20 text-[#4284c9] border-[#4284c9]/30",
+    anilist: "bg-[#02a9ff]/20 text-[#02a9ff] border-[#02a9ff]/30",
+    mal: "bg-[#2e51a2]/20 text-[#2e51a2] border-[#2e51a2]/30",
+};
+
+const emptyForm: SmartGroupForm = {
+    name: "",
+    enabled: true,
+    smart: true,
+    rules: [{ field: "label", operator: "includes", values: [] }],
+    min_picks: 0,
+    max_picks: 1,
+    weight: 1,
+    min_gap_rotations: 0,
+    display_order: 0,
+    visibility_home: true,
+    visibility_shared: false,
+    visibility_recommended: false,
+    date_range: null,
+    collections: [],
+};
+
+// ─── Component ───────────────────────────────────────────────────────
+
+export default function SmartGroupDetailPage() {
+    const navigate = useNavigate();
+    const { groupId } = useParams<{ groupId: string }>();
+    const isNew = groupId === undefined || groupId === "new";
+
+    const [form, setForm] = useState<SmartGroupForm>(emptyForm);
+    const [groups, setGroups] = useState<SmartGroupForm[]>([]);
+    const [loading, setLoading] = useState(!isNew);
+    const [saving, setSaving] = useState(false);
+    const [deleting, setDeleting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [autoSaveError, setAutoSaveError] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [messageVisible, setMessageVisible] = useState(false);
+    const [settingsOpen, setSettingsOpen] = useState(false);
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [renaming, setRenaming] = useState(false);
+
+    // Filter options for rule builder dropdowns
+    const [filterOptions, setFilterOptions] = useState<FilterOptions>({ labels: [], sources: [], libraries: [] });
+
+    // Live preview
+    const [preview, setPreview] = useState<PreviewResult | null>(null);
+    const [previewLoading, setPreviewLoading] = useState(false);
+    const [previewExpanded, setPreviewExpanded] = useState(false);
+    const previewDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+    // Auto-save refs
+    const savedFormRef = useRef<string>("");
+    const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+    const selectedIndex = isNew ? "new" : Number(groupId);
+
+    // ─── Data fetching ──────────────────────────────────────────
+
+    useEffect(() => {
+        fetchWithAuth("/api/admin/config/groups/smart-filter-options")
+            .then((r) => r.json())
+            .then(setFilterOptions)
+            .catch(() => {}); // Non-critical
+    }, []);
+
+    useEffect(() => {
+        if (isNew) return;
+        setLoading(true);
+        fetchWithAuth("/api/admin/config/groups")
+            .then((r) => r.json())
+            .then((allGroups: SmartGroupForm[]) => {
+                setGroups(allGroups);
+                const idx = Number(groupId);
+                if (idx >= 0 && idx < allGroups.length) {
+                    setForm(allGroups[idx]);
+                    savedFormRef.current = JSON.stringify(allGroups[idx]);
+                }
+            })
+            .catch((e) => setError(String(e)))
+            .finally(() => setLoading(false));
+    }, [groupId, isNew]);
+
+    // ─── Live preview ───────────────────────────────────────────
+
+    useEffect(() => {
+        if (previewDebounceRef.current) clearTimeout(previewDebounceRef.current);
+
+        // Only preview if there are rules with values
+        const hasRules = form.rules.some((r) =>
+            r.field === "item_count" ? r.values.length > 0 : r.values.length > 0
+        );
+        if (!hasRules) {
+            setPreview(null);
+            return;
+        }
+
+        previewDebounceRef.current = setTimeout(async () => {
+            setPreviewLoading(true);
+            try {
+                const r = await fetchWithAuth("/api/admin/config/groups/preview-smart", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ rules: form.rules }),
+                });
+                if (r.ok) {
+                    const data = await r.json();
+                    setPreview(data);
+                }
+            } catch {
+                // Preview is non-critical
+            } finally {
+                setPreviewLoading(false);
+            }
+        }, 500);
+
+        return () => {
+            if (previewDebounceRef.current) clearTimeout(previewDebounceRef.current);
+        };
+    }, [form.rules]);
+
+    // ─── Auto-save ──────────────────────────────────────────────
+
+    const autoSave = useCallback(async (formToSave: SmartGroupForm, index: number) => {
+        try {
+            setAutoSaveError(null);
+            const payload = {
+                ...formToSave,
+                date_range: formToSave.date_range?.start && formToSave.date_range?.end ? formToSave.date_range : null,
+            };
+            const r = await fetchWithAuth(`/api/admin/config/groups/${index}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+            if (!r.ok) {
+                const text = await r.text();
+                throw new Error(text || "Failed to save group");
+            }
+            savedFormRef.current = JSON.stringify(formToSave);
+        } catch (e) {
+            setAutoSaveError(String(e));
+        }
+    }, []);
+
+    const flushAutoSave = () => {
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current);
+            debounceRef.current = undefined;
+        }
+        if (selectedIndex !== "new") {
+            const currentJson = JSON.stringify(form);
+            if (currentJson !== savedFormRef.current) {
+                autoSave(form, selectedIndex as number);
+            }
+        }
+    };
+
+    useEffect(() => {
+        if (selectedIndex === "new") return;
+        const currentJson = JSON.stringify(form);
+        if (currentJson === savedFormRef.current) return;
+
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        const formSnapshot = form;
+        const indexSnapshot = selectedIndex as number;
+        debounceRef.current = setTimeout(() => {
+            autoSave(formSnapshot, indexSnapshot);
+        }, 800);
+
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+        };
+    }, [form, selectedIndex, autoSave]);
+
+    // Auto-dismiss toast
+    useEffect(() => {
+        if (!message) return;
+        setMessageVisible(true);
+        const fadeTimer = setTimeout(() => setMessageVisible(false), 2500);
+        const clearTimer = setTimeout(() => setMessage(null), 3000);
+        return () => { clearTimeout(fadeTimer); clearTimeout(clearTimer); };
+    }, [message]);
+
+    // ─── Actions ────────────────────────────────────────────────
+
+    const createGroup = async () => {
+        try {
+            setSaving(true);
+            setError(null);
+            const payload = {
+                ...form,
+                date_range: form.date_range?.start && form.date_range?.end ? form.date_range : null,
+            };
+            const r = await fetchWithAuth("/api/admin/config/groups", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+            const text = await r.text();
+            if (!r.ok) throw new Error(text || "Failed to create group");
+
+            const nextGroups = await fetchWithAuth("/api/admin/config/groups").then((res) => res.json());
+            const targetIndex = nextGroups.length - 1;
+            if (targetIndex >= 0) {
+                setMessage("Smart group created");
+                navigate(`/groups/smart/${targetIndex}`);
+            }
+        } catch (e) {
+            setError(String(e));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const deleteGroup = async () => {
+        if (selectedIndex === "new") return;
+        try {
+            setDeleting(true);
+            const r = await fetchWithAuth(`/api/admin/config/groups/${selectedIndex}`, { method: "DELETE" });
+            if (!r.ok) throw new Error("Failed to delete group");
+            navigate("/groups");
+        } catch (e) {
+            setError(String(e));
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    // ─── Rule helpers ───────────────────────────────────────────
+
+    const updateRule = (index: number, updates: Partial<SmartGroupRule>) => {
+        setForm((prev) => {
+            const newRules = [...prev.rules];
+            const current = newRules[index];
+            const updated = { ...current, ...updates };
+
+            // Reset operator and values when field changes
+            if (updates.field && updates.field !== current.field) {
+                updated.operator = OPERATORS_BY_FIELD[updates.field][0].value;
+                updated.values = [];
+            }
+
+            newRules[index] = updated;
+            return { ...prev, rules: newRules };
+        });
+    };
+
+    const addRule = () => {
+        setForm((prev) => ({
+            ...prev,
+            rules: [...prev.rules, { field: "label", operator: "includes", values: [] }],
+        }));
+    };
+
+    const removeRule = (index: number) => {
+        setForm((prev) => ({
+            ...prev,
+            rules: prev.rules.filter((_, i) => i !== index),
+        }));
+    };
+
+    const toggleRuleValue = (ruleIndex: number, value: string) => {
+        setForm((prev) => {
+            const newRules = [...prev.rules];
+            const rule = { ...newRules[ruleIndex] };
+            const vals = [...rule.values];
+            const idx = vals.indexOf(value);
+            if (idx >= 0) vals.splice(idx, 1);
+            else vals.push(value);
+            rule.values = vals;
+            newRules[ruleIndex] = rule;
+            return { ...prev, rules: newRules };
+        });
+    };
+
+    // ─── Number input helpers ───────────────────────────────────
+
+    const handleNumberChange = (key: keyof SmartGroupForm, value: string) => {
+        if (value === "") {
+            setForm((prev) => ({ ...prev, [key]: "" as unknown as number }));
+            return;
+        }
+        const num = Number(value);
+        setForm((prev) => ({ ...prev, [key]: Number.isNaN(num) ? 0 : num }) as SmartGroupForm);
+    };
+
+    const handleNumberBlur = (key: keyof SmartGroupForm) => {
+        const val = form[key];
+        if (val === "" || val === undefined || val === null) {
+            setForm((prev) => ({ ...prev, [key]: 0 }) as SmartGroupForm);
+        }
+    };
+
+    const handleDateChange = (key: keyof DateRange, value: string) => {
+        setForm((prev) => {
+            const nextRange: DateRange = {
+                start: prev.date_range?.start ?? "",
+                end: prev.date_range?.end ?? "",
+                [key]: value,
+            };
+            if (!nextRange.start && !nextRange.end) return { ...prev, date_range: null };
+            return { ...prev, date_range: nextRange };
+        });
+    };
+
+    // ─── Value options for a rule ────────────────────────────────
+
+    const getValueOptions = (field: SmartGroupRule["field"]): string[] => {
+        switch (field) {
+            case "label": return filterOptions.labels;
+            case "source": return SOURCE_OPTIONS;
+            case "library": return filterOptions.libraries;
+            default: return [];
+        }
+    };
+
+    // ─── Render ─────────────────────────────────────────────────
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center min-h-[400px]">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="mx-auto max-w-5xl space-y-6 p-6">
+            {/* Header */}
+            <div className="flex flex-col gap-4">
+                <button
+                    onClick={() => { flushAutoSave(); navigate("/groups"); }}
+                    className="flex items-center gap-2 text-slate-400 hover:text-white w-fit transition-colors"
+                >
+                    <ArrowLeft size={20} />
+                    Back to Groups
+                </button>
+
+                <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                        {renaming && selectedIndex !== "new" ? (
+                            <input
+                                autoFocus
+                                value={form.name}
+                                onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+                                onBlur={() => setRenaming(false)}
+                                onKeyDown={(e) => { if (e.key === "Enter") setRenaming(false); }}
+                                className="text-3xl font-black tracking-tight text-white bg-transparent border-b-2 border-primary/50 outline-none w-full"
+                                placeholder="Group name"
+                            />
+                        ) : (
+                            <>
+                                <span
+                                    onClick={selectedIndex !== "new" ? () => setRenaming(true) : undefined}
+                                    className={`text-3xl font-black tracking-tight text-white ${selectedIndex !== "new" ? "hover:text-slate-200 cursor-text transition-colors" : ""}`}
+                                >
+                                    {isNew ? "Create Smart Group" : form.name || "Untitled Group"}
+                                </span>
+                                <span className="shrink-0 rounded-full bg-primary/20 text-primary border border-primary/30 px-2.5 py-0.5 text-xs font-semibold flex items-center gap-1">
+                                    <Sparkles className="h-3 w-3" />
+                                    Smart
+                                </span>
+                                {selectedIndex !== "new" && (() => {
+                                    const status = getGroupStatus(form);
+                                    const pillStyles = {
+                                        active: "bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 hover:bg-emerald-500/25",
+                                        scheduled: "bg-amber-500/15 text-amber-400 border border-amber-500/30 hover:bg-amber-500/25",
+                                        disabled: "bg-slate-700/40 text-slate-400 border border-slate-600/50 hover:bg-slate-700/60",
+                                    };
+                                    const dotStyles = {
+                                        active: "bg-emerald-400",
+                                        scheduled: "bg-amber-400",
+                                        disabled: "bg-slate-500",
+                                    };
+                                    const labels = {
+                                        active: "Active",
+                                        scheduled: "Scheduled",
+                                        disabled: "Disabled",
+                                    };
+                                    return (
+                                        <button
+                                            type="button"
+                                            onClick={() => setForm((p) => ({ ...p, enabled: !p.enabled }))}
+                                            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold transition-all duration-200 cursor-pointer ${pillStyles[status]}`}
+                                        >
+                                            <span className={`h-2 w-2 rounded-full ${dotStyles[status]}`} />
+                                            {labels[status]}
+                                        </button>
+                                    );
+                                })()}
+                            </>
+                        )}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => setSettingsOpen(true)}
+                            className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm font-medium text-slate-200 hover:border-primary/50 hover:bg-slate-800 hover:text-white transition-all duration-200"
+                        >
+                            <SlidersHorizontal className="h-4 w-4 text-primary" />
+                            Group Settings
+                        </button>
+                        {selectedIndex !== "new" && (
+                            <button
+                                type="button"
+                                onClick={() => setShowDeleteConfirm(true)}
+                                disabled={deleting}
+                                className="flex items-center justify-center p-2 rounded-lg border border-slate-700 bg-slate-900 text-slate-400 hover:border-red-500/50 hover:text-red-400 transition-all duration-200 disabled:opacity-50"
+                            >
+                                {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                            </button>
+                        )}
+                        {isNew && (
+                            <button
+                                type="button"
+                                onClick={createGroup}
+                                disabled={saving || !form.name.trim() || form.rules.length === 0}
+                                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary hover:bg-blue-600 text-white text-sm font-bold shadow-lg shadow-primary/30 hover:shadow-primary/40 transition-all duration-200 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                                Create Group
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Name input for new groups */}
+            {isNew && (
+                <div className="space-y-2">
+                    <label className="text-sm font-medium text-white">Group Name</label>
+                    <input
+                        type="text"
+                        value={form.name}
+                        onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+                        placeholder="e.g. Horror Collections, Trakt Lists..."
+                        className="w-full px-4 py-3 bg-slate-900 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70 text-sm"
+                    />
+                </div>
+            )}
+
+            {/* Error / auto-save status */}
+            {error && (
+                <div className="rounded-xl border border-red-500/30 bg-red-950/50 px-4 py-3 text-sm text-red-200">{error}</div>
+            )}
+            {autoSaveError && (
+                <div className="rounded-xl border border-amber-500/30 bg-amber-950/50 px-4 py-3 text-sm text-amber-200">Auto-save failed: {autoSaveError}</div>
+            )}
+
+            {/* Rule Builder */}
+            <section className="space-y-4">
+                <div className="flex items-center justify-between">
+                    <div>
+                        <h2 className="text-lg font-bold text-white">Rules</h2>
+                        <p className="text-xs text-slate-400 mt-0.5">Collections matching <span className="text-slate-300 font-medium">all</span> rules will be included.</p>
+                    </div>
+                </div>
+
+                <div className="space-y-3">
+                    {form.rules.map((rule, i) => (
+                        <div key={i} className="rounded-xl border border-slate-800/60 bg-slate-900/50 p-4 space-y-3">
+                            <div className="flex items-center gap-3">
+                                <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider w-16 shrink-0">
+                                    {i === 0 ? "Where" : "And"}
+                                </span>
+
+                                {/* Field selector */}
+                                <Listbox value={rule.field} onChange={(val) => updateRule(i, { field: val as SmartGroupRule["field"] })}>
+                                    <div className="relative w-36">
+                                        <Listbox.Button className="flex items-center justify-between w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white hover:bg-slate-750 focus:outline-none focus:ring-2 focus:ring-primary/70">
+                                            <span>{FIELD_OPTIONS.find((f) => f.value === rule.field)?.label}</span>
+                                            <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
+                                        </Listbox.Button>
+                                        <Listbox.Options className="absolute z-20 mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg">
+                                            {FIELD_OPTIONS.map((opt) => (
+                                                <Listbox.Option key={opt.value} value={opt.value} className="cursor-pointer px-3 py-2 text-sm text-white hover:bg-slate-700 data-[selected]:bg-primary data-[selected]:font-semibold">
+                                                    {opt.label}
+                                                </Listbox.Option>
+                                            ))}
+                                        </Listbox.Options>
+                                    </div>
+                                </Listbox>
+
+                                {/* Operator selector */}
+                                <Listbox value={rule.operator} onChange={(val) => updateRule(i, { operator: val })}>
+                                    <div className="relative w-44">
+                                        <Listbox.Button className="flex items-center justify-between w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white hover:bg-slate-750 focus:outline-none focus:ring-2 focus:ring-primary/70">
+                                            <span>{OPERATORS_BY_FIELD[rule.field]?.find((o) => o.value === rule.operator)?.label}</span>
+                                            <ChevronDown className="h-3.5 w-3.5 text-slate-400" />
+                                        </Listbox.Button>
+                                        <Listbox.Options className="absolute z-20 mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg">
+                                            {OPERATORS_BY_FIELD[rule.field]?.map((opt) => (
+                                                <Listbox.Option key={opt.value} value={opt.value} className="cursor-pointer px-3 py-2 text-sm text-white hover:bg-slate-700 data-[selected]:bg-primary data-[selected]:font-semibold">
+                                                    {opt.label}
+                                                </Listbox.Option>
+                                            ))}
+                                        </Listbox.Options>
+                                    </div>
+                                </Listbox>
+
+                                <div className="flex-1" />
+
+                                {/* Remove rule */}
+                                {form.rules.length > 1 && (
+                                    <button
+                                        type="button"
+                                        onClick={() => removeRule(i)}
+                                        className="p-1.5 rounded-lg text-slate-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </button>
+                                )}
+                            </div>
+
+                            {/* Value input — varies by field type */}
+                            {rule.field === "item_count" ? (
+                                <div className="flex items-center gap-2 ml-[76px]">
+                                    <input
+                                        type="number"
+                                        min={0}
+                                        value={rule.values[0] ?? ""}
+                                        onChange={(e) => {
+                                            const v = e.target.value === "" ? [] : [Number(e.target.value)];
+                                            updateRule(i, { values: v });
+                                        }}
+                                        placeholder="10"
+                                        className="w-24 px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                                    />
+                                    <span className="text-xs text-slate-400">items</span>
+                                </div>
+                            ) : rule.field === "name" ? (
+                                <div className="ml-[76px] space-y-2">
+                                    <div className="flex flex-wrap gap-2">
+                                        {(rule.values as string[]).map((v, vi) => (
+                                            <span key={vi} className="flex items-center gap-1 rounded-full bg-primary/20 text-primary border border-primary/30 px-3 py-1 text-xs font-medium">
+                                                {v}
+                                                <button type="button" onClick={() => {
+                                                    const newVals = [...rule.values];
+                                                    newVals.splice(vi, 1);
+                                                    updateRule(i, { values: newVals });
+                                                }}>
+                                                    <X className="h-3 w-3" />
+                                                </button>
+                                            </span>
+                                        ))}
+                                    </div>
+                                    <input
+                                        type="text"
+                                        placeholder="Type a keyword and press Enter"
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter" && e.currentTarget.value.trim()) {
+                                                updateRule(i, { values: [...rule.values, e.currentTarget.value.trim()] });
+                                                e.currentTarget.value = "";
+                                            }
+                                        }}
+                                        className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                                    />
+                                </div>
+                            ) : (
+                                <div className="ml-[76px] flex flex-wrap gap-2">
+                                    {getValueOptions(rule.field).map((opt) => {
+                                        const isSelected = rule.values.includes(opt);
+                                        const colorClass = rule.field === "source" && SOURCE_COLORS[opt];
+                                        return (
+                                            <button
+                                                key={opt}
+                                                type="button"
+                                                onClick={() => toggleRuleValue(i, opt)}
+                                                className={`rounded-full px-3 py-1 text-xs font-medium border transition-all duration-200 ${
+                                                    isSelected
+                                                        ? colorClass || "bg-primary/20 text-primary border-primary/30"
+                                                        : "bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600 hover:text-slate-300"
+                                                }`}
+                                            >
+                                                {opt}
+                                            </button>
+                                        );
+                                    })}
+                                    {getValueOptions(rule.field).length === 0 && (
+                                        <p className="text-xs text-slate-500 italic">No options available</p>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+                <button
+                    type="button"
+                    onClick={addRule}
+                    className="flex items-center gap-2 rounded-lg border border-dashed border-slate-700/50 px-4 py-2.5 text-sm text-slate-400 hover:text-primary hover:border-primary/40 transition-all duration-200"
+                >
+                    <Plus className="h-4 w-4" />
+                    Add Rule
+                </button>
+            </section>
+
+            {/* Live Preview */}
+            <section className="rounded-xl border border-slate-800/60 bg-slate-900/50 p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <h3 className="text-sm font-semibold text-white">Matching Collections</h3>
+                        {previewLoading ? (
+                            <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                        ) : preview ? (
+                            <span className="rounded-full bg-primary/20 text-primary border border-primary/30 px-2.5 py-0.5 text-xs font-bold">
+                                {preview.count}
+                            </span>
+                        ) : null}
+                    </div>
+                    {preview && preview.count > 0 && (
+                        <button
+                            type="button"
+                            onClick={() => setPreviewExpanded(!previewExpanded)}
+                            className="text-xs text-slate-400 hover:text-white transition-colors"
+                        >
+                            {previewExpanded ? "Collapse" : "Show all"}
+                        </button>
+                    )}
+                </div>
+
+                {!preview || preview.count === 0 ? (
+                    <p className="text-xs text-slate-500 italic">
+                        {form.rules.some((r) => r.values.length > 0)
+                            ? "No collections match these rules."
+                            : "Add values to your rules to see matching collections."}
+                    </p>
+                ) : (
+                    <div className={`flex flex-wrap gap-2 ${!previewExpanded && preview.count > 10 ? "max-h-20 overflow-hidden" : ""}`}>
+                        {preview.collections.map((name) => (
+                            <span key={name} className="rounded-full bg-slate-800 border border-slate-700 px-3 py-1 text-xs text-slate-300">
+                                {name}
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            {/* Group Settings Sheet */}
+            <Sheet open={settingsOpen} onOpenChange={setSettingsOpen}>
+                <SheetContent>
+                    <SheetHeader>
+                        <div className="flex items-center gap-3">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 border border-primary/20">
+                                <SlidersHorizontal className="h-5 w-5 text-primary" />
+                            </div>
+                            <div>
+                                <SheetTitle>Group Settings</SheetTitle>
+                                <SheetDescription>Rotation rules, visibility, and scheduling</SheetDescription>
+                            </div>
+                        </div>
+                        <SheetCloseButton />
+                    </SheetHeader>
+                    <SheetBody>
+                        {/* Pick Limits */}
+                        <div className="space-y-3">
+                            <label className="text-sm font-medium text-white">Pick Limits</label>
+                            <p className="text-xs text-slate-400">Min and max collections to include per rotation.</p>
+                            <div className="grid grid-cols-2 gap-3">
+                                {(["min_picks", "max_picks"] as const).map((key) => (
+                                    <div key={key} className="space-y-1">
+                                        <label className="text-xs text-slate-400">{key === "min_picks" ? "Min picks" : "Max picks"}</label>
+                                        <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
+                                            <button type="button" disabled={Number(form[key]) <= 0} onClick={() => handleNumberChange(key, String(Math.max(0, Number(form[key]) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                                                <Minus className="h-4 w-4" />
+                                            </button>
+                                            <input type="number" min={0} value={form[key]} onChange={(e) => handleNumberChange(key, e.target.value)} onBlur={() => handleNumberBlur(key)} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
+                                            <button type="button" onClick={() => handleNumberChange(key, String(Number(form[key]) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
+                                                <Plus className="h-4 w-4" />
+                                            </button>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        <hr className="border-slate-700/50" />
+
+                        {/* Priority & Spacing */}
+                        <div className="space-y-3">
+                            <label className="text-sm font-medium text-white">Priority & Spacing</label>
+                            <p className="text-xs text-slate-400">Higher weights are picked more often. Min gap prevents repeats.</p>
+                            <div className="grid grid-cols-2 gap-3">
+                                <div className="space-y-1">
+                                    <label className="text-xs text-slate-400">Weight</label>
+                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
+                                        <button type="button" disabled={Number(form.weight) <= 1} onClick={() => handleNumberChange("weight", String(Math.max(1, Number(form.weight) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                                            <Minus className="h-4 w-4" />
+                                        </button>
+                                        <input type="number" min={1} value={form.weight} onChange={(e) => handleNumberChange("weight", e.target.value)} onBlur={() => handleNumberBlur("weight")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
+                                        <button type="button" onClick={() => handleNumberChange("weight", String(Number(form.weight) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
+                                            <Plus className="h-4 w-4" />
+                                        </button>
+                                    </div>
+                                </div>
+                                <div className="space-y-1">
+                                    <label className="text-xs text-slate-400">Min gap (rotations)</label>
+                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
+                                        <button type="button" disabled={Number(form.min_gap_rotations) <= 0} onClick={() => handleNumberChange("min_gap_rotations", String(Math.max(0, Number(form.min_gap_rotations) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                                            <Minus className="h-4 w-4" />
+                                        </button>
+                                        <input type="number" min={0} value={form.min_gap_rotations} onChange={(e) => handleNumberChange("min_gap_rotations", e.target.value)} onBlur={() => handleNumberBlur("min_gap_rotations")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
+                                        <button type="button" onClick={() => handleNumberChange("min_gap_rotations", String(Number(form.min_gap_rotations) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
+                                            <Plus className="h-4 w-4" />
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <hr className="border-slate-700/50" />
+
+                        {/* Visibility */}
+                        <div className="space-y-3">
+                            <label className="text-sm font-medium text-white">Visibility</label>
+                            <p className="text-xs text-slate-400">Control where collections from this group appear on Plex.</p>
+                            <div className="grid gap-2">
+                                {([
+                                    { key: "visibility_home" as const, label: "Home", icon: Home },
+                                    { key: "visibility_shared" as const, label: "Shared", icon: Share2 },
+                                    { key: "visibility_recommended" as const, label: "Recommended", icon: Compass },
+                                ]).map(({ key, label, icon: Icon }) => {
+                                    const isSelected = form[key];
+                                    return (
+                                        <button
+                                            key={key}
+                                            type="button"
+                                            onClick={() => setForm((p) => ({ ...p, [key]: !p[key] }))}
+                                            className={`flex items-center justify-center gap-2 rounded-lg border px-4 py-2.5 transition-all duration-200 ${
+                                                isSelected ? "border-primary bg-primary/15" : "border-slate-700 bg-slate-900 hover:border-slate-600"
+                                            }`}
+                                        >
+                                            <Icon className={`h-4 w-4 shrink-0 ${isSelected ? "text-primary" : "text-slate-500"}`} />
+                                            <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>{label}</span>
+                                            <div className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all duration-200 ml-auto ${isSelected ? "border-primary bg-primary" : "border-slate-600 bg-transparent"}`} />
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+
+                        <hr className="border-slate-700/50" />
+
+                        {/* Date Range */}
+                        <div className="space-y-3">
+                            <div className="flex items-center gap-2">
+                                <CalendarRange className="h-4 w-4 text-primary" />
+                                <label className="text-sm font-medium text-white">Date Range</label>
+                            </div>
+                            <p className="text-xs text-slate-400">Optional activation window (MM-DD). Leave empty for year-round.</p>
+                            <div className="grid grid-cols-2 gap-3">
+                                <div className="space-y-1">
+                                    <label className="text-xs text-slate-400">Start</label>
+                                    <input type="text" value={form.date_range?.start ?? ""} onChange={(e) => handleDateChange("start", e.target.value)} placeholder="11-20" className="w-full px-3 py-2.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70" />
+                                </div>
+                                <div className="space-y-1">
+                                    <label className="text-xs text-slate-400">End</label>
+                                    <input type="text" value={form.date_range?.end ?? ""} onChange={(e) => handleDateChange("end", e.target.value)} placeholder="12-26" className="w-full px-3 py-2.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70" />
+                                </div>
+                            </div>
+                        </div>
+                    </SheetBody>
+                </SheetContent>
+            </Sheet>
+
+            {/* Delete confirmation */}
+            <ConfirmDialog
+                open={showDeleteConfirm}
+                onOpenChange={setShowDeleteConfirm}
+                title="Delete Smart Group"
+                description={`Are you sure you want to delete "${form.name}"? This action cannot be undone.`}
+                confirmLabel="Delete"
+                variant="danger"
+                onConfirm={() => { setShowDeleteConfirm(false); deleteGroup(); }}
+            />
+
+            {/* Success toast */}
+            {message && (
+                <div className={`fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-950/90 px-4 py-3 text-emerald-100 shadow-lg backdrop-blur-sm transition-all duration-500 ${messageVisible ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0"}`}>
+                    <Check className="h-4 w-4 text-emerald-400" />
+                    <p className="text-sm font-medium">{message}</p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/homescreen-hero-ui/src/utils/auth.tsx
+++ b/homescreen-hero-ui/src/utils/auth.tsx
@@ -130,6 +130,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
     const context = useContext(AuthContext);
     if (context === undefined) {

--- a/homescreen-hero-ui/src/utils/theme.tsx
+++ b/homescreen-hero-ui/src/utils/theme.tsx
@@ -49,6 +49,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTheme() {
     const ctx = useContext(ThemeContext);
     if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");

--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -89,7 +89,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
     # Plex URL override
     plex_url = os.getenv("HSH_PLEX_URL")
     if plex_url:
-        logger.info("Using Plex URL from HSH_PLEX_URL environment variable")
+        logger.debug("Using Plex URL from HSH_PLEX_URL environment variable")
         config.plex.base_url = plex_url
     elif not config.plex.base_url:
         raise ValueError(
@@ -99,7 +99,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
     # Plex token override
     plex_token = os.getenv("HSH_PLEX_TOKEN")
     if plex_token:
-        logger.info("Using Plex token from HSH_PLEX_TOKEN environment variable")
+        logger.debug("Using Plex token from HSH_PLEX_TOKEN environment variable")
         config.plex.token = plex_token
     elif not config.plex.token:
         raise ValueError(
@@ -114,7 +114,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
         if method in ("password", "both"):
             auth_password = os.getenv("HSH_AUTH_PASSWORD")
             if auth_password:
-                logger.info("Using auth password from HSH_AUTH_PASSWORD environment variable")
+                logger.debug("Using auth password from HSH_AUTH_PASSWORD environment variable")
                 config.auth.password = auth_password
             elif not config.auth.password:
                 raise ValueError(
@@ -125,7 +125,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
         # Secret key is always required when auth is enabled (used for JWT signing)
         auth_secret = os.getenv("HSH_AUTH_SECRET_KEY")
         if auth_secret:
-            logger.info("Using auth secret key from HSH_AUTH_SECRET_KEY environment variable")
+            logger.debug("Using auth secret key from HSH_AUTH_SECRET_KEY environment variable")
             config.auth.secret_key = auth_secret
         elif not config.auth.secret_key:
             raise ValueError(
@@ -136,7 +136,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
     if config.trakt and config.trakt.enabled:
         trakt_client_id = os.getenv("HSH_TRAKT_CLIENT_ID")
         if trakt_client_id:
-            logger.info("Using Trakt client ID from HSH_TRAKT_CLIENT_ID environment variable")
+            logger.debug("Using Trakt client ID from HSH_TRAKT_CLIENT_ID environment variable")
             config.trakt.client_id = trakt_client_id
         elif not config.trakt.client_id:
             raise ValueError(
@@ -147,14 +147,14 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
     if config.mdblist and config.mdblist.enabled:
         mdblist_api_key = os.getenv("HSH_MDBLIST_API_KEY")
         if mdblist_api_key:
-            logger.info("Using MDBList API key from HSH_MDBLIST_API_KEY environment variable")
+            logger.debug("Using MDBList API key from HSH_MDBLIST_API_KEY environment variable")
             config.mdblist.api_key = mdblist_api_key
 
     # Tautulli API key override (if Tautulli is enabled)
     if config.tautulli and config.tautulli.enabled:
         tautulli_api_key = os.getenv("HSH_TAUTULLI_API_KEY")
         if tautulli_api_key:
-            logger.info("Using Tautulli API key from HSH_TAUTULLI_API_KEY environment variable")
+            logger.debug("Using Tautulli API key from HSH_TAUTULLI_API_KEY environment variable")
             config.tautulli.api_key = tautulli_api_key
         elif not config.tautulli.api_key:
             raise ValueError(
@@ -165,14 +165,14 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
         # Skip placeholder value from Unraid template
         tautulli_base_url = os.getenv("HSH_TAUTULLI_BASE_URL")
         if tautulli_base_url and tautulli_base_url != "http://your-tautulli-url:8181":
-            logger.info("Using Tautulli base URL from HSH_TAUTULLI_BASE_URL environment variable")
+            logger.debug("Using Tautulli base URL from HSH_TAUTULLI_BASE_URL environment variable")
             config.tautulli.base_url = tautulli_base_url
 
     # MAL Client ID override (if MAL is enabled)
     if config.mal and config.mal.enabled:
         mal_client_id = os.getenv("HSH_MAL_CLIENT_ID")
         if mal_client_id:
-            logger.info("Using MAL Client ID from HSH_MAL_CLIENT_ID environment variable")
+            logger.debug("Using MAL Client ID from HSH_MAL_CLIENT_ID environment variable")
             config.mal.client_id = mal_client_id
         elif not config.mal.client_id:
             raise ValueError(
@@ -184,7 +184,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
     if config.seerr and config.seerr.enabled:
         seerr_api_key = os.getenv("HSH_SEERR_API_KEY")
         if seerr_api_key:
-            logger.info("Using Seerr API key from HSH_SEERR_API_KEY environment variable")
+            logger.debug("Using Seerr API key from HSH_SEERR_API_KEY environment variable")
             config.seerr.api_key = seerr_api_key
         elif not config.seerr.api_key:
             raise ValueError(
@@ -195,7 +195,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
         # Skip placeholder value from Unraid template
         seerr_base_url = os.getenv("HSH_SEERR_BASE_URL")
         if seerr_base_url and seerr_base_url != "http://your-seerr-url:5055":
-            logger.info("Using Seerr base URL from HSH_SEERR_BASE_URL environment variable")
+            logger.debug("Using Seerr base URL from HSH_SEERR_BASE_URL environment variable")
             config.seerr.base_url = seerr_base_url
 
     return config
@@ -213,7 +213,7 @@ def _validate_config_dict(raw_data: dict) -> AppConfig:
     # Validate that collections in groups have corresponding sources or are manual
     _validate_collection_references(config)
 
-    logger.info("Config validation successful")
+    logger.debug("Config validation successful")
     return config
 
 
@@ -305,7 +305,7 @@ def load_config(path: Optional[Path | str] = None, force_reload: bool = False) -
         logger.debug("Using cached config")
         return _cached_config
 
-    logger.info(f"Loading config from {config_path}")
+    logger.debug(f"Loading config from {config_path}")
     raw_data = _read_raw_config(config_path)
     app_config = _validate_config_dict(raw_data)
     

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
-from typing import Any, Dict, List, Literal, Optional
-from pydantic import BaseModel, Field
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class DateRange(BaseModel):
@@ -95,6 +95,45 @@ class RotationSettings(BaseModel):
     )
 
 
+class SmartGroupRule(BaseModel):
+    # A single filter rule for smart groups.
+    # Rules within a group are ANDed; multiple values within a rule are ORed.
+    field: Literal["label", "source", "library", "name", "item_count"] = Field(
+        ..., description="Which collection attribute to filter on"
+    )
+    operator: str = Field(
+        ...,
+        description=(
+            "Comparison operator. Varies by field: "
+            "label: includes/excludes; source/library: is/is_not; "
+            "name: contains/not_contains; item_count: gte/lte"
+        ),
+    )
+    values: List[Union[str, int]] = Field(
+        ..., description="Values to match against (ORed within this rule)"
+    )
+
+    model_config = ConfigDict(arbitrary_types_allowed=False)
+
+    VALID_OPERATORS: ClassVar[dict] = {
+        "label": {"includes", "excludes"},
+        "source": {"is", "is_not"},
+        "library": {"is", "is_not"},
+        "name": {"contains", "not_contains"},
+        "item_count": {"gte", "lte"},
+    }
+
+    @model_validator(mode="after")
+    def validate_operator(self):
+        valid = self.VALID_OPERATORS.get(self.field, set())
+        if self.operator not in valid:
+            raise ValueError(
+                f"Invalid operator '{self.operator}' for field '{self.field}'. "
+                f"Valid operators: {sorted(valid)}"
+            )
+        return self
+
+
 class CollectionGroupConfig(BaseModel):
     name: str = Field(..., description="Name of this group (e.g. 'Christmas')")
     enabled: bool = Field(default=True)
@@ -139,10 +178,24 @@ class CollectionGroupConfig(BaseModel):
         default=None,
         description="Optional yearly date window when this group is active",
     )
+    smart: bool = Field(
+        default=False,
+        description="Whether this group uses smart rules instead of a manual collection list",
+    )
+    rules: List[SmartGroupRule] = Field(
+        default_factory=list,
+        description="Smart group filter rules (only used when smart=True)",
+    )
     collections: List[str] = Field(
         default_factory=list,
-        description="List of Plex collection names belonging to this group",
+        description="List of Plex collection names belonging to this group (ignored when smart=True)",
     )
+
+    @model_validator(mode="after")
+    def validate_smart_rules(self):
+        if self.smart and not self.rules:
+            raise ValueError("Smart groups must have at least one rule")
+        return self
 
 
 class LoggingSettings(BaseModel):

--- a/homescreen_hero/core/integrations/letterboxd_sync.py
+++ b/homescreen_hero/core/integrations/letterboxd_sync.py
@@ -187,10 +187,10 @@ def sync_single_letterboxd_source(
         missing,
     )
 
-    # Log missing items
+    # Log missing items (summary already logged at INFO above)
     if missing_items:
         for m in missing_items:
-            logger.info(
+            logger.debug(
                 "Letterboxd missing in Plex: %s (%s) slug=%s",
                 m.get("title"),
                 m.get("year"),

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -158,11 +158,11 @@ def sync_single_mdblist_source(
         missing,
     )
 
-    # Logs missing item from MDBList Collection
+    # Log missing items (summary already logged at INFO above)
     # Future plan: automatically send requests to Sonarr/Radarr to add them
     if missing_items:
         for m in missing_items:
-            logger.info(
+            logger.debug(
                 "MDBList missing in Plex: %s (%s) imdb=%s tmdb=%s",
                 m.get("title"),
                 m.get("year"),

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -55,6 +55,17 @@ def get_library_collections(
     return by_title
 
 
+def get_collection_labels(collection: object) -> List[str]:
+    # Extract label tags from a PlexAPI Collection object.
+    # Returns empty list if collection has no labels or labels aren't loaded.
+    return [label.tag for label in getattr(collection, "labels", [])]
+
+
+def get_collection_item_count(collection: object) -> int:
+    # Get the number of items in a collection without fetching them all.
+    return getattr(collection, "childCount", 0)
+
+
 def get_configured_collection_names(config: AppConfig) -> Set[str]:
     # Build the set of all collection names referenced in your groups and integration sources
     names: Set[str] = set()
@@ -235,6 +246,7 @@ def apply_home_screen_selection(
     collection_visibility: Dict[str, Dict[str, bool]],
     *,
     dry_run: bool = False,
+    smart_group_collections: Dict[str, List[str]] | None = None,
 ) -> List[str]:
     # Apply the chosen collections to the Plex Home screen
     #
@@ -368,6 +380,7 @@ def apply_home_screen_selection(
             config,
             pinned_names=pinned_names,
             pinned_order=pinned_order,
+            smart_group_collections=smart_group_collections,
         )
         reorder_homescreen_collections(server, config, ordered_applied)
 

--- a/homescreen_hero/core/poster_proxy.py
+++ b/homescreen_hero/core/poster_proxy.py
@@ -1,0 +1,90 @@
+import hashlib
+import logging
+import requests
+from cachetools import TTLCache
+from fastapi import HTTPException, Response
+
+logger = logging.getLogger(__name__)
+
+# TTL Cache for poster URLs: stores up to 1000 items, each expires after 1 hour (3600 seconds)
+poster_url_cache = TTLCache(maxsize=1000, ttl=3600)
+
+# TTL Cache for actual image content: stores up to 500 images, each expires after 1 hour
+# Each image can be ~200KB, so 500 images = ~100MB in memory
+poster_image_cache = TTLCache(maxsize=500, ttl=3600)
+
+
+def create_proxy_url(plex_url: str) -> str:
+    # Store a Plex URL in cache and return a proxied URL the frontend can use.
+    # The Plex token stays server-side; the frontend only sees a hash key.
+    cache_key = hashlib.md5(plex_url.encode()).hexdigest()
+    poster_url_cache[cache_key] = plex_url
+    return f"/api/collections/poster-proxy/{cache_key}"
+
+
+def serve_proxy_poster(cache_key: str) -> Response:
+    # Serve a cached poster image, or fetch it from Plex if not cached.
+    try:
+        cached_image = poster_image_cache.get(cache_key)
+        if cached_image:
+            logger.debug(f"Serving cached image for key: {cache_key}")
+            return Response(
+                content=cached_image['content'],
+                media_type=cached_image['media_type'],
+                headers={
+                    'Cache-Control': 'public, max-age=3600',
+                    'ETag': cache_key
+                }
+            )
+
+        poster_url = poster_url_cache.get(cache_key)
+        if not poster_url:
+            logger.warning(f"Poster URL not found in cache for key: {cache_key}")
+            raise HTTPException(status_code=404, detail="Poster not found or expired")
+
+        logger.debug(f"Fetching image from Plex for key: {cache_key}")
+        response = requests.get(poster_url, timeout=10, verify=False)
+        response.raise_for_status()
+
+        media_type = response.headers.get('content-type', 'image/jpeg')
+        poster_image_cache[cache_key] = {
+            'content': response.content,
+            'media_type': media_type
+        }
+
+        return Response(
+            content=response.content,
+            media_type=media_type,
+            headers={
+                'Cache-Control': 'public, max-age=3600',
+                'ETag': cache_key
+            }
+        )
+
+    except HTTPException:
+        raise
+    except requests.RequestException as e:
+        logger.error(f"Failed to proxy poster {cache_key}: {e}")
+        raise HTTPException(status_code=502, detail="Failed to fetch poster from Plex")
+    except Exception as e:
+        logger.error(f"Unexpected error proxying poster {cache_key}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+def build_collection_poster_url(server, col) -> str | None:
+    # Build a proxied poster URL for a Plex collection object.
+    # Returns None if the collection has no thumbnail.
+    if not getattr(col, "thumb", None):
+        return None
+    try:
+        full_thumb_url = server.url(col.thumb, includeToken=True)
+        plex_url = server.transcodeImage(full_thumb_url, height=450, width=300, minSize=1)
+    except Exception:
+        plex_url = server.url(col.thumb, includeToken=True)
+    return create_proxy_url(plex_url)
+
+
+def invalidate_poster_caches():
+    # Clear both poster caches (e.g. after a poster upload).
+    poster_url_cache.clear()
+    poster_image_cache.clear()

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -165,6 +165,16 @@ def _is_blacklisted(collection_name: str, blacklist: List[str]) -> bool:
     return collection_name in blacklist
 
 
+def _get_collection_pool(
+    group: CollectionGroupConfig,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
+) -> List[str]:
+    # Return the collection pool for a group — resolved smart rules or static list.
+    if group.smart and smart_group_collections and group.name in smart_group_collections:
+        return list(smart_group_collections[group.name])
+    return list(group.collections)
+
+
 # Same as run_rotation_dry, but respects history for gap rules
 def run_rotation_with_history(
     config: AppConfig,
@@ -174,6 +184,7 @@ def run_rotation_with_history(
     last_rotation_collections: Optional[List[str]] = None,
     pinned_names: Optional[Set[str]] = None,
     collection_library_map: Optional[Dict[str, str]] = None,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
     today: Optional[date] = None,
     rng: Optional[random.Random] = None,
 ) -> RotationResult:
@@ -236,12 +247,14 @@ def run_rotation_with_history(
     for group in ordered_groups:
         is_active = _group_is_active(group, today)
 
+        pool = _get_collection_pool(group, smart_group_collections)
+
         result = GroupSelectionResult(
             group_name=group.name,
             active=is_active,
             min_picks=group.min_picks,
             max_picks=group.max_picks,
-            available_collections=list(group.collections),
+            available_collections=pool,
             chosen_collections=[],
             picked_count=0,
             reason_skipped=None,
@@ -260,7 +273,7 @@ def run_rotation_with_history(
             continue
 
         # Filter out collections already chosen in this rotation
-        available = [c for c in group.collections if c not in selected_set]
+        available = [c for c in pool if c not in selected_set]
 
         # Apply gap rule based on history
         available = [
@@ -532,6 +545,7 @@ def run_auto_rotation_with_history(
 def run_rotation_dry(
     config: AppConfig,
     *,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
     today: Optional[date] = None,               # Core Rotation Logic:
     rng: Optional[random.Random] = None,        # For each active group:
 ) -> RotationResult:                            #   1. Choose between min_picks and max_picks collections (if available)
@@ -562,13 +576,14 @@ def run_rotation_dry(
 
     for group in ordered_groups:
         is_active = _group_is_active(group, today)
+        pool = _get_collection_pool(group, smart_group_collections)
 
         result = GroupSelectionResult(
             group_name=group.name,
             active=is_active,
             min_picks=group.min_picks,
             max_picks=group.max_picks,
-            available_collections=list(group.collections),
+            available_collections=pool,
             chosen_collections=[],
             picked_count=0,
             reason_skipped=None,
@@ -587,7 +602,7 @@ def run_rotation_dry(
             continue
 
         # Remove any collections already chosen by earlier groups
-        available = [c for c in group.collections if c not in selected_set]
+        available = [c for c in pool if c not in selected_set]
 
         # Filter out blacklisted collections
         blacklist = config.rotation.blacklisted_collections
@@ -668,14 +683,18 @@ def run_rotation_dry(
 def select_collections_for_rotation(
     config: AppConfig,
     *,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
     today: Optional[date] = None,
     rng: Optional[random.Random] = None,
 ) -> List[str]:
-    result = run_rotation_dry(config, today=today, rng=rng)
+    result = run_rotation_dry(config, smart_group_collections=smart_group_collections, today=today, rng=rng)
     return result.selected_collections
 
 
-def build_collection_visibility_map(config: AppConfig) -> Dict[str, Dict[str, bool]]:
+def build_collection_visibility_map(
+    config: AppConfig,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
+) -> Dict[str, Dict[str, bool]]:
     """
     Build a mapping from collection name to visibility settings based on the group it belongs to.
 
@@ -688,7 +707,8 @@ def build_collection_visibility_map(config: AppConfig) -> Dict[str, Dict[str, bo
     visibility_map: Dict[str, Dict[str, bool]] = {}
 
     for group in config.groups:
-        for collection_name in group.collections:
+        pool = _get_collection_pool(group, smart_group_collections)
+        for collection_name in pool:
             # Only set visibility if this collection hasn't been seen yet
             # (first group wins if a collection is in multiple groups)
             if collection_name not in visibility_map:
@@ -703,11 +723,13 @@ def build_collection_visibility_map(config: AppConfig) -> Dict[str, Dict[str, bo
 
 def _build_collection_group_map(
     config: AppConfig,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
 ) -> Dict[str, CollectionGroupConfig]:
     # Map collection name -> its group config (first group wins for duplicates)
     coll_to_group: Dict[str, CollectionGroupConfig] = {}
     for group in config.groups:
-        for name in group.collections:
+        pool = _get_collection_pool(group, smart_group_collections)
+        for name in pool:
             if name not in coll_to_group:
                 coll_to_group[name] = group
     return coll_to_group
@@ -718,6 +740,7 @@ def order_collections_for_display(
     config: AppConfig,
     pinned_names: Optional[Set[str]] = None,
     pinned_order: Optional[Dict[str, int]] = None,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
     rng: Optional[random.Random] = None,
 ) -> List[str]:
     # Order selected collections based on group display_order and display mode.
@@ -728,7 +751,7 @@ def order_collections_for_display(
     pinned_names = pinned_names or set()
     pinned_order = pinned_order or {}
 
-    coll_to_group = _build_collection_group_map(config)
+    coll_to_group = _build_collection_group_map(config, smart_group_collections)
     mode = config.display.group_display_mode
 
     # Separate pinned and non-pinned

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -411,6 +411,9 @@ def simulate_rotation_once(
     server = get_plex_server(config)
     collection_library_map = _build_collection_library_map(server, config)
 
+    # Resolve smart groups into concrete collection lists
+    smart_group_collections = _resolve_smart_groups(server, config)
+
     # Check if auto-rotate mode is enabled
     if config.rotation.auto_rotate.enabled:
         rotation_result = _run_auto_rotation(
@@ -425,6 +428,7 @@ def simulate_rotation_once(
             last_rotation_collections=last_rotation_collections,
             pinned_names=pinned_names,
             collection_library_map=collection_library_map,
+            smart_group_collections=smart_group_collections,
         )
 
     simulation_id = create_simulation(rotation_result)

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -18,6 +18,7 @@ from .integrations.plex_client import get_library_collections
 from .config.loader import load_config
 from .config.schema import AppConfig, RotationExecution, RotationResult
 from .rotation import run_rotation_with_history, run_auto_rotation_with_history, build_collection_visibility_map
+from .smart_groups import build_collection_metadata, resolve_smart_rules
 from .db import (
     init_db,
     get_last_rotation_collections,
@@ -46,6 +47,23 @@ def _build_collection_library_map(server, config: AppConfig) -> Dict[str, str]:
             except Exception as e:
                 logger.warning("Failed to get collections from library '%s': %s", lib_config.name, e)
     return coll_to_lib
+
+
+def _resolve_smart_groups(server, config: AppConfig) -> Dict[str, List[str]]:
+    # Resolve all smart groups into concrete collection name lists.
+    # Returns a dict mapping group name -> resolved collection names.
+    smart_groups = [g for g in config.groups if g.smart]
+    if not smart_groups:
+        return {}
+
+    logger.info("Resolving %d smart group(s)", len(smart_groups))
+    metadata = build_collection_metadata(server, config)
+    result = {}
+    for group in smart_groups:
+        resolved = resolve_smart_rules(group.rules, metadata)
+        result[group.name] = resolved
+        logger.info("Smart group '%s' resolved to %d collections", group.name, len(resolved))
+    return result
 
 
 def _run_auto_rotation(
@@ -217,6 +235,9 @@ def run_rotation_once(
     # Build collection→library map for per-library limits
     collection_library_map = _build_collection_library_map(server, config)
 
+    # Resolve smart groups into concrete collection lists
+    smart_group_collections = _resolve_smart_groups(server, config)
+
     # DISABLED: Auto-cleanup was too aggressive and deleting user's collections
     # TODO: Redesign cleanup to only delete collections that HSH created (not native Plex collections)
     # cleanup_result = cleanup_deleted_integration_sources(server, config)
@@ -271,6 +292,7 @@ def run_rotation_once(
                 last_rotation_collections=last_rotation_collections,
                 pinned_names=pinned_names,
                 collection_library_map=collection_library_map,
+                smart_group_collections=smart_group_collections,
             )
 
         # Now sync only the selected collections
@@ -294,6 +316,7 @@ def run_rotation_once(
                 usage_map=usage_map,
                 last_rotation_collections=last_rotation_collections,
                 pinned_names=pinned_names,
+                smart_group_collections=smart_group_collections,
                 collection_library_map=collection_library_map,
             )
 
@@ -311,7 +334,7 @@ def run_rotation_once(
             for name in rotation_result.selected_collections
         }
     else:
-        collection_visibility = build_collection_visibility_map(config)
+        collection_visibility = build_collection_visibility_map(config, smart_group_collections)
 
     # Add pinned collection visibility (overrides group settings for pinned collections)
     from .db import get_pinned_visibility_map
@@ -325,6 +348,7 @@ def run_rotation_once(
         rotation_result.selected_collections,
         collection_visibility,
         dry_run=dry_run,  # controls whether Plex is actually changed
+        smart_group_collections=smart_group_collections,
     )
 
     rotation_id = record_rotation(
@@ -488,6 +512,9 @@ def apply_simulation(
     # Apply collections to Plex
     server = get_plex_server(config)
 
+    # Resolve smart groups for visibility mapping
+    smart_group_collections = _resolve_smart_groups(server, config)
+
     # Build visibility map (auto-rotate uses its own settings)
     if config.rotation.auto_rotate.enabled:
         auto_rotate = config.rotation.auto_rotate
@@ -501,7 +528,7 @@ def apply_simulation(
             for name in rotation_result.selected_collections
         }
     else:
-        collection_visibility = build_collection_visibility_map(config)
+        collection_visibility = build_collection_visibility_map(config, smart_group_collections)
 
     # Add pinned collection visibility (overrides group settings for pinned collections)
     from .db import get_pinned_visibility_map
@@ -514,6 +541,7 @@ def apply_simulation(
         rotation_result.selected_collections,
         collection_visibility,
         dry_run=False,
+        smart_group_collections=smart_group_collections,
     )
 
     # Record in db as a real rotation in history

--- a/homescreen_hero/core/smart_groups.py
+++ b/homescreen_hero/core/smart_groups.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .config.schema import AppConfig, SmartGroupRule
+from .integrations.plex_client import get_collection_labels, get_collection_item_count
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CollectionMetadata:
+    name: str
+    source: str        # "plex", "trakt", "letterboxd", "mdblist", "anilist", "mal"
+    library: str
+    labels: list = field(default_factory=list)
+    item_count: int = 0
+
+
+def build_collection_metadata(server, config: AppConfig) -> List[CollectionMetadata]:
+    # Build metadata for all known collections from Plex + integration sources.
+    # Third-party sources that also exist as Plex collections get their
+    # labels/item_count enriched from Plex but keep the original source tag.
+    metadata: List[CollectionMetadata] = []
+
+    # Collect third-party source names so we can attribute them correctly
+    third_party: dict[str, tuple[str, str]] = {}  # name -> (source, library)
+
+    if config.trakt and config.trakt.enabled and config.trakt.sources:
+        for src in config.trakt.sources:
+            third_party[src.name] = ("trakt", src.plex_library)
+
+    if config.letterboxd and config.letterboxd.sources:
+        for src in config.letterboxd.sources:
+            third_party[src.name] = ("letterboxd", src.plex_library)
+
+    if config.mdblist and config.mdblist.enabled and config.mdblist.sources:
+        for src in config.mdblist.sources:
+            third_party[src.name] = ("mdblist", src.plex_library)
+
+    if config.anilist and config.anilist.sources:
+        for src in config.anilist.sources:
+            third_party[src.name] = ("anilist", src.plex_library)
+
+    if config.mal and config.mal.enabled and config.mal.sources:
+        for src in config.mal.sources:
+            third_party[src.name] = ("mal", src.plex_library)
+
+    # Iterate Plex libraries and build metadata for each collection
+    seen_names: set = set()
+    for section in server.library.sections():
+        try:
+            for coll in section.collections():
+                name = coll.title
+                if name in seen_names:
+                    continue
+                seen_names.add(name)
+
+                # Determine source — third-party takes priority over "plex"
+                if name in third_party:
+                    source, _ = third_party[name]
+                else:
+                    source = "plex"
+
+                metadata.append(CollectionMetadata(
+                    name=name,
+                    source=source,
+                    library=section.title,
+                    labels=get_collection_labels(coll),
+                    item_count=get_collection_item_count(coll),
+                ))
+        except Exception:
+            logger.warning("Failed to fetch collections from library '%s'", section.title)
+            continue
+
+    # Add third-party sources that don't exist in Plex yet (not synced or sync failed)
+    for name, (source, library) in third_party.items():
+        if name not in seen_names:
+            metadata.append(CollectionMetadata(
+                name=name,
+                source=source,
+                library=library,
+                labels=[],
+                item_count=0,
+            ))
+
+    logger.debug("Built metadata for %d collections", len(metadata))
+    return metadata
+
+
+def _matches_rule(rule: SmartGroupRule, coll: CollectionMetadata) -> bool:
+    # Evaluate a single rule against one collection. Returns True if the collection matches.
+    f = rule.field
+    op = rule.operator
+    vals = rule.values
+
+    if f == "label":
+        coll_labels_lower = {l.lower() for l in coll.labels}
+        rule_labels_lower = {str(v).lower() for v in vals}
+        if op == "includes":
+            # Collection has at least one of the specified labels
+            return bool(coll_labels_lower & rule_labels_lower)
+        elif op == "excludes":
+            # Collection has none of the specified labels
+            return not bool(coll_labels_lower & rule_labels_lower)
+
+    elif f == "source":
+        rule_sources = {str(v).lower() for v in vals}
+        if op == "is":
+            return coll.source.lower() in rule_sources
+        elif op == "is_not":
+            return coll.source.lower() not in rule_sources
+
+    elif f == "library":
+        rule_libs = {str(v).lower() for v in vals}
+        if op == "is":
+            return coll.library.lower() in rule_libs
+        elif op == "is_not":
+            return coll.library.lower() not in rule_libs
+
+    elif f == "name":
+        coll_name_lower = coll.name.lower()
+        rule_strs = [str(v).lower() for v in vals]
+        if op == "contains":
+            # Collection name contains at least one of the specified strings
+            return any(s in coll_name_lower for s in rule_strs)
+        elif op == "not_contains":
+            # Collection name contains none of the specified strings
+            return not any(s in coll_name_lower for s in rule_strs)
+
+    elif f == "item_count":
+        threshold = int(vals[0]) if vals else 0
+        if op == "gte":
+            return coll.item_count >= threshold
+        elif op == "lte":
+            return coll.item_count <= threshold
+
+    # Unknown field/operator combo — shouldn't happen if schema validation passes
+    logger.warning("Unknown rule: field=%s, operator=%s", f, op)
+    return False
+
+
+def resolve_smart_rules(
+    rules: List[SmartGroupRule],
+    metadata: List[CollectionMetadata],
+) -> List[str]:
+    # Evaluate rules against all collections. Rules are ANDed together.
+    # Returns list of matching collection names.
+    if not rules:
+        return []
+
+    matching = []
+    for coll in metadata:
+        if all(_matches_rule(rule, coll) for rule in rules):
+            matching.append(coll.name)
+
+    logger.debug("Smart rules resolved to %d collections: %s", len(matching), matching)
+    return matching
+
+
+def get_available_filter_options(
+    server,
+    config: AppConfig,
+) -> dict:
+    # Return all available values for smart group rule builder dropdowns.
+    metadata = build_collection_metadata(server, config)
+
+    # Collect unique labels across all collections
+    all_labels: set = set()
+    for coll in metadata:
+        all_labels.update(coll.labels)
+
+    # Collect unique sources
+    all_sources: set = set()
+    for coll in metadata:
+        all_sources.add(coll.source)
+
+    # Collect unique libraries
+    all_libraries: set = set()
+    for coll in metadata:
+        all_libraries.add(coll.library)
+
+    return {
+        "labels": sorted(all_labels),
+        "sources": sorted(all_sources),
+        "libraries": sorted(all_libraries),
+    }

--- a/homescreen_hero/core/smart_groups.py
+++ b/homescreen_hero/core/smart_groups.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from .config.schema import AppConfig, SmartGroupRule
 from .integrations.plex_client import get_collection_labels, get_collection_item_count
+from .poster_proxy import build_collection_poster_url
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,7 @@ class CollectionMetadata:
     library: str
     labels: list = field(default_factory=list)
     item_count: int = 0
+    poster_url: Optional[str] = None
 
 
 def build_collection_metadata(server, config: AppConfig) -> List[CollectionMetadata]:
@@ -70,6 +72,7 @@ def build_collection_metadata(server, config: AppConfig) -> List[CollectionMetad
                     library=section.title,
                     labels=get_collection_labels(coll),
                     item_count=get_collection_item_count(coll),
+                    poster_url=build_collection_poster_url(server, coll),
                 ))
         except Exception:
             logger.warning("Failed to fetch collections from library '%s'", section.title)
@@ -142,18 +145,31 @@ def _matches_rule(rule: SmartGroupRule, coll: CollectionMetadata) -> bool:
     return False
 
 
+def _rule_has_values(rule: SmartGroupRule) -> bool:
+    # Only rules with meaningful values should affect matching.
+    # Empty/incomplete rules are ignored so smart previews can start from all collections.
+    if not rule.values:
+        return False
+
+    if rule.field == "item_count":
+        return True
+
+    return any(str(v).strip() for v in rule.values)
+
+
 def resolve_smart_rules(
     rules: List[SmartGroupRule],
     metadata: List[CollectionMetadata],
 ) -> List[str]:
     # Evaluate rules against all collections. Rules are ANDed together.
     # Returns list of matching collection names.
-    if not rules:
-        return []
+    active_rules = [rule for rule in rules if _rule_has_values(rule)]
+    if not active_rules:
+        return [coll.name for coll in metadata]
 
     matching = []
     for coll in metadata:
-        if all(_matches_rule(rule, coll) for rule in rules):
+        if all(_matches_rule(rule, coll) for rule in active_rules):
             matching.append(coll.name)
 
     logger.debug("Smart rules resolved to %d collections: %s", len(matching), matching)

--- a/homescreen_hero/web/routers/collections.py
+++ b/homescreen_hero/web/routers/collections.py
@@ -1,14 +1,12 @@
 from datetime import datetime
 from typing import List, Optional
-from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile, File, Form
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
 from pydantic import BaseModel
-import hashlib
 import logging
 import random
 import requests
 import tempfile
 import os
-from cachetools import TTLCache
 
 from homescreen_hero.core.config.loader import load_config
 from homescreen_hero.core.config.schema import HealthResponse
@@ -28,6 +26,12 @@ from homescreen_hero.core.integrations.plex_client import (
     get_plex_server,
     reorder_homescreen_collections,
     get_library_collections,
+)
+from homescreen_hero.core.poster_proxy import (
+    create_proxy_url,
+    serve_proxy_poster,
+    build_collection_poster_url,
+    invalidate_poster_caches,
 )
 
 
@@ -189,22 +193,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/collections")
 
-# TTL Cache for poster URLs: stores up to 1000 items, each expires after 1 hour (3600 seconds)
-poster_url_cache = TTLCache(maxsize=1000, ttl=3600)
-
-# TTL Cache for actual image content: stores up to 500 images, each expires after 1 hour
-# Each image can be ~200KB, so 500 images = ~100MB in memory
-poster_image_cache = TTLCache(maxsize=500, ttl=3600)
-
 # Cache version counter - increment this to invalidate client-side caches
 _cache_version = 0
-
-
-def _create_proxy_url(plex_url: str) -> str:
-    # Store a Plex URL in cache and return a proxied URL the frontend can use
-    cache_key = hashlib.md5(plex_url.encode()).hexdigest()
-    poster_url_cache[cache_key] = plex_url
-    return f"/api/collections/poster-proxy/{cache_key}"
 
 
 class CacheVersionResponse(BaseModel):
@@ -274,15 +264,7 @@ def get_active_collections(
                     promoted_recommended = getattr(hub, "promotedToRecommended", False)
 
                     if promoted_own or promoted_shared or promoted_recommended:
-                        poster_url = None
-                        if getattr(col, "thumb", None):
-                            try:
-                                full_thumb_url = server.url(col.thumb, includeToken=True)
-                                plex_url = server.transcodeImage(full_thumb_url, height=450, width=300, minSize=1)
-                            except Exception:
-                                plex_url = server.url(col.thumb, includeToken=True)
-                            poster_url = _create_proxy_url(plex_url)
-
+                        poster_url = build_collection_poster_url(server, col)
                         is_pinned = col.title in pinned_names
                         # Use Plex's actual order, fallback to 9999 for unknown
                         display_order = plex_order_map.get(col.title, 9999)
@@ -342,14 +324,7 @@ def get_all_collections(
     for section in server.library.sections():
         try:
             for col in section.collections():
-                poster_url = None
-                if getattr(col, "thumb", None):
-                    try:
-                        full_thumb_url = server.url(col.thumb, includeToken=True)
-                        plex_url = server.transcodeImage(full_thumb_url, height=450, width=300, minSize=1)
-                    except Exception:
-                        plex_url = server.url(col.thumb, includeToken=True)
-                    poster_url = _create_proxy_url(plex_url)
+                poster_url = build_collection_poster_url(server, col)
 
                 # Use metadata attribute for O(1) count instead of fetching all items
                 item_count = getattr(col, "childCount", 0)
@@ -423,7 +398,7 @@ async def get_group_posters(
         for item in sampled_items:
             if hasattr(item, 'thumb') and item.thumb:
                 plex_url = server.url(item.thumb, includeToken=True)
-                posters.append(_create_proxy_url(plex_url))
+                posters.append(create_proxy_url(plex_url))
 
         logger.info(f"Fetched {len(posters)} poster URLs for group collections: {collections_to_fetch}")
         return GroupPostersResponse(posters=posters)
@@ -435,56 +410,7 @@ async def get_group_posters(
 
 @router.get("/poster-proxy/{cache_key}")
 def proxy_poster(cache_key: str):
-    # Proxy endpoint to serve poster images from Plex, avoiding direct browser-to-Plex requests.
-    try:
-        cached_image = poster_image_cache.get(cache_key)
-        if cached_image:
-            logger.debug(f"Serving cached image for key: {cache_key}")
-            return Response(
-                content=cached_image['content'],
-                media_type=cached_image['media_type'],
-                headers={
-                    'Cache-Control': 'public, max-age=3600',  # Cache in browser for 1 hour
-                    'ETag': cache_key  # Allow browser to revalidate if needed
-                }
-            )
-
-        # Image not cached, get the URL from URL cache
-        poster_url = poster_url_cache.get(cache_key)
-        if not poster_url:
-            logger.warning(f"Poster URL not found in cache for key: {cache_key}")
-            raise HTTPException(status_code=404, detail="Poster not found or expired")
-
-        # Fetch the image from Plex
-        logger.debug(f"Fetching image from Plex for key: {cache_key}")
-        response = requests.get(poster_url, timeout=10, verify=False)
-        response.raise_for_status()
-
-        # Cache the image content
-        media_type = response.headers.get('content-type', 'image/jpeg')
-        poster_image_cache[cache_key] = {
-            'content': response.content,
-            'media_type': media_type
-        }
-
-        return Response(
-            content=response.content,
-            media_type=media_type,
-            headers={
-                'Cache-Control': 'public, max-age=3600',  # Cache in browser for 1 hour
-                'ETag': cache_key  # Allow browser to revalidate if needed
-            }
-        )
-
-    except HTTPException:
-        # Re-raise HTTP exceptions (like 404) without wrapping them
-        raise
-    except requests.RequestException as e:
-        logger.error(f"Failed to proxy poster {cache_key}: {e}")
-        raise HTTPException(status_code=502, detail="Failed to fetch poster from Plex")
-    except Exception as e:
-        logger.error(f"Unexpected error proxying poster {cache_key}: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error")
+    return serve_proxy_poster(cache_key)
 
 
 @router.get("/group-poster-proxy/{cache_key}", include_in_schema=False)
@@ -578,7 +504,7 @@ def get_collection_details(
         for item in items:
             thumb_url = None
             if hasattr(item, "thumb") and item.thumb:
-                thumb_url = _create_proxy_url(server.url(item.thumb, includeToken=True))
+                thumb_url = create_proxy_url(server.url(item.thumb, includeToken=True))
 
             collection_items.append(
                 CollectionItemOut(
@@ -600,7 +526,7 @@ def get_collection_details(
                 plex_url = server.transcodeImage(full_thumb_url, height=600, width=400, minSize=1)
             except Exception:
                 plex_url = server.url(collection.thumb, includeToken=True)
-            poster_url = _create_proxy_url(plex_url)
+            poster_url = create_proxy_url(plex_url)
 
         # Get additional metadata
         sort_title = getattr(collection, "titleSort", None)
@@ -686,7 +612,7 @@ def search_library_items(
         for idx, item in enumerate(items):
             thumb_url = None
             if hasattr(item, "thumb") and item.thumb:
-                thumb_url = _create_proxy_url(server.url(item.thumb, includeToken=True))
+                thumb_url = create_proxy_url(server.url(item.thumb, includeToken=True))
 
             # Log first few items to help debug
             if idx < 3:
@@ -1071,8 +997,7 @@ async def upload_collection_poster(
 
         # Invalidate caches to show the new poster
         invalidate_collections_cache()
-        poster_url_cache.clear()
-        poster_image_cache.clear()
+        invalidate_poster_caches()
 
         return {
             "success": True,
@@ -1158,8 +1083,7 @@ async def upload_item_poster(
                     logger.warning(f"Failed to clean up temporary file: {cleanup_error}")
 
         # Invalidate caches to show the new poster
-        poster_url_cache.clear()
-        poster_image_cache.clear()
+        invalidate_poster_caches()
 
         return {
             "success": True,

--- a/homescreen_hero/web/routers/config/groups.py
+++ b/homescreen_hero/web/routers/config/groups.py
@@ -28,6 +28,9 @@ from .schemas import (
     GroupValidationResult,
     CollectionSourcesResponse,
     GroupReorderRequest,
+    SmartGroupPreviewRequest,
+    SmartGroupPreviewResponse,
+    SmartFilterOptionsResponse,
 )
 
 router = APIRouter()
@@ -284,6 +287,44 @@ def list_group_sources(current_user: CurrentUser = Depends(require_admin)) -> Co
             mal=mal_sources,
         )
     except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ========================================================================
+# SMART GROUPS
+# ========================================================================
+
+@router.post("/groups/preview-smart", response_model=SmartGroupPreviewResponse)
+def preview_smart_group(
+    payload: SmartGroupPreviewRequest,
+    current_user: CurrentUser = Depends(require_admin),
+) -> SmartGroupPreviewResponse:
+    # Evaluate smart group rules and return matching collections (for live preview).
+    from homescreen_hero.core.smart_groups import build_collection_metadata, resolve_smart_rules
+
+    try:
+        config = load_config()
+        server = get_plex_server(config)
+        metadata = build_collection_metadata(server, config)
+        matching = resolve_smart_rules(payload.rules, metadata)
+        return SmartGroupPreviewResponse(collections=matching, count=len(matching))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/groups/smart-filter-options", response_model=SmartFilterOptionsResponse)
+def get_smart_filter_options(
+    current_user: CurrentUser = Depends(require_admin),
+) -> SmartFilterOptionsResponse:
+    # Return available values for smart group rule builder dropdowns.
+    from homescreen_hero.core.smart_groups import get_available_filter_options
+
+    try:
+        config = load_config()
+        server = get_plex_server(config)
+        options = get_available_filter_options(server, config)
+        return SmartFilterOptionsResponse(**options)
+    except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/homescreen_hero/web/routers/config/groups.py
+++ b/homescreen_hero/web/routers/config/groups.py
@@ -30,6 +30,7 @@ from .schemas import (
     GroupReorderRequest,
     SmartGroupPreviewRequest,
     SmartGroupPreviewResponse,
+    SmartGroupPreviewCollection,
     SmartFilterOptionsResponse,
 )
 
@@ -299,15 +300,25 @@ def preview_smart_group(
     payload: SmartGroupPreviewRequest,
     current_user: CurrentUser = Depends(require_admin),
 ) -> SmartGroupPreviewResponse:
-    # Evaluate smart group rules and return matching collections (for live preview).
+    # Evaluate smart group rules and return matching collections with poster URLs.
     from homescreen_hero.core.smart_groups import build_collection_metadata, resolve_smart_rules
 
     try:
         config = load_config()
         server = get_plex_server(config)
         metadata = build_collection_metadata(server, config)
-        matching = resolve_smart_rules(payload.rules, metadata)
-        return SmartGroupPreviewResponse(collections=matching, count=len(matching))
+        matching_names = resolve_smart_rules(payload.rules, metadata)
+
+        # Build name → metadata lookup for poster URLs
+        meta_by_name = {m.name: m for m in metadata}
+        collections = [
+            SmartGroupPreviewCollection(
+                name=name,
+                poster_url=meta_by_name[name].poster_url if name in meta_by_name else None,
+            )
+            for name in matching_names
+        ]
+        return SmartGroupPreviewResponse(collections=collections, count=len(collections))
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -436,8 +436,13 @@ class SmartGroupPreviewRequest(BaseModel):
     rules: List[SmartGroupRule]
 
 
+class SmartGroupPreviewCollection(BaseModel):
+    name: str
+    poster_url: Optional[str] = None
+
+
 class SmartGroupPreviewResponse(BaseModel):
-    collections: List[str]
+    collections: List[SmartGroupPreviewCollection]
     count: int
 
 

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -21,6 +21,7 @@ from homescreen_hero.core.config.schema import (
     TautulliSettings,
     SeerrSettings,
     CollectionGroupConfig,
+    SmartGroupRule,
     DisplaySettings,
 )
 
@@ -428,3 +429,20 @@ class AuthSettingsResponse(BaseModel):
 class AuthSettingsSaveRequest(BaseModel):
     method: Literal["password", "plex", "both"]
     auto_approve_users: bool
+
+
+# Smart group preview request — evaluate rules and return matching collections.
+class SmartGroupPreviewRequest(BaseModel):
+    rules: List[SmartGroupRule]
+
+
+class SmartGroupPreviewResponse(BaseModel):
+    collections: List[str]
+    count: int
+
+
+# Available values for smart group rule builder dropdowns.
+class SmartFilterOptionsResponse(BaseModel):
+    labels: List[str]
+    sources: List[str]
+    libraries: List[str]

--- a/homescreen_hero/web/routers/tools.py
+++ b/homescreen_hero/web/routers/tools.py
@@ -20,6 +20,7 @@ from homescreen_hero.core.integrations.plex_client import (
 )
 from homescreen_hero.core.integrations.tautulli_client import get_tautulli_client
 from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
+from homescreen_hero.core.poster_proxy import create_proxy_url
 
 
 logger = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ def get_recent_media(
             for item in items:
                 thumb_url = None
                 if hasattr(item, "thumb") and item.thumb:
-                    thumb_url = server.url(item.thumb, includeToken=True)
+                    thumb_url = create_proxy_url(server.url(item.thumb, includeToken=True))
 
                 added_at = getattr(item, "addedAt", None)
                 originally_available_at = getattr(item, "originallyAvailableAt", None)
@@ -277,7 +278,7 @@ def search_media(
             for item in items:
                 thumb_url = None
                 if hasattr(item, "thumb") and item.thumb:
-                    thumb_url = server.url(item.thumb, includeToken=True)
+                    thumb_url = create_proxy_url(server.url(item.thumb, includeToken=True))
 
                 # Get addedAt and originallyAvailableAt
                 added_at = getattr(item, "addedAt", None)
@@ -387,7 +388,7 @@ def search_shows(
             for show in shows:
                 thumb_url = None
                 if hasattr(show, "thumb") and show.thumb:
-                    thumb_url = server.url(show.thumb, includeToken=True)
+                    thumb_url = create_proxy_url(server.url(show.thumb, includeToken=True))
 
                 # Get episode counts
                 episodes = show.episodes()
@@ -646,7 +647,7 @@ def _get_unwatched_items(
         if is_unwatched:
             thumb_url = None
             if hasattr(item, "thumb") and item.thumb:
-                thumb_url = server.url(item.thumb, includeToken=True)
+                thumb_url = create_proxy_url(server.url(item.thumb, includeToken=True))
 
             added_at = getattr(item, "addedAt", None)
             added_at_str = added_at.strftime("%Y-%m-%d") if added_at else None

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -10,9 +10,17 @@ from homescreen_hero.web.app import create_app
 
 @pytest.fixture
 def client():
-    """Create a test client for the FastAPI app"""
-    app = create_app()
-    return TestClient(app)
+    """Create a test client for the FastAPI app with config mocked out"""
+    mock_config = Mock()
+    mock_config.logging.level = "INFO"
+    mock_config.tautulli = Mock(enabled=False)
+    mock_config.auth = Mock(enabled=False, method="password")
+
+    with patch('homescreen_hero.web.app.load_config', return_value=mock_config), \
+         patch('homescreen_hero.core.auth.load_config', return_value=mock_config), \
+         patch('homescreen_hero.web.routers.analytics.load_config', return_value=mock_config):
+        app = create_app()
+        yield TestClient(app)
 
 
 @pytest.fixture
@@ -206,7 +214,7 @@ class TestAnalyticsTautulliDisabled:
         response = client.get("/api/admin/analytics/graph/plays-by-hour")
 
         # Should return 200 with empty data or appropriate error, not crash
-        assert response.status_code in [200, 401, 403, 503]
+        assert response.status_code in [200, 400, 401, 403, 503]
 
     @patch('homescreen_hero.web.routers.analytics.get_tautulli_client')
     @patch('homescreen_hero.web.routers.analytics.load_config')
@@ -217,7 +225,7 @@ class TestAnalyticsTautulliDisabled:
 
         response = client.get("/api/admin/analytics/users/top")
 
-        assert response.status_code in [200, 401, 403, 503]
+        assert response.status_code in [200, 400, 401, 403, 503]
 
 
 class TestConcurrentEndpointsReturnProperFormat:
@@ -227,8 +235,8 @@ class TestConcurrentEndpointsReturnProperFormat:
         """Test concurrent by date returns proper format"""
         response = client.get("/api/admin/analytics/graph/concurrent-by-date?query_days=7")
 
-        # Should return 200 or auth error
-        assert response.status_code in [200, 401, 403]
+        # Should return 200 or auth/config error
+        assert response.status_code in [200, 400, 401, 403]
 
         if response.status_code == 200:
             data = response.json()
@@ -242,7 +250,7 @@ class TestConcurrentEndpointsReturnProperFormat:
         """Test concurrent by hour returns 24 hour entries"""
         response = client.get("/api/admin/analytics/graph/concurrent-by-hour")
 
-        assert response.status_code in [200, 401, 403]
+        assert response.status_code in [200, 400, 401, 403]
 
         if response.status_code == 200:
             data = response.json()

--- a/tests/test_smart_groups.py
+++ b/tests/test_smart_groups.py
@@ -271,9 +271,38 @@ class TestAndLogic:
 
 class TestEdgeCases:
 
-    def test_empty_rules_returns_empty(self, sample_metadata):
+    def test_empty_rules_returns_all_collections(self, sample_metadata):
         result = resolve_smart_rules([], sample_metadata)
-        assert result == []
+        assert result == [
+            "Horror Classics",
+            "Marvel Collection",
+            "Anime Favorites",
+            "Stand-up Specials",
+            "DC Universe",
+        ]
+
+    def test_empty_value_rules_are_ignored(self, sample_metadata):
+        rules = [
+            _rule("label", "includes", []),
+            _rule("name", "contains", [""]),
+            _rule("source", "is", []),
+        ]
+        result = resolve_smart_rules(rules, sample_metadata)
+        assert result == [
+            "Horror Classics",
+            "Marvel Collection",
+            "Anime Favorites",
+            "Stand-up Specials",
+            "DC Universe",
+        ]
+
+    def test_only_active_rules_are_applied(self, sample_metadata):
+        rules = [
+            _rule("label", "includes", []),
+            _rule("source", "is", ["trakt"]),
+        ]
+        result = resolve_smart_rules(rules, sample_metadata)
+        assert result == ["Marvel Collection"]
 
     def test_empty_metadata_returns_empty(self):
         rule = _rule("label", "includes", ["horror"])

--- a/tests/test_smart_groups.py
+++ b/tests/test_smart_groups.py
@@ -1,0 +1,339 @@
+import pytest
+from homescreen_hero.core.config.schema import SmartGroupRule
+from homescreen_hero.core.smart_groups import (
+    CollectionMetadata,
+    _matches_rule,
+    resolve_smart_rules,
+    get_available_filter_options,
+    build_collection_metadata,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture
+def sample_metadata():
+    return [
+        CollectionMetadata(
+            name="Horror Classics",
+            source="plex",
+            library="Movies",
+            labels=["horror", "classics"],
+            item_count=25,
+        ),
+        CollectionMetadata(
+            name="Marvel Collection",
+            source="trakt",
+            library="Movies",
+            labels=["superhero", "action"],
+            item_count=40,
+        ),
+        CollectionMetadata(
+            name="Anime Favorites",
+            source="anilist",
+            library="Anime",
+            labels=["anime"],
+            item_count=15,
+        ),
+        CollectionMetadata(
+            name="Stand-up Specials",
+            source="plex",
+            library="TV Shows",
+            labels=[],
+            item_count=8,
+        ),
+        CollectionMetadata(
+            name="DC Universe",
+            source="mdblist",
+            library="Movies",
+            labels=["superhero", "action", "dc"],
+            item_count=30,
+        ),
+    ]
+
+
+def _rule(field, operator, values):
+    return SmartGroupRule(field=field, operator=operator, values=values)
+
+
+# ── SmartGroupRule validation ─────────────────────────────────────────
+
+class TestSmartGroupRuleValidation:
+
+    def test_valid_rule(self):
+        r = SmartGroupRule(field="label", operator="includes", values=["horror"])
+        assert r.field == "label"
+        assert r.operator == "includes"
+
+    def test_invalid_operator_rejected(self):
+        with pytest.raises(ValueError, match="Invalid operator"):
+            SmartGroupRule(field="label", operator="is", values=["horror"])
+
+    def test_invalid_field_rejected(self):
+        with pytest.raises(ValueError):
+            SmartGroupRule(field="rating", operator="gte", values=[8])
+
+
+# ── Label rules ───────────────────────────────────────────────────────
+
+class TestLabelRules:
+
+    def test_label_includes_match(self, sample_metadata):
+        rule = _rule("label", "includes", ["horror"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Horror Classics"]
+
+    def test_label_includes_multiple_values_or(self, sample_metadata):
+        # Multiple values are ORed — match collections with "horror" OR "anime"
+        rule = _rule("label", "includes", ["horror", "anime"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Horror Classics", "Anime Favorites"}
+
+    def test_label_includes_no_match(self, sample_metadata):
+        rule = _rule("label", "includes", ["documentary"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == []
+
+    def test_label_excludes(self, sample_metadata):
+        rule = _rule("label", "excludes", ["superhero"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        # Excludes Marvel and DC, keeps the rest
+        assert "Marvel Collection" not in result
+        assert "DC Universe" not in result
+        assert "Horror Classics" in result
+
+    def test_label_includes_case_insensitive(self, sample_metadata):
+        rule = _rule("label", "includes", ["HORROR"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Horror Classics"]
+
+    def test_label_includes_empty_labels_collection(self, sample_metadata):
+        # Stand-up Specials has no labels — should not match any includes rule
+        rule = _rule("label", "includes", ["standup"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert "Stand-up Specials" not in result
+
+    def test_label_excludes_empty_labels_passes(self, sample_metadata):
+        # Stand-up Specials has no labels — should pass excludes
+        rule = _rule("label", "excludes", ["horror"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert "Stand-up Specials" in result
+
+
+# ── Source rules ──────────────────────────────────────────────────────
+
+class TestSourceRules:
+
+    def test_source_is(self, sample_metadata):
+        rule = _rule("source", "is", ["trakt"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Marvel Collection"]
+
+    def test_source_is_multiple(self, sample_metadata):
+        rule = _rule("source", "is", ["trakt", "mdblist"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Marvel Collection", "DC Universe"}
+
+    def test_source_is_not(self, sample_metadata):
+        rule = _rule("source", "is_not", ["plex"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert "Horror Classics" not in result
+        assert "Stand-up Specials" not in result
+        assert "Marvel Collection" in result
+
+    def test_source_is_case_insensitive(self, sample_metadata):
+        rule = _rule("source", "is", ["Trakt"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Marvel Collection"]
+
+
+# ── Library rules ─────────────────────────────────────────────────────
+
+class TestLibraryRules:
+
+    def test_library_is(self, sample_metadata):
+        rule = _rule("library", "is", ["Movies"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Horror Classics", "Marvel Collection", "DC Universe"}
+
+    def test_library_is_not(self, sample_metadata):
+        rule = _rule("library", "is_not", ["Movies"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Anime Favorites", "Stand-up Specials"}
+
+    def test_library_case_insensitive(self, sample_metadata):
+        rule = _rule("library", "is", ["movies"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Horror Classics", "Marvel Collection", "DC Universe"}
+
+
+# ── Name rules ────────────────────────────────────────────────────────
+
+class TestNameRules:
+
+    def test_name_contains(self, sample_metadata):
+        rule = _rule("name", "contains", ["Marvel"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Marvel Collection"]
+
+    def test_name_contains_multiple_values_or(self, sample_metadata):
+        rule = _rule("name", "contains", ["Marvel", "DC"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Marvel Collection", "DC Universe"}
+
+    def test_name_not_contains(self, sample_metadata):
+        rule = _rule("name", "not_contains", ["Marvel", "DC"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert "Marvel Collection" not in result
+        assert "DC Universe" not in result
+        assert "Horror Classics" in result
+
+    def test_name_contains_case_insensitive(self, sample_metadata):
+        rule = _rule("name", "contains", ["marvel"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Marvel Collection"]
+
+    def test_name_contains_partial_match(self, sample_metadata):
+        rule = _rule("name", "contains", ["Classic"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Horror Classics"]
+
+
+# ── Item count rules ──────────────────────────────────────────────────
+
+class TestItemCountRules:
+
+    def test_item_count_gte(self, sample_metadata):
+        rule = _rule("item_count", "gte", [30])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Marvel Collection", "DC Universe"}
+
+    def test_item_count_lte(self, sample_metadata):
+        rule = _rule("item_count", "lte", [15])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert set(result) == {"Anime Favorites", "Stand-up Specials"}
+
+    def test_item_count_exact_boundary(self, sample_metadata):
+        rule = _rule("item_count", "gte", [25])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert "Horror Classics" in result  # exactly 25
+        assert "Anime Favorites" not in result  # 15
+
+    def test_item_count_zero(self, sample_metadata):
+        rule = _rule("item_count", "gte", [0])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert len(result) == 5  # everything matches
+
+
+# ── AND logic (multiple rules) ────────────────────────────────────────
+
+class TestAndLogic:
+
+    def test_two_rules_anded(self, sample_metadata):
+        # label includes superhero AND library is Movies
+        rules = [
+            _rule("label", "includes", ["superhero"]),
+            _rule("library", "is", ["Movies"]),
+        ]
+        result = resolve_smart_rules(rules, sample_metadata)
+        assert set(result) == {"Marvel Collection", "DC Universe"}
+
+    def test_and_narrows_results(self, sample_metadata):
+        # label includes superhero AND source is trakt
+        rules = [
+            _rule("label", "includes", ["superhero"]),
+            _rule("source", "is", ["trakt"]),
+        ]
+        result = resolve_smart_rules(rules, sample_metadata)
+        assert result == ["Marvel Collection"]
+
+    def test_and_no_overlap(self, sample_metadata):
+        # source is plex AND library is Anime — no collection matches both
+        rules = [
+            _rule("source", "is", ["plex"]),
+            _rule("library", "is", ["Anime"]),
+        ]
+        result = resolve_smart_rules(rules, sample_metadata)
+        assert result == []
+
+    def test_three_rules(self, sample_metadata):
+        # library Movies AND label superhero AND item_count >= 35
+        rules = [
+            _rule("library", "is", ["Movies"]),
+            _rule("label", "includes", ["superhero"]),
+            _rule("item_count", "gte", [35]),
+        ]
+        result = resolve_smart_rules(rules, sample_metadata)
+        assert result == ["Marvel Collection"]  # 40 items, DC has 30
+
+
+# ── Edge cases ────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+
+    def test_empty_rules_returns_empty(self, sample_metadata):
+        result = resolve_smart_rules([], sample_metadata)
+        assert result == []
+
+    def test_empty_metadata_returns_empty(self):
+        rule = _rule("label", "includes", ["horror"])
+        result = resolve_smart_rules([rule], [])
+        assert result == []
+
+    def test_single_collection_match(self):
+        metadata = [
+            CollectionMetadata(name="Test", source="plex", library="Movies", labels=["test"], item_count=5),
+        ]
+        rule = _rule("label", "includes", ["test"])
+        result = resolve_smart_rules([rule], metadata)
+        assert result == ["Test"]
+
+    def test_result_preserves_order(self, sample_metadata):
+        # Results should come back in the same order as the metadata
+        rule = _rule("library", "is", ["Movies"])
+        result = resolve_smart_rules([rule], sample_metadata)
+        assert result == ["Horror Classics", "Marvel Collection", "DC Universe"]
+
+
+# ── get_available_filter_options ──────────────────────────────────────
+
+class TestGetAvailableFilterOptions:
+
+    def test_collects_unique_labels(self):
+        # Mock server that returns no sections (filter options come from metadata)
+        class MockSection:
+            def __init__(self, title, collections):
+                self.title = title
+                self._collections = collections
+            def collections(self):
+                return self._collections
+
+        class MockCollection:
+            def __init__(self, title, labels=None, childCount=0):
+                self.title = title
+                self.labels = [type("Label", (), {"tag": l})() for l in (labels or [])]
+                self.childCount = childCount
+
+        class MockLibrary:
+            def sections(self):
+                return [
+                    MockSection("Movies", [
+                        MockCollection("Coll A", labels=["horror", "action"]),
+                        MockCollection("Coll B", labels=["action", "comedy"]),
+                    ]),
+                ]
+
+        class MockServer:
+            library = MockLibrary()
+
+        class MockConfig:
+            trakt = None
+            letterboxd = None
+            mdblist = None
+            anilist = None
+            mal = None
+
+        options = get_available_filter_options(MockServer(), MockConfig())
+        assert sorted(options["labels"]) == ["action", "comedy", "horror"]
+        assert "plex" in options["sources"]
+        assert "Movies" in options["libraries"]


### PR DESCRIPTION
## Feature: Smart Groups

### Summary
Introducing **Smart Groups**! Create dynamic collection groups that auto-populate based on collection metadata rules instead of manually picking collections one by one. As collections get added, removed, or edited, smart groups automatically stay up to date with no manual intervention needed. Includes a full builder UI with live preview so you can see what collections match your rules before saving.

### Major Changes
- **Smart Group Builder** page with an interactive rule editor- add/remove filter rules, combine with AND/OR logic, and see matching collections update in real time
- Live preview panel that shows which collections match your current rules, complete with poster thumbnails and collection counts
- Backend support for smart groups: new DB models, CRUD endpoints, and rule evaluation engine that filters collections based on configurable criteria

### Minor Changes
- Updated various tools (Watch History Cleaner, Date Added Editor, Unwatched Report) on the `ToolsPage` to use the update poster-proxy