### PR TITLE
Feature: Smart Groups Sort Title Filter & Preview Grid Update

### DIFF
--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -37,7 +37,7 @@ import { ConfirmDialog } from "../components/ui/confirm-dialog";
 type DateRange = { start: string; end: string };
 
 type SmartGroupRule = {
-    field: "label" | "source" | "library" | "name" | "item_count";
+    field: "label" | "source" | "library" | "name" | "sort_title" | "item_count";
     operator: string;
     values: (string | number)[];
 };
@@ -82,6 +82,7 @@ const FIELD_OPTIONS: { value: SmartGroupRule["field"]; label: string }[] = [
     { value: "source", label: "Source" },
     { value: "library", label: "Library" },
     { value: "name", label: "Name" },
+    { value: "sort_title", label: "Sort Title" },
     { value: "item_count", label: "Item Count" },
 ];
 
@@ -99,6 +100,10 @@ const OPERATORS_BY_FIELD: Record<string, { value: string; label: string }[]> = {
         { value: "is_not", label: "is not" },
     ],
     name: [
+        { value: "contains", label: "contains" },
+        { value: "not_contains", label: "does not contain" },
+    ],
+    sort_title: [
         { value: "contains", label: "contains" },
         { value: "not_contains", label: "does not contain" },
     ],
@@ -409,9 +414,9 @@ export default function SmartGroupDetailPage() {
 
     const hasRuleValues = form.rules.some((r) => r.values.length > 0);
     const previewCollections = preview?.collections ?? [];
-    const PREVIEW_LIMIT = 8;
+    const PREVIEW_LIMIT = 15;
     const hasOverflow = previewCollections.length > PREVIEW_LIMIT;
-    // When collapsed with overflow, show 7 posters + the "+N" tile to fill the grid
+    // When collapsed with overflow, show 14 posters + the "+N" tile to fill the grid
     const visiblePreviewCollections = previewExpanded
         ? previewCollections
         : hasOverflow
@@ -595,7 +600,7 @@ export default function SmartGroupDetailPage() {
                                         />
                                         <span className="text-xs text-slate-400">items</span>
                                     </div>
-                                ) : rule.field === "name" ? (
+                                ) : rule.field === "name" || rule.field === "sort_title" ? (
                                     <div className="space-y-2 rounded-xl border border-blue-400/15 bg-[#0d1a31] px-3 pb-3 pt-2">
                                         {(rule.values as string[]).length > 0 && (
                                             <div className="flex flex-wrap gap-2.5">
@@ -743,8 +748,8 @@ export default function SmartGroupDetailPage() {
                     </div>
 
                     {!preview ? (
-                        <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
-                            {Array.from({ length: 8 }).map((_, idx) => (
+                        <div className="grid grid-cols-3 gap-2.5 sm:grid-cols-5">
+                            {Array.from({ length: 15 }).map((_, idx) => (
                                 <div key={idx} className="relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950 aspect-[2/3]">
                                     <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-800 via-slate-700/70 to-slate-800" />
                                 </div>
@@ -757,7 +762,7 @@ export default function SmartGroupDetailPage() {
                             </p>
                         </div>
                     ) : (
-                        <div className={`grid grid-cols-2 gap-2.5 sm:grid-cols-4 transition-opacity duration-300 ${previewLoading ? "opacity-40" : "opacity-100"}`}>
+                        <div className={`grid grid-cols-3 gap-2.5 sm:grid-cols-5 transition-opacity duration-300 ${previewLoading ? "opacity-40" : "opacity-100"}`}>
                             {visiblePreviewCollections.map((col, idx) => {
                                 const posterLoaded = !col.poster_url || loadedPreviewPosters[col.name];
                                 return (

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -98,7 +98,7 @@ class RotationSettings(BaseModel):
 class SmartGroupRule(BaseModel):
     # A single filter rule for smart groups.
     # Rules within a group are ANDed; multiple values within a rule are ORed.
-    field: Literal["label", "source", "library", "name", "item_count"] = Field(
+    field: Literal["label", "source", "library", "name", "sort_title", "item_count"] = Field(
         ..., description="Which collection attribute to filter on"
     )
     operator: str = Field(
@@ -120,6 +120,7 @@ class SmartGroupRule(BaseModel):
         "source": {"is", "is_not"},
         "library": {"is", "is_not"},
         "name": {"contains", "not_contains"},
+        "sort_title": {"contains", "not_contains"},
         "item_count": {"gte", "lte"},
     }
 

--- a/homescreen_hero/core/smart_groups.py
+++ b/homescreen_hero/core/smart_groups.py
@@ -18,6 +18,7 @@ class CollectionMetadata:
     library: str
     labels: list = field(default_factory=list)
     item_count: int = 0
+    sort_title: str = ""
     poster_url: Optional[str] = None
 
 
@@ -72,6 +73,7 @@ def build_collection_metadata(server, config: AppConfig) -> List[CollectionMetad
                     library=section.title,
                     labels=get_collection_labels(coll),
                     item_count=get_collection_item_count(coll),
+                    sort_title=getattr(coll, "titleSort", "") or "",
                     poster_url=build_collection_poster_url(server, coll),
                 ))
         except Exception:
@@ -132,6 +134,14 @@ def _matches_rule(rule: SmartGroupRule, coll: CollectionMetadata) -> bool:
         elif op == "not_contains":
             # Collection name contains none of the specified strings
             return not any(s in coll_name_lower for s in rule_strs)
+
+    elif f == "sort_title":
+        sort_title_lower = coll.sort_title.lower()
+        rule_strs = [str(v).lower() for v in vals]
+        if op == "contains":
+            return any(s in sort_title_lower for s in rule_strs)
+        elif op == "not_contains":
+            return not any(s in sort_title_lower for s in rule_strs)
 
     elif f == "item_count":
         threshold = int(vals[0]) if vals else 0


### PR DESCRIPTION
### Summary
Adds sort title as a new filter option for smart groups, letting users filter collections by their Plex sort title. This is particularly useful for Kometa users who use sort title prefixes to organize collections. Also bumps the live preview grid from 4x2 to 5x3.

### Major Changes
- Added "Sort Title" as a smart group filter field with `contains` / `does not contain` operators — works the same way as the existing Name filter with free-text tag input
- Expanded the smart group live preview grid from 4 columns / 8 posters to 5 columns / 15 posters

### Minor Changes
- Added `sort_title` to `CollectionMetadata` dataclass, populated from Plex's `titleSort` attribute
- Small screen preview grid now falls back to 3 columns instead of 2