### PR TITLE
Feature: Per-group collection ordering and sort settings

### DIFF
--- a/homescreen-hero-ui/package-lock.json
+++ b/homescreen-hero-ui/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.8",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@types/react-datepicker": "^6.2.0",
         "class-variance-authority": "^0.7.1",
@@ -1768,6 +1769,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1873,6 +1880,50 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1947,6 +1998,21 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2264,6 +2330,39 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/homescreen-hero-ui/package.json
+++ b/homescreen-hero-ui/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@types/react-datepicker": "^6.2.0",
     "class-variance-authority": "^0.7.1",

--- a/homescreen-hero-ui/src/components/ui/info-tooltip.tsx
+++ b/homescreen-hero-ui/src/components/ui/info-tooltip.tsx
@@ -9,8 +9,8 @@ export function InfoTooltip({ text }: { text: string }) {
                     <Info className="h-3.5 w-3.5" />
                 </button>
             </PopoverTrigger>
-            <PopoverContent side="top" className="w-auto max-w-56 px-3 py-2">
-                <p className="text-xs text-slate-300">{text}</p>
+            <PopoverContent side="top" className="w-auto max-w-56 border-slate-600 bg-slate-800 px-3 py-2">
+                <p className="text-xs text-slate-200">{text}</p>
             </PopoverContent>
         </Popover>
     );

--- a/homescreen-hero-ui/src/components/ui/info-tooltip.tsx
+++ b/homescreen-hero-ui/src/components/ui/info-tooltip.tsx
@@ -1,0 +1,17 @@
+import { Info } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "./popover";
+
+export function InfoTooltip({ text }: { text: string }) {
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <button type="button" className="text-slate-500 hover:text-slate-300 transition-colors">
+                    <Info className="h-3.5 w-3.5" />
+                </button>
+            </PopoverTrigger>
+            <PopoverContent side="top" className="w-auto max-w-56 px-3 py-2">
+                <p className="text-xs text-slate-300">{text}</p>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/homescreen-hero-ui/src/components/ui/slider.tsx
+++ b/homescreen-hero-ui/src/components/ui/slider.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+import { cn } from "@/lib/utils";
+
+const Slider = React.forwardRef<
+    React.ElementRef<typeof SliderPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+    <SliderPrimitive.Root
+        ref={ref}
+        className={cn(
+            "relative flex w-full touch-none select-none items-center",
+            className
+        )}
+        {...props}
+    >
+        <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-slate-800">
+            <SliderPrimitive.Range className="absolute h-full bg-primary" />
+        </SliderPrimitive.Track>
+        {(props.defaultValue ?? props.value ?? [0]).map((_, i) => (
+            <SliderPrimitive.Thumb
+                key={i}
+                className="block h-4 w-4 rounded-full border-2 border-primary bg-slate-950 ring-offset-slate-950 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-primary/20"
+            />
+        ))}
+    </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchWithAuth } from "../utils/api";
 import { useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, ArrowUpDown, Check, ChevronDown, Compass, Eye, Home, Loader2, Minus, Plus, RefreshCcw, Search, Share2, SlidersHorizontal, Trash2 } from "lucide-react";
+import { InfoTooltip } from "../components/ui/info-tooltip";
 import { Listbox } from "@headlessui/react";
 import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import {
@@ -33,6 +34,8 @@ type CollectionGroup = {
     visibility_home: boolean;
     visibility_shared: boolean;
     visibility_recommended: boolean;
+    collection_selection?: "random" | "lru";
+    collection_order?: "random" | "alpha" | null;
     collection_sort?: "release" | "alpha" | null;
     date_range?: DateRange | null;
     collections: string[];
@@ -65,6 +68,8 @@ const emptyGroup: CollectionGroup = {
     visibility_home: true,
     visibility_shared: false,
     visibility_recommended: false,
+    collection_selection: "random",
+    collection_order: null,
     collection_sort: null,
     date_range: null,
     collections: [],
@@ -114,11 +119,11 @@ export default function GroupDetailPage() {
 
         if (!Number.isNaN(parsedIndex) && groups[parsedIndex]) {
             setSelectedIndex(parsedIndex);
-            setForm(groups[parsedIndex]);
+            setForm({ ...groups[parsedIndex] });
             savedFormRef.current = JSON.stringify(groups[parsedIndex]);
         } else if (groups.length) {
             setSelectedIndex(0);
-            setForm(groups[0]);
+            setForm({ ...groups[0] });
             savedFormRef.current = JSON.stringify(groups[0]);
         } else {
             setSelectedIndex("new");
@@ -839,35 +844,104 @@ export default function GroupDetailPage() {
 
                         <hr className="border-slate-700/50" />
 
-                        {/* Collection Sort */}
-                        <div className="space-y-3">
+                        {/* Collection Settings */}
+                        <div className="space-y-4">
                             <div className="flex items-center gap-2">
                                 <ArrowUpDown className="h-4 w-4 text-primary" />
-                                <label className="text-base font-medium text-white">Collection Sort</label>
+                                <label className="text-base font-medium text-white">Collection Settings</label>
                             </div>
-                            <p className="text-xs text-slate-400">Sort order for items within a collection when gets selected.</p>
-                            <div className="grid grid-cols-3 gap-2">
-                                {([
-                                    { value: null, label: "Default" },
-                                    { value: "release" as const, label: "Release" },
-                                    { value: "alpha" as const, label: "Alpha" },
-                                ]).map(({ value, label }) => {
-                                    const isSelected = form.collection_sort === value;
-                                    return (
-                                        <button
-                                            key={label}
-                                            type="button"
-                                            onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
-                                            className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 transition-all duration-200 ${
-                                                isSelected
-                                                    ? "border-primary bg-primary/15"
-                                                    : "border-slate-700 bg-slate-900 hover:border-slate-600"
-                                            }`}
-                                        >
-                                            <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>{label}</span>
-                                        </button>
-                                    );
-                                })}
+
+                            <div className="space-y-3">
+                                {/* Selection */}
+                                <div className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-sm text-slate-300">Selection</span>
+                                        <InfoTooltip text="How collections are picked from this group during rotation." />
+                                    </div>
+                                    <div className="flex gap-1.5">
+                                        {([
+                                            { value: "random" as const, label: "Random" },
+                                            { value: "lru" as const, label: "LRU" },
+                                        ]).map(({ value, label }) => {
+                                            const isSelected = form.collection_selection === value;
+                                            return (
+                                                <button
+                                                    key={label}
+                                                    type="button"
+                                                    onClick={() => setForm((p) => ({ ...p, collection_selection: value }))}
+                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                        isSelected
+                                                            ? "border-primary bg-primary/15 text-white"
+                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                    }`}
+                                                >
+                                                    {label}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+
+                                {/* Order */}
+                                <div className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-sm text-slate-300">Order</span>
+                                        <InfoTooltip text="Display order of picked collections on the homescreen within this group." />
+                                    </div>
+                                    <div className="flex gap-1.5">
+                                        {([
+                                            { value: null, label: "Random" },
+                                            { value: "alpha" as const, label: "Alpha" },
+                                        ]).map(({ value, label }) => {
+                                            const isSelected = form.collection_order === value;
+                                            return (
+                                                <button
+                                                    key={label}
+                                                    type="button"
+                                                    onClick={() => setForm((p) => ({ ...p, collection_order: value }))}
+                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                        isSelected
+                                                            ? "border-primary bg-primary/15 text-white"
+                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                    }`}
+                                                >
+                                                    {label}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+
+                                {/* Sort */}
+                                <div className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-sm text-slate-300">Sort</span>
+                                        <InfoTooltip text="Sort order for items within a collection when it gets selected." />
+                                    </div>
+                                    <div className="flex gap-1.5">
+                                        {([
+                                            { value: null, label: "Default" },
+                                            { value: "release" as const, label: "Release" },
+                                            { value: "alpha" as const, label: "Alpha" },
+                                        ]).map(({ value, label }) => {
+                                            const isSelected = form.collection_sort === value;
+                                            return (
+                                                <button
+                                                    key={label}
+                                                    type="button"
+                                                    onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
+                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                        isSelected
+                                                            ? "border-primary bg-primary/15 text-white"
+                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                    }`}
+                                                >
+                                                    {label}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </SheetBody>

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchWithAuth } from "../utils/api";
 import { useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, CalendarRange, Check, ChevronDown, Compass, Home, Lightbulb, Loader2, Minus, Plus, RefreshCcw, Search, Share2, SlidersHorizontal, Trash2 } from "lucide-react";
+import { ArrowLeft, ArrowUpDown, Check, ChevronDown, Compass, Home, Loader2, Minus, Plus, RefreshCcw, Search, Share2, SlidersHorizontal, Trash2 } from "lucide-react";
 import { Listbox } from "@headlessui/react";
 import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import {
@@ -13,6 +13,7 @@ import {
     SheetBody,
     SheetCloseButton,
 } from "../components/ui/sheet";
+import { Slider } from "../components/ui/slider";
 import { getGroupStatus } from "../utils/dates";
 
 
@@ -32,6 +33,7 @@ type CollectionGroup = {
     visibility_home: boolean;
     visibility_shared: boolean;
     visibility_recommended: boolean;
+    collection_sort?: "release" | "alpha" | null;
     date_range?: DateRange | null;
     collections: string[];
 };
@@ -63,6 +65,7 @@ const emptyGroup: CollectionGroup = {
     visibility_home: true,
     visibility_shared: false,
     visibility_recommended: false,
+    collection_sort: null,
     date_range: null,
     collections: [],
 };
@@ -223,13 +226,6 @@ export default function GroupDetailPage() {
         }
         const num = Number(value);
         setForm((prev) => ({ ...prev, [key]: Number.isNaN(num) ? 0 : num } as CollectionGroup));
-    };
-
-    const handleNumberBlur = (key: keyof CollectionGroup) => {
-        const val = form[key];
-        if (val === "" || val === undefined || val === null) {
-            setForm((prev) => ({ ...prev, [key]: 0 } as CollectionGroup));
-        }
     };
 
     const handleDateChange = (key: keyof DateRange, value: string) => {
@@ -735,69 +731,53 @@ export default function GroupDetailPage() {
                         <SheetCloseButton />
                     </SheetHeader>
                     <SheetBody>
-                        {/* Pick Limits */}
-                        <div className="space-y-3">
-                            <label className="text-sm font-medium text-white">Pick Limits</label>
-                            <p className="text-xs text-slate-400">Min and max collections to include per rotation.</p>
-                            <div className="grid grid-cols-2 gap-3">
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Min picks</label>
-                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                        <button type="button" disabled={Number(form.min_picks) <= 0} onClick={() => handleNumberChange("min_picks", String(Math.max(0, Number(form.min_picks) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                                            <Minus className="h-4 w-4" />
-                                        </button>
-                                        <input type="number" min={0} value={form.min_picks} onChange={(e) => handleNumberChange("min_picks", e.target.value)} onBlur={() => handleNumberBlur("min_picks")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
-                                        <button type="button" onClick={() => handleNumberChange("min_picks", String(Number(form.min_picks) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
-                                            <Plus className="h-4 w-4" />
-                                        </button>
-                                    </div>
+                        {/* Rotation Rules */}
+                        <div className="space-y-4">
+                            <label className="text-sm font-medium text-white">Rotation Rules</label>
+
+                            {/* Pick range slider */}
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <label className="text-xs text-slate-400">Collections to select</label>
+                                    <span className="text-xs font-medium text-slate-300 tabular-nums">
+                                        Min: {form.min_picks} / Max: {form.max_picks}
+                                    </span>
                                 </div>
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Max picks</label>
-                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                        <button type="button" disabled={Number(form.max_picks) <= 0} onClick={() => handleNumberChange("max_picks", String(Math.max(0, Number(form.max_picks) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                                            <Minus className="h-4 w-4" />
-                                        </button>
-                                        <input type="number" min={0} value={form.max_picks} onChange={(e) => handleNumberChange("max_picks", e.target.value)} onBlur={() => handleNumberBlur("max_picks")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
-                                        <button type="button" onClick={() => handleNumberChange("max_picks", String(Number(form.max_picks) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
-                                            <Plus className="h-4 w-4" />
-                                        </button>
-                                    </div>
+                                <Slider
+                                    min={0}
+                                    max={10}
+                                    step={1}
+                                    value={[Number(form.min_picks), Number(form.max_picks)]}
+                                    onValueChange={([min, max]) => {
+                                        setForm((p) => ({ ...p, min_picks: min, max_picks: max }));
+                                    }}
+                                />
+                                <div className="flex justify-between text-[10px] text-slate-600">
+                                    <span>0</span>
+                                    <span>5</span>
+                                    <span>10</span>
                                 </div>
                             </div>
-                        </div>
 
-                        <hr className="border-slate-700/50" />
-
-                        {/* Priority & Spacing */}
-                        <div className="space-y-3">
-                            <label className="text-sm font-medium text-white">Priority & Spacing</label>
-                            <p className="text-xs text-slate-400">Higher weights are picked more often. Min gap prevents repeats.</p>
-                            <div className="grid grid-cols-2 gap-3">
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Weight</label>
-                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                        <button type="button" disabled={Number(form.weight) <= 1} onClick={() => handleNumberChange("weight", String(Math.max(1, Number(form.weight) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                                            <Minus className="h-4 w-4" />
-                                        </button>
-                                        <input type="number" min={1} value={form.weight} onChange={(e) => handleNumberChange("weight", e.target.value)} onBlur={() => handleNumberBlur("weight")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
-                                        <button type="button" onClick={() => handleNumberChange("weight", String(Number(form.weight) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
-                                            <Plus className="h-4 w-4" />
-                                        </button>
+                            {/* Weight & Min gap */}
+                            <div className="flex items-end justify-between">
+                                {([
+                                    { key: "weight" as const, label: "Weight", min: 1 },
+                                    { key: "min_gap_rotations" as const, label: "Min gap", min: 0 },
+                                ]).map(({ key, label, min }) => (
+                                    <div key={key} className="flex items-center gap-2">
+                                        <label className="text-xs text-slate-400 whitespace-nowrap">{label}</label>
+                                        <div className="flex items-center rounded-md border border-slate-700 bg-slate-900 overflow-hidden">
+                                            <button type="button" disabled={Number(form[key]) <= min} onClick={() => handleNumberChange(key, String(Math.max(min, Number(form[key]) - 1)))} className="flex items-center justify-center h-7 w-7 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                                                <Minus className="h-3 w-3" />
+                                            </button>
+                                            <span className="w-6 text-center text-xs font-semibold text-white tabular-nums">{form[key]}</span>
+                                            <button type="button" onClick={() => handleNumberChange(key, String(Number(form[key]) + 1))} className="flex items-center justify-center h-7 w-7 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
+                                                <Plus className="h-3 w-3" />
+                                            </button>
+                                        </div>
                                     </div>
-                                </div>
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Min gap (rotations)</label>
-                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                        <button type="button" disabled={Number(form.min_gap_rotations) <= 0} onClick={() => handleNumberChange("min_gap_rotations", String(Math.max(0, Number(form.min_gap_rotations) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                                            <Minus className="h-4 w-4" />
-                                        </button>
-                                        <input type="number" min={0} value={form.min_gap_rotations} onChange={(e) => handleNumberChange("min_gap_rotations", e.target.value)} onBlur={() => handleNumberBlur("min_gap_rotations")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
-                                        <button type="button" onClick={() => handleNumberChange("min_gap_rotations", String(Number(form.min_gap_rotations) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
-                                            <Plus className="h-4 w-4" />
-                                        </button>
-                                    </div>
-                                </div>
+                                ))}
                             </div>
                         </div>
 
@@ -807,11 +787,11 @@ export default function GroupDetailPage() {
                         <div className="space-y-3">
                             <label className="text-sm font-medium text-white">Visibility</label>
                             <p className="text-xs text-slate-400">Control where collections from this group appear on Plex.</p>
-                            <div className="grid gap-2">
+                            <div className="grid grid-cols-3 gap-2">
                                 {([
                                     { key: "visibility_home" as const, label: "Home", icon: Home },
                                     { key: "visibility_shared" as const, label: "Shared", icon: Share2 },
-                                    { key: "visibility_recommended" as const, label: "Recommended", icon: Compass },
+                                    { key: "visibility_recommended" as const, label: "Library", icon: Compass },
                                 ]).map(({ key, label, icon: Icon }) => {
                                     const isSelected = form[key];
                                     return (
@@ -819,75 +799,69 @@ export default function GroupDetailPage() {
                                             key={key}
                                             type="button"
                                             onClick={() => setForm((p) => ({ ...p, [key]: !p[key] }))}
-                                            className={`flex items-center justify-center gap-2 rounded-lg border px-4 py-2.5 transition-all duration-200 ${
+                                            className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 transition-all duration-200 ${
                                                 isSelected
                                                     ? "border-primary bg-primary/15"
                                                     : "border-slate-700 bg-slate-900 hover:border-slate-600"
                                             }`}
                                         >
-                                            <Icon className={`h-4 w-4 shrink-0 ${isSelected ? "text-primary" : "text-slate-500"}`} />
+                                            <Icon className={`h-3.5 w-3.5 shrink-0 ${isSelected ? "text-primary" : "text-slate-500"}`} />
                                             <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>{label}</span>
-                                            <div className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all duration-200 ml-auto ${
-                                                isSelected
-                                                    ? "border-primary bg-primary"
-                                                    : "border-slate-600 bg-transparent"
-                                            }`} />
                                         </button>
                                     );
                                 })}
                             </div>
-                            {(() => {
-                                const active = [
-                                    form.visibility_home && "your homescreen",
-                                    form.visibility_shared && "shared users' homescreens",
-                                    form.visibility_recommended && "the Library Recommended section",
-                                ].filter(Boolean) as string[];
-                                const joined = active.length <= 2
-                                    ? active.join(" and ")
-                                    : `${active.slice(0, -1).join(", ")}, and ${active[active.length - 1]}`;
-                                return (
-                                    <div className="flex items-center gap-2.5 rounded-lg bg-primary/10 border border-primary/20 px-3 py-2.5">
-                                        <Lightbulb className="h-4 w-4 text-slate-300 shrink-0" strokeWidth={1.5} />
-                                        <p className="text-xs text-blue-200">
-                                            {active.length === 0
-                                                ? "No visibility options selected. Collections in this group won't appear on any homescreen."
-                                                : `Collections will appear on ${joined}.`}
-                                        </p>
-                                    </div>
-                                );
-                            })()}
+                            <div className="flex items-center gap-2 pt-1">
+                                <label className="text-xs text-slate-400 whitespace-nowrap">Active <span className="text-slate-600">(optional)</span></label>
+                                <input
+                                    type="text"
+                                    value={form.date_range?.start ?? ""}
+                                    onChange={(e) => handleDateChange("start", e.target.value)}
+                                    placeholder="MM-DD"
+                                    className="w-20 px-2 py-1.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-center text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                                />
+                                <span className="text-xs text-slate-500">–</span>
+                                <input
+                                    type="text"
+                                    value={form.date_range?.end ?? ""}
+                                    onChange={(e) => handleDateChange("end", e.target.value)}
+                                    placeholder="MM-DD"
+                                    className="w-20 px-2 py-1.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-center text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                                />
+                            </div>
                         </div>
 
                         <hr className="border-slate-700/50" />
 
-                        {/* Date Range */}
+                        {/* Collection Sort */}
                         <div className="space-y-3">
                             <div className="flex items-center gap-2">
-                                <CalendarRange className="h-4 w-4 text-primary" />
-                                <label className="text-sm font-medium text-white">Date Range</label>
+                                <ArrowUpDown className="h-4 w-4 text-primary" />
+                                <label className="text-sm font-medium text-white">Collection Sort</label>
                             </div>
-                            <p className="text-xs text-slate-400">Optional activation window (MM-DD). Leave empty for year-round.</p>
-                            <div className="grid grid-cols-2 gap-3">
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Start</label>
-                                    <input
-                                        type="text"
-                                        value={form.date_range?.start ?? ""}
-                                        onChange={(e) => handleDateChange("start", e.target.value)}
-                                        placeholder="11-20"
-                                        className="w-full px-3 py-2.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
-                                    />
-                                </div>
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">End</label>
-                                    <input
-                                        type="text"
-                                        value={form.date_range?.end ?? ""}
-                                        onChange={(e) => handleDateChange("end", e.target.value)}
-                                        placeholder="12-26"
-                                        className="w-full px-3 py-2.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
-                                    />
-                                </div>
+                            <p className="text-xs text-slate-400">Sort order for items within a collection when gets selected.</p>
+                            <div className="grid grid-cols-3 gap-2">
+                                {([
+                                    { value: null, label: "Default" },
+                                    { value: "release" as const, label: "Release" },
+                                    { value: "alpha" as const, label: "Alpha" },
+                                ]).map(({ value, label }) => {
+                                    const isSelected = form.collection_sort === value;
+                                    return (
+                                        <button
+                                            key={label}
+                                            type="button"
+                                            onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
+                                            className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 transition-all duration-200 ${
+                                                isSelected
+                                                    ? "border-primary bg-primary/15"
+                                                    : "border-slate-700 bg-slate-900 hover:border-slate-600"
+                                            }`}
+                                        >
+                                            <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>{label}</span>
+                                        </button>
+                                    );
+                                })}
                             </div>
                         </div>
                     </SheetBody>

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchWithAuth } from "../utils/api";
 import { useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, ArrowUpDown, Check, ChevronDown, Compass, Home, Loader2, Minus, Plus, RefreshCcw, Search, Share2, SlidersHorizontal, Trash2 } from "lucide-react";
+import { ArrowLeft, ArrowUpDown, Check, ChevronDown, Compass, Eye, Home, Loader2, Minus, Plus, RefreshCcw, Search, Share2, SlidersHorizontal, Trash2 } from "lucide-react";
 import { Listbox } from "@headlessui/react";
 import { ConfirmDialog } from "../components/ui/confirm-dialog";
 import {
@@ -733,7 +733,10 @@ export default function GroupDetailPage() {
                     <SheetBody>
                         {/* Rotation Rules */}
                         <div className="space-y-4">
-                            <label className="text-sm font-medium text-white">Rotation Rules</label>
+                            <div className="flex items-center gap-2">
+                                <SlidersHorizontal className="h-4 w-4 text-primary" />
+                                <label className="text-base font-medium text-white">Rotation Rules</label>
+                            </div>
 
                             {/* Pick range slider */}
                             <div className="space-y-3">
@@ -785,7 +788,10 @@ export default function GroupDetailPage() {
 
                         {/* Visibility */}
                         <div className="space-y-3">
-                            <label className="text-sm font-medium text-white">Visibility</label>
+                            <div className="flex items-center gap-2">
+                                <Eye className="h-4 w-4 text-primary" />
+                                <label className="text-base font-medium text-white">Visibility</label>
+                            </div>
                             <p className="text-xs text-slate-400">Control where collections from this group appear on Plex.</p>
                             <div className="grid grid-cols-3 gap-2">
                                 {([
@@ -837,7 +843,7 @@ export default function GroupDetailPage() {
                         <div className="space-y-3">
                             <div className="flex items-center gap-2">
                                 <ArrowUpDown className="h-4 w-4 text-primary" />
-                                <label className="text-sm font-medium text-white">Collection Sort</label>
+                                <label className="text-base font-medium text-white">Collection Sort</label>
                             </div>
                             <p className="text-xs text-slate-400">Sort order for items within a collection when gets selected.</p>
                             <div className="grid grid-cols-3 gap-2">

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -858,21 +858,23 @@ export default function GroupDetailPage() {
                                         <span className="text-sm text-slate-300">Selection</span>
                                         <InfoTooltip text="How collections are picked from this group during rotation." />
                                     </div>
-                                    <div className="flex gap-1.5">
+                                    <div className="inline-flex w-56 rounded-lg border border-slate-700 overflow-hidden">
                                         {([
                                             { value: "random" as const, label: "Random" },
-                                            { value: "lru" as const, label: "LRU" },
-                                        ]).map(({ value, label }) => {
+                                            { value: "lru" as const, label: "Least Recent" },
+                                        ]).map(({ value, label }, i, arr) => {
                                             const isSelected = form.collection_selection === value;
                                             return (
                                                 <button
                                                     key={label}
                                                     type="button"
                                                     onClick={() => setForm((p) => ({ ...p, collection_selection: value }))}
-                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                    className={`flex-1 px-3 py-1.5 text-xs font-medium text-center transition-all duration-200 ${
+                                                        i < arr.length - 1 ? "border-r border-slate-700" : ""
+                                                    } ${
                                                         isSelected
-                                                            ? "border-primary bg-primary/15 text-white"
-                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                            ? "bg-primary/15 text-white"
+                                                            : "bg-slate-900 text-slate-400 hover:bg-slate-800"
                                                     }`}
                                                 >
                                                     {label}
@@ -888,21 +890,23 @@ export default function GroupDetailPage() {
                                         <span className="text-sm text-slate-300">Order</span>
                                         <InfoTooltip text="Display order of picked collections on the homescreen within this group." />
                                     </div>
-                                    <div className="flex gap-1.5">
+                                    <div className="inline-flex w-56 rounded-lg border border-slate-700 overflow-hidden">
                                         {([
                                             { value: null, label: "Random" },
                                             { value: "alpha" as const, label: "Alpha" },
-                                        ]).map(({ value, label }) => {
+                                        ]).map(({ value, label }, i, arr) => {
                                             const isSelected = form.collection_order === value;
                                             return (
                                                 <button
                                                     key={label}
                                                     type="button"
                                                     onClick={() => setForm((p) => ({ ...p, collection_order: value }))}
-                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                    className={`flex-1 px-3 py-1.5 text-xs font-medium text-center transition-all duration-200 ${
+                                                        i < arr.length - 1 ? "border-r border-slate-700" : ""
+                                                    } ${
                                                         isSelected
-                                                            ? "border-primary bg-primary/15 text-white"
-                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                            ? "bg-primary/15 text-white"
+                                                            : "bg-slate-900 text-slate-400 hover:bg-slate-800"
                                                     }`}
                                                 >
                                                     {label}
@@ -915,25 +919,27 @@ export default function GroupDetailPage() {
                                 {/* Sort */}
                                 <div className="flex items-center justify-between gap-3">
                                     <div className="flex items-center gap-1.5">
-                                        <span className="text-sm text-slate-300">Sort</span>
+                                        <span className="text-sm text-slate-300">Item Sort</span>
                                         <InfoTooltip text="Sort order for items within a collection when it gets selected." />
                                     </div>
-                                    <div className="flex gap-1.5">
+                                    <div className="inline-flex w-56 rounded-lg border border-slate-700 overflow-hidden">
                                         {([
                                             { value: null, label: "Default" },
                                             { value: "release" as const, label: "Release" },
                                             { value: "alpha" as const, label: "Alpha" },
-                                        ]).map(({ value, label }) => {
+                                        ]).map(({ value, label }, i, arr) => {
                                             const isSelected = form.collection_sort === value;
                                             return (
                                                 <button
                                                     key={label}
                                                     type="button"
                                                     onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
-                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                    className={`flex-1 px-3 py-1.5 text-xs font-medium text-center transition-all duration-200 ${
+                                                        i < arr.length - 1 ? "border-r border-slate-700" : ""
+                                                    } ${
                                                         isSelected
-                                                            ? "border-primary bg-primary/15 text-white"
-                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                            ? "bg-primary/15 text-white"
+                                                            : "bg-slate-900 text-slate-400 hover:bg-slate-800"
                                                     }`}
                                                 >
                                                     {label}

--- a/homescreen-hero-ui/src/pages/GroupsPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupsPage.tsx
@@ -103,12 +103,11 @@ type RotationSettings = {
     enabled: boolean;
     interval_hours: number;
     max_collections: number;
-    strategy: string;
+    group_order: string;
     allow_repeats: boolean;
     sync_all_on_rotation: boolean;
     blacklisted_collections: string[];
     auto_rotate: AutoRotateSettings;
-    randomize_group_order: boolean;
 };
 
 const defaultAutoRotate: AutoRotateSettings = {
@@ -213,7 +212,7 @@ export default function GroupsPage() {
     const [displaySettings, setDisplaySettings] = useState<DisplaySettings>({ group_display_mode: "grouped" });
     const [layoutModalOpen, setLayoutModalOpen] = useState(false);
     const [savingDisplay, setSavingDisplay] = useState(false);
-    const [maxCollectionsInput, setMaxCollectionsInput] = useState("");
+    const [_maxCollectionsInput, setMaxCollectionsInput] = useState("");
 
     const handleViewModeChange = (mode: ViewMode) => {
         setViewMode(mode);
@@ -1145,34 +1144,34 @@ export default function GroupsPage() {
 
                         <hr className="border-slate-700/50" />
 
-                        {/* Selection Strategy */}
+                        {/* Group Order */}
                         <div className="space-y-2">
-                            <label className="text-sm font-medium text-white">Selection Strategy</label>
+                            <label className="text-sm font-medium text-white">Group Order</label>
                             <p className="text-xs text-slate-400">
-                                Determine how groups are ordered and how collections are picked within each group.
+                                How groups are ordered for processing during rotation.
                             </p>
                             <Listbox
-                                value={rotationSettings?.strategy ?? "random"}
-                                onChange={(val) => saveRotationField({ strategy: val })}
+                                value={rotationSettings?.group_order ?? "display_order"}
+                                onChange={(val) => saveRotationField({ group_order: val })}
                                 disabled={!rotationSettings}
                             >
                                 <div className="relative mt-2">
                                     <Listbox.Button className="flex items-center gap-2 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2.5 text-sm text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-primary/70 transition-colors">
                                         <span className="flex-1 text-left">
-                                            {rotationSettings?.strategy === "weighted" ? "Weighted" :
-                                             rotationSettings?.strategy === "lru" ? "Least Recently Used" :
-                                             "Random"}
+                                            {rotationSettings?.group_order === "weighted" ? "Weighted" :
+                                             rotationSettings?.group_order === "random" ? "Random" :
+                                             "Display Order"}
                                         </span>
                                         <ChevronDown className="h-4 w-4 text-slate-400" />
                                     </Listbox.Button>
                                     <Listbox.Options className="absolute left-0 z-10 mt-1 w-full rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg focus:outline-none">
                                         <Listbox.Option
-                                            value="random"
+                                            value="display_order"
                                             className="cursor-pointer px-3 py-2 text-sm text-white hover:bg-slate-700 data-[selected]:bg-primary data-[selected]:font-semibold flex items-center justify-between"
                                         >
                                             {({ selected }) => (
                                                 <>
-                                                    <span>Random</span>
+                                                    <span>Display Order</span>
                                                     {selected && <Check className="h-4 w-4 text-white" />}
                                                 </>
                                             )}
@@ -1189,12 +1188,12 @@ export default function GroupsPage() {
                                             )}
                                         </Listbox.Option>
                                         <Listbox.Option
-                                            value="lru"
+                                            value="random"
                                             className="cursor-pointer px-3 py-2 text-sm text-white hover:bg-slate-700 data-[selected]:bg-primary data-[selected]:font-semibold flex items-center justify-between"
                                         >
                                             {({ selected }) => (
                                                 <>
-                                                    <span>Least Recently Used</span>
+                                                    <span>Random</span>
                                                     {selected && <Check className="h-4 w-4 text-white" />}
                                                 </>
                                             )}
@@ -1202,59 +1201,26 @@ export default function GroupsPage() {
                                     </Listbox.Options>
                                 </div>
                             </Listbox>
-                            {rotationSettings?.strategy === "random" && (
+                            {rotationSettings?.group_order === "display_order" && (
                                 <div className="flex items-center gap-2.5 rounded-lg bg-primary/10 border border-primary/20 px-3 py-2.5">
                                     <Lightbulb className="h-4 w-4 text-slate-300 shrink-0" strokeWidth={1.5} />
-                                    <p className="text-xs text-blue-200">Groups are processed in display order. Collections are picked randomly within each group.</p>
+                                    <p className="text-xs text-blue-200">Groups are processed in the order shown on this page. Drag to reorder.</p>
                                 </div>
                             )}
-                            {rotationSettings?.strategy === "weighted" && (
+                            {rotationSettings?.group_order === "weighted" && (
                                 <div className="flex items-center gap-2.5 rounded-lg bg-primary/10 border border-primary/20 px-3 py-2.5">
                                     <Lightbulb className="h-4 w-4 text-slate-300 shrink-0" strokeWidth={1.5} />
-                                    <p className="text-xs text-blue-200">Groups with higher weight are prioritized first. Collections are picked randomly within each group.</p>
+                                    <p className="text-xs text-blue-200">Groups with higher weight are prioritized first.</p>
                                 </div>
                             )}
-                            {rotationSettings?.strategy === "lru" && (
-                                <div className="flex items-center gap-2.5 rounded-lg bg-primary/10 border border-primary/20 px-3 py-2.5">
-                                    <Lightbulb className="h-4 w-4 text-slate-300 shrink-0" strokeWidth={1.5} />
-                                    <p className="text-xs text-blue-200">Groups are processed in display order. Collections that haven't been featured recently are picked first.</p>
-                                </div>
-                            )}
-                        </div>
-
-                        <hr className="border-slate-700/50" />
-
-                        {/* Randomize Group Order */}
-                        <div className="space-y-2">
-                            <div className="flex items-center justify-between">
-                                <div className="space-y-1">
-                                    <label className="text-sm font-medium text-white">Randomize Group Order</label>
-                                    <p className="text-xs text-slate-400">
-                                        Shuffle which groups get priority each rotation so no single group always dominates.
-                                    </p>
-                                </div>
-                                <Switch
-                                    checked={rotationSettings?.randomize_group_order ?? false}
-                                    onChange={(val) => saveRotationField({ randomize_group_order: val })}
-                                    disabled={!rotationSettings}
-                                    className={`${
-                                        rotationSettings?.randomize_group_order ? "bg-primary" : "bg-slate-700"
-                                    } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/70 disabled:opacity-60 shrink-0 ml-4`}
-                                >
-                                    <span
-                                        className={`${
-                                            rotationSettings?.randomize_group_order ? "translate-x-6" : "translate-x-1"
-                                        } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
-                                    />
-                                </Switch>
-                            </div>
-                            {rotationSettings?.randomize_group_order && (
+                            {rotationSettings?.group_order === "random" && (
                                 <div className="flex items-center gap-2.5 rounded-lg bg-primary/10 border border-primary/20 px-3 py-2.5">
                                     <Shuffle className="h-4 w-4 text-slate-300 shrink-0" strokeWidth={1.5} />
-                                    <p className="text-xs text-blue-200">Group processing order will be shuffled each rotation, overriding display order and weight-based sorting.</p>
+                                    <p className="text-xs text-blue-200">Group processing order is shuffled each rotation so no single group always dominates.</p>
                                 </div>
                             )}
                         </div>
+
                     </SheetBody>
                 </SheetContent>
             </Sheet>

--- a/homescreen-hero-ui/src/pages/GroupsPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupsPage.tsx
@@ -212,7 +212,7 @@ export default function GroupsPage() {
     const [displaySettings, setDisplaySettings] = useState<DisplaySettings>({ group_display_mode: "grouped" });
     const [layoutModalOpen, setLayoutModalOpen] = useState(false);
     const [savingDisplay, setSavingDisplay] = useState(false);
-    const [_maxCollectionsInput, setMaxCollectionsInput] = useState("");
+    const [, setMaxCollectionsInput] = useState("");
 
     const handleViewModeChange = (mode: ViewMode) => {
         setViewMode(mode);

--- a/homescreen-hero-ui/src/pages/GroupsPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupsPage.tsx
@@ -13,7 +13,6 @@ import {
     Lightbulb,
     List,
     Loader2,
-    Minus,
     Pencil,
     Plus,
     RefreshCw,
@@ -24,6 +23,7 @@ import {
     Trash2,
 } from "lucide-react";
 import { Listbox, Switch } from "@headlessui/react";
+import { Slider } from "../components/ui/slider";
 import {
     DndContext,
     closestCenter,
@@ -1116,54 +1116,30 @@ export default function GroupsPage() {
                         <hr className="border-slate-700/50" />
 
                         {/* Max Collections */}
-                        <div className="space-y-2">
-                            <label className="text-sm font-medium text-white">Max Collections</label>
+                        <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                                <label className="text-sm font-medium text-white">Max Collections</label>
+                                <span className="text-xs font-medium text-slate-300 tabular-nums">
+                                    {rotationSettings?.max_collections ?? 1}
+                                </span>
+                            </div>
                             <p className="text-xs text-slate-400">
                                 Limit the number of collections displayed.
                             </p>
-                            <div className="flex items-center gap-3 mt-2">
-                                <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                    <button
-                                        type="button"
-                                        disabled={!rotationSettings || rotationSettings.max_collections <= 1}
-                                        onClick={() => {
-                                            setMaxCollectionsInput((prev) => String(Math.max(1, Number(prev) - 1)));
-                                            saveRotationField({ max_collections: (rotationSettings?.max_collections ?? 1) - 1 });
-                                        }}
-                                        className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                                    >
-                                        <Minus className="h-4 w-4" />
-                                    </button>
-                                    <input
-                                        type="number"
-                                        min={1}
-                                        value={maxCollectionsInput}
-                                        onChange={(e) => setMaxCollectionsInput(e.target.value)}
-                                        onBlur={() => {
-                                            const val = parseInt(maxCollectionsInput, 10);
-                                            if (!Number.isNaN(val) && val >= 1 && rotationSettings) {
-                                                setMaxCollectionsInput(String(val));
-                                                saveRotationField({ max_collections: val });
-                                            } else {
-                                                // Revert to current value
-                                                setMaxCollectionsInput(String(rotationSettings?.max_collections ?? ""));
-                                            }
-                                        }}
-                                        className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                                    />
-                                    <button
-                                        type="button"
-                                        disabled={!rotationSettings}
-                                        onClick={() => {
-                                            setMaxCollectionsInput((prev) => String(Number(prev) + 1));
-                                            saveRotationField({ max_collections: (rotationSettings?.max_collections ?? 0) + 1 });
-                                        }}
-                                        className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                                    >
-                                        <Plus className="h-4 w-4" />
-                                    </button>
-                                </div>
-                                <span className="text-sm text-slate-400">items visible</span>
+                            <Slider
+                                min={1}
+                                max={20}
+                                step={1}
+                                value={[rotationSettings?.max_collections ?? 1]}
+                                onValueChange={([val]) => {
+                                    setMaxCollectionsInput(String(val));
+                                    saveRotationField({ max_collections: val });
+                                }}
+                            />
+                            <div className="flex justify-between text-[10px] text-slate-600">
+                                <span>1</span>
+                                <span>10</span>
+                                <span>20</span>
                             </div>
                         </div>
 

--- a/homescreen-hero-ui/src/pages/SettingsPage.tsx
+++ b/homescreen-hero-ui/src/pages/SettingsPage.tsx
@@ -25,10 +25,9 @@ type RotationSettings = {
     enabled: boolean;
     interval_hours: number;
     max_collections: number;
-    strategy: string;
+    group_order: string;
     allow_repeats: boolean;
     sync_all_on_rotation: boolean;
-    randomize_group_order: boolean;
     blacklisted_collections: string[];
     per_library_limits: Record<string, number>;
 };
@@ -143,10 +142,9 @@ export default function SettingsPage() {
         enabled: true,
         interval_hours: 12,
         max_collections: 5,
-        strategy: "random",
+        group_order: "display_order",
         allow_repeats: false,
         sync_all_on_rotation: true,
-        randomize_group_order: false,
         blacklisted_collections: [],
         per_library_limits: {},
     });
@@ -1135,7 +1133,7 @@ export default function SettingsPage() {
                         title="Rotation Settings"
                         description="Configure how often the scheduler rotates featured collections."
                         icon={CalendarSync}
-                        expanded={rotationExpanded}
+                        defaultExpanded={rotationExpanded}
                     >
                         <FieldRow label="Automatic rotations">
                             <div className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50 px-3 py-2">
@@ -1205,13 +1203,13 @@ export default function SettingsPage() {
                             </FieldRow>
                         )}
 
-                        <FieldRow label="Strategy" hint="Choose how groups are prioritized during rotation.">
+                        <FieldRow label="Group Order" hint="How groups are ordered for processing during rotation.">
                             <Listbox
-                                value={rotationSettings.strategy}
+                                value={rotationSettings.group_order}
                                 onChange={(val) =>
                                     setRotationSettings((prev) => ({
                                         ...prev,
-                                        strategy: val,
+                                        group_order: val,
                                     }))
                                 }
                                 disabled={loadingRotation}
@@ -1219,20 +1217,20 @@ export default function SettingsPage() {
                                 <div className="relative">
                                     <Listbox.Button className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white/90 dark:bg-slate-950 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary/70 text-left flex items-center justify-between data-[disabled]:opacity-50">
                                         <span>
-                                            {rotationSettings.strategy === "weighted" ? "Weighted" :
-                                             rotationSettings.strategy === "lru" ? "Least Recently Used" :
-                                             "Random"}
+                                            {rotationSettings.group_order === "weighted" ? "Weighted" :
+                                             rotationSettings.group_order === "random" ? "Random" :
+                                             "Display Order"}
                                         </span>
                                         <ChevronDown size={16} className="text-slate-400" />
                                     </Listbox.Button>
 
                                     <Listbox.Options className="absolute z-10 mt-1 w-full bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg shadow-lg overflow-hidden focus:outline-none">
                                         <Listbox.Option
-                                            value="random"
+                                            value="display_order"
                                             className="px-3 py-2 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
-                                                <span className="data-[selected]:font-medium">Random</span>
+                                                <span className="data-[selected]:font-medium">Display Order</span>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
                                         </Listbox.Option>
@@ -1246,11 +1244,11 @@ export default function SettingsPage() {
                                             </div>
                                         </Listbox.Option>
                                         <Listbox.Option
-                                            value="lru"
+                                            value="random"
                                             className="px-3 py-2 cursor-pointer transition-colors data-[focus]:bg-slate-100 dark:data-[focus]:bg-slate-800"
                                         >
                                             <div className="flex items-center justify-between text-slate-900 dark:text-slate-100 text-sm">
-                                                <span className="data-[selected]:font-medium">Least Recently Used</span>
+                                                <span className="data-[selected]:font-medium">Random</span>
                                                 <Check size={14} className="text-primary invisible data-[selected]:visible" />
                                             </div>
                                         </Listbox.Option>
@@ -1258,7 +1256,6 @@ export default function SettingsPage() {
                                 </div>
                             </Listbox>
                         </FieldRow>
-
                         <FieldRow label="Allow repeats" hint="Permit the same collection to appear in consecutive rotations.">
                             <Switch
                                 checked={rotationSettings.allow_repeats}

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -4,7 +4,7 @@ import { getGroupStatus } from "../utils/dates";
 import { useNavigate, useParams } from "react-router-dom";
 import {
     ArrowLeft,
-    CalendarRange,
+    ArrowUpDown,
     Check,
     ChevronDown,
     CircleDot,
@@ -30,6 +30,7 @@ import {
     SheetBody,
     SheetCloseButton,
 } from "../components/ui/sheet";
+import { Slider } from "../components/ui/slider";
 import { ConfirmDialog } from "../components/ui/confirm-dialog";
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -55,6 +56,7 @@ type SmartGroupForm = {
     visibility_home: boolean;
     visibility_shared: boolean;
     visibility_recommended: boolean;
+    collection_sort?: "release" | "alpha" | null;
     date_range?: DateRange | null;
     collections: string[];
 };
@@ -128,6 +130,7 @@ const emptyForm: SmartGroupForm = {
     visibility_home: true,
     visibility_shared: false,
     visibility_recommended: false,
+    collection_sort: null,
     date_range: null,
     collections: [],
 };
@@ -370,13 +373,6 @@ export default function SmartGroupDetailPage() {
         }
         const num = Number(value);
         setForm((prev) => ({ ...prev, [key]: Number.isNaN(num) ? 0 : num }) as SmartGroupForm);
-    };
-
-    const handleNumberBlur = (key: keyof SmartGroupForm) => {
-        const val = form[key];
-        if (val === "" || val === undefined || val === null) {
-            setForm((prev) => ({ ...prev, [key]: 0 }) as SmartGroupForm);
-        }
     };
 
     const handleDateChange = (key: keyof DateRange, value: string) => {
@@ -865,21 +861,49 @@ export default function SmartGroupDetailPage() {
                         <SheetCloseButton />
                     </SheetHeader>
                     <SheetBody>
-                        {/* Pick Limits */}
-                        <div className="space-y-3">
-                            <label className="text-sm font-medium text-white">Pick Limits</label>
-                            <p className="text-xs text-slate-400">Min and max collections to include per rotation.</p>
-                            <div className="grid grid-cols-2 gap-3">
-                                {(["min_picks", "max_picks"] as const).map((key) => (
-                                    <div key={key} className="space-y-1">
-                                        <label className="text-xs text-slate-400">{key === "min_picks" ? "Min picks" : "Max picks"}</label>
-                                        <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                            <button type="button" disabled={Number(form[key]) <= 0} onClick={() => handleNumberChange(key, String(Math.max(0, Number(form[key]) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                                                <Minus className="h-4 w-4" />
+                        {/* Rotation Rules */}
+                        <div className="space-y-4">
+                            <label className="text-sm font-medium text-white">Rotation Rules</label>
+
+                            {/* Pick range slider */}
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <label className="text-xs text-slate-400">Collections to select</label>
+                                    <span className="text-xs font-medium text-slate-300 tabular-nums">
+                                        Min: {form.min_picks} / Max: {form.max_picks}
+                                    </span>
+                                </div>
+                                <Slider
+                                    min={0}
+                                    max={10}
+                                    step={1}
+                                    value={[Number(form.min_picks), Number(form.max_picks)]}
+                                    onValueChange={([min, max]) => {
+                                        setForm((p) => ({ ...p, min_picks: min, max_picks: max }));
+                                    }}
+                                />
+                                <div className="flex justify-between text-[10px] text-slate-600">
+                                    <span>0</span>
+                                    <span>5</span>
+                                    <span>10</span>
+                                </div>
+                            </div>
+
+                            {/* Weight & Min gap */}
+                            <div className="flex items-center gap-4">
+                                {([
+                                    { key: "weight" as const, label: "Weight", min: 1 },
+                                    { key: "min_gap_rotations" as const, label: "Min gap", min: 0 },
+                                ]).map(({ key, label, min }) => (
+                                    <div key={key} className="flex items-center gap-2">
+                                        <label className="text-xs text-slate-400 whitespace-nowrap">{label}</label>
+                                        <div className="flex items-center rounded-md border border-slate-700 bg-slate-900 overflow-hidden">
+                                            <button type="button" disabled={Number(form[key]) <= min} onClick={() => handleNumberChange(key, String(Math.max(min, Number(form[key]) - 1)))} className="flex items-center justify-center h-7 w-7 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                                                <Minus className="h-3 w-3" />
                                             </button>
-                                            <input type="number" min={0} value={form[key]} onChange={(e) => handleNumberChange(key, e.target.value)} onBlur={() => handleNumberBlur(key)} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
-                                            <button type="button" onClick={() => handleNumberChange(key, String(Number(form[key]) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
-                                                <Plus className="h-4 w-4" />
+                                            <span className="w-6 text-center text-xs font-semibold text-white tabular-nums">{form[key]}</span>
+                                            <button type="button" onClick={() => handleNumberChange(key, String(Number(form[key]) + 1))} className="flex items-center justify-center h-7 w-7 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
+                                                <Plus className="h-3 w-3" />
                                             </button>
                                         </div>
                                     </div>
@@ -889,49 +913,15 @@ export default function SmartGroupDetailPage() {
 
                         <hr className="border-slate-700/50" />
 
-                        {/* Priority & Spacing */}
-                        <div className="space-y-3">
-                            <label className="text-sm font-medium text-white">Priority & Spacing</label>
-                            <p className="text-xs text-slate-400">Higher weights are picked more often. Min gap prevents repeats.</p>
-                            <div className="grid grid-cols-2 gap-3">
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Weight</label>
-                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                        <button type="button" disabled={Number(form.weight) <= 1} onClick={() => handleNumberChange("weight", String(Math.max(1, Number(form.weight) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                                            <Minus className="h-4 w-4" />
-                                        </button>
-                                        <input type="number" min={1} value={form.weight} onChange={(e) => handleNumberChange("weight", e.target.value)} onBlur={() => handleNumberBlur("weight")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
-                                        <button type="button" onClick={() => handleNumberChange("weight", String(Number(form.weight) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
-                                            <Plus className="h-4 w-4" />
-                                        </button>
-                                    </div>
-                                </div>
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Min gap (rotations)</label>
-                                    <div className="flex items-center rounded-lg border border-slate-700 bg-slate-900 overflow-hidden">
-                                        <button type="button" disabled={Number(form.min_gap_rotations) <= 0} onClick={() => handleNumberChange("min_gap_rotations", String(Math.max(0, Number(form.min_gap_rotations) - 1)))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
-                                            <Minus className="h-4 w-4" />
-                                        </button>
-                                        <input type="number" min={0} value={form.min_gap_rotations} onChange={(e) => handleNumberChange("min_gap_rotations", e.target.value)} onBlur={() => handleNumberBlur("min_gap_rotations")} className="w-12 text-center text-sm font-semibold text-white tabular-nums bg-transparent border-none outline-none focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" />
-                                        <button type="button" onClick={() => handleNumberChange("min_gap_rotations", String(Number(form.min_gap_rotations) + 1))} className="flex items-center justify-center h-10 w-10 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors">
-                                            <Plus className="h-4 w-4" />
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <hr className="border-slate-700/50" />
-
                         {/* Visibility */}
                         <div className="space-y-3">
                             <label className="text-sm font-medium text-white">Visibility</label>
                             <p className="text-xs text-slate-400">Control where collections from this group appear on Plex.</p>
-                            <div className="grid gap-2">
+                            <div className="grid grid-cols-3 gap-2">
                                 {([
                                     { key: "visibility_home" as const, label: "Home", icon: Home },
                                     { key: "visibility_shared" as const, label: "Shared", icon: Share2 },
-                                    { key: "visibility_recommended" as const, label: "Recommended", icon: Compass },
+                                    { key: "visibility_recommended" as const, label: "Library", icon: Compass },
                                 ]).map(({ key, label, icon: Icon }) => {
                                     const isSelected = form[key];
                                     return (
@@ -939,37 +929,67 @@ export default function SmartGroupDetailPage() {
                                             key={key}
                                             type="button"
                                             onClick={() => setForm((p) => ({ ...p, [key]: !p[key] }))}
-                                            className={`flex items-center justify-center gap-2 rounded-lg border px-4 py-2.5 transition-all duration-200 ${
+                                            className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 transition-all duration-200 ${
                                                 isSelected ? "border-primary bg-primary/15" : "border-slate-700 bg-slate-900 hover:border-slate-600"
                                             }`}
                                         >
-                                            <Icon className={`h-4 w-4 shrink-0 ${isSelected ? "text-primary" : "text-slate-500"}`} />
+                                            <Icon className={`h-3.5 w-3.5 shrink-0 ${isSelected ? "text-primary" : "text-slate-500"}`} />
                                             <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>{label}</span>
-                                            <div className={`h-4 w-4 shrink-0 rounded-full border-2 transition-all duration-200 ml-auto ${isSelected ? "border-primary bg-primary" : "border-slate-600 bg-transparent"}`} />
                                         </button>
                                     );
                                 })}
+                            </div>
+                            <div className="flex items-center gap-2 pt-1">
+                                <label className="text-xs text-slate-400 whitespace-nowrap">Active <span className="text-slate-600">(optional)</span></label>
+                                <input
+                                    type="text"
+                                    value={form.date_range?.start ?? ""}
+                                    onChange={(e) => handleDateChange("start", e.target.value)}
+                                    placeholder="MM-DD"
+                                    className="w-20 px-2 py-1.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-center text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                                />
+                                <span className="text-xs text-slate-500">–</span>
+                                <input
+                                    type="text"
+                                    value={form.date_range?.end ?? ""}
+                                    onChange={(e) => handleDateChange("end", e.target.value)}
+                                    placeholder="MM-DD"
+                                    className="w-20 px-2 py-1.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-center text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70"
+                                />
                             </div>
                         </div>
 
                         <hr className="border-slate-700/50" />
 
-                        {/* Date Range */}
+                        {/* Collection Sort */}
                         <div className="space-y-3">
                             <div className="flex items-center gap-2">
-                                <CalendarRange className="h-4 w-4 text-primary" />
-                                <label className="text-sm font-medium text-white">Date Range</label>
+                                <ArrowUpDown className="h-4 w-4 text-primary" />
+                                <label className="text-sm font-medium text-white">Collection Sort</label>
                             </div>
-                            <p className="text-xs text-slate-400">Optional activation window (MM-DD). Leave empty for year-round.</p>
-                            <div className="grid grid-cols-2 gap-3">
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">Start</label>
-                                    <input type="text" value={form.date_range?.start ?? ""} onChange={(e) => handleDateChange("start", e.target.value)} placeholder="11-20" className="w-full px-3 py-2.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70" />
-                                </div>
-                                <div className="space-y-1">
-                                    <label className="text-xs text-slate-400">End</label>
-                                    <input type="text" value={form.date_range?.end ?? ""} onChange={(e) => handleDateChange("end", e.target.value)} placeholder="12-26" className="w-full px-3 py-2.5 bg-slate-900 border border-slate-700 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-primary/70" />
-                                </div>
+                            <p className="text-xs text-slate-400">Sort order for items within a collection when gets selected.</p>
+                            <div className="grid grid-cols-3 gap-2">
+                                {([
+                                    { value: null, label: "Default" },
+                                    { value: "release" as const, label: "Release" },
+                                    { value: "alpha" as const, label: "Alpha" },
+                                ]).map(({ value, label }) => {
+                                    const isSelected = form.collection_sort === value;
+                                    return (
+                                        <button
+                                            key={label}
+                                            type="button"
+                                            onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
+                                            className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 transition-all duration-200 ${
+                                                isSelected
+                                                    ? "border-primary bg-primary/15"
+                                                    : "border-slate-700 bg-slate-900 hover:border-slate-600"
+                                            }`}
+                                        >
+                                            <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>{label}</span>
+                                        </button>
+                                    );
+                                })}
                             </div>
                         </div>
                     </SheetBody>

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -987,21 +987,23 @@ export default function SmartGroupDetailPage() {
                                         <span className="text-sm text-slate-300">Selection</span>
                                         <InfoTooltip text="How collections are picked from this group during rotation." />
                                     </div>
-                                    <div className="flex gap-1.5">
+                                    <div className="inline-flex w-56 rounded-lg border border-slate-700 overflow-hidden">
                                         {([
                                             { value: "random" as const, label: "Random" },
-                                            { value: "lru" as const, label: "LRU" },
-                                        ]).map(({ value, label }) => {
+                                            { value: "lru" as const, label: "Least Recent" },
+                                        ]).map(({ value, label }, i, arr) => {
                                             const isSelected = form.collection_selection === value;
                                             return (
                                                 <button
                                                     key={label}
                                                     type="button"
                                                     onClick={() => setForm((p) => ({ ...p, collection_selection: value }))}
-                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                    className={`flex-1 px-3 py-1.5 text-xs font-medium text-center transition-all duration-200 ${
+                                                        i < arr.length - 1 ? "border-r border-slate-700" : ""
+                                                    } ${
                                                         isSelected
-                                                            ? "border-primary bg-primary/15 text-white"
-                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                            ? "bg-primary/15 text-white"
+                                                            : "bg-slate-900 text-slate-400 hover:bg-slate-800"
                                                     }`}
                                                 >
                                                     {label}
@@ -1017,21 +1019,23 @@ export default function SmartGroupDetailPage() {
                                         <span className="text-sm text-slate-300">Order</span>
                                         <InfoTooltip text="Display order of picked collections on the homescreen within this group." />
                                     </div>
-                                    <div className="flex gap-1.5">
+                                    <div className="inline-flex w-56 rounded-lg border border-slate-700 overflow-hidden">
                                         {([
                                             { value: null, label: "Random" },
                                             { value: "alpha" as const, label: "Alpha" },
-                                        ]).map(({ value, label }) => {
+                                        ]).map(({ value, label }, i, arr) => {
                                             const isSelected = form.collection_order === value;
                                             return (
                                                 <button
                                                     key={label}
                                                     type="button"
                                                     onClick={() => setForm((p) => ({ ...p, collection_order: value }))}
-                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                    className={`flex-1 px-3 py-1.5 text-xs font-medium text-center transition-all duration-200 ${
+                                                        i < arr.length - 1 ? "border-r border-slate-700" : ""
+                                                    } ${
                                                         isSelected
-                                                            ? "border-primary bg-primary/15 text-white"
-                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                            ? "bg-primary/15 text-white"
+                                                            : "bg-slate-900 text-slate-400 hover:bg-slate-800"
                                                     }`}
                                                 >
                                                     {label}
@@ -1044,25 +1048,27 @@ export default function SmartGroupDetailPage() {
                                 {/* Sort */}
                                 <div className="flex items-center justify-between gap-3">
                                     <div className="flex items-center gap-1.5">
-                                        <span className="text-sm text-slate-300">Sort</span>
+                                        <span className="text-sm text-slate-300">Item Sort</span>
                                         <InfoTooltip text="Sort order for items within a collection when it gets selected." />
                                     </div>
-                                    <div className="flex gap-1.5">
+                                    <div className="inline-flex w-56 rounded-lg border border-slate-700 overflow-hidden">
                                         {([
                                             { value: null, label: "Default" },
                                             { value: "release" as const, label: "Release" },
                                             { value: "alpha" as const, label: "Alpha" },
-                                        ]).map(({ value, label }) => {
+                                        ]).map(({ value, label }, i, arr) => {
                                             const isSelected = form.collection_sort === value;
                                             return (
                                                 <button
                                                     key={label}
                                                     type="button"
                                                     onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
-                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                    className={`flex-1 px-3 py-1.5 text-xs font-medium text-center transition-all duration-200 ${
+                                                        i < arr.length - 1 ? "border-r border-slate-700" : ""
+                                                    } ${
                                                         isSelected
-                                                            ? "border-primary bg-primary/15 text-white"
-                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                            ? "bg-primary/15 text-white"
+                                                            : "bg-slate-900 text-slate-400 hover:bg-slate-800"
                                                     }`}
                                                 >
                                                     {label}

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -9,6 +9,7 @@ import {
     ChevronDown,
     CircleDot,
     Compass,
+    Eye,
     Home,
     Loader2,
     Minus,
@@ -863,7 +864,10 @@ export default function SmartGroupDetailPage() {
                     <SheetBody>
                         {/* Rotation Rules */}
                         <div className="space-y-4">
-                            <label className="text-sm font-medium text-white">Rotation Rules</label>
+                            <div className="flex items-center gap-2">
+                                <SlidersHorizontal className="h-4 w-4 text-primary" />
+                                <label className="text-base font-medium text-white">Rotation Rules</label>
+                            </div>
 
                             {/* Pick range slider */}
                             <div className="space-y-3">
@@ -915,7 +919,10 @@ export default function SmartGroupDetailPage() {
 
                         {/* Visibility */}
                         <div className="space-y-3">
-                            <label className="text-sm font-medium text-white">Visibility</label>
+                            <div className="flex items-center gap-2">
+                                <Eye className="h-4 w-4 text-primary" />
+                                <label className="text-base font-medium text-white">Visibility</label>
+                            </div>
                             <p className="text-xs text-slate-400">Control where collections from this group appear on Plex.</p>
                             <div className="grid grid-cols-3 gap-2">
                                 {([
@@ -965,7 +972,7 @@ export default function SmartGroupDetailPage() {
                         <div className="space-y-3">
                             <div className="flex items-center gap-2">
                                 <ArrowUpDown className="h-4 w-4 text-primary" />
-                                <label className="text-sm font-medium text-white">Collection Sort</label>
+                                <label className="text-base font-medium text-white">Collection Sort</label>
                             </div>
                             <p className="text-xs text-slate-400">Sort order for items within a collection when gets selected.</p>
                             <div className="grid grid-cols-3 gap-2">

--- a/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/SmartGroupDetailPage.tsx
@@ -21,6 +21,7 @@ import {
     Trash2,
     X,
 } from "lucide-react";
+import { InfoTooltip } from "../components/ui/info-tooltip";
 import { Listbox } from "@headlessui/react";
 import {
     Sheet,
@@ -57,6 +58,8 @@ type SmartGroupForm = {
     visibility_home: boolean;
     visibility_shared: boolean;
     visibility_recommended: boolean;
+    collection_selection?: "random" | "lru";
+    collection_order?: "random" | "alpha" | null;
     collection_sort?: "release" | "alpha" | null;
     date_range?: DateRange | null;
     collections: string[];
@@ -131,6 +134,8 @@ const emptyForm: SmartGroupForm = {
     visibility_home: true,
     visibility_shared: false,
     visibility_recommended: false,
+    collection_selection: "random",
+    collection_order: null,
     collection_sort: null,
     date_range: null,
     collections: [],
@@ -193,7 +198,7 @@ export default function SmartGroupDetailPage() {
             .then((allGroups: SmartGroupForm[]) => {
                 const idx = Number(groupId);
                 if (idx >= 0 && idx < allGroups.length) {
-                    setForm(allGroups[idx]);
+                    setForm({ ...allGroups[idx] });
                     savedFormRef.current = JSON.stringify(allGroups[idx]);
                 }
             })
@@ -968,35 +973,104 @@ export default function SmartGroupDetailPage() {
 
                         <hr className="border-slate-700/50" />
 
-                        {/* Collection Sort */}
-                        <div className="space-y-3">
+                        {/* Collection Settings */}
+                        <div className="space-y-4">
                             <div className="flex items-center gap-2">
                                 <ArrowUpDown className="h-4 w-4 text-primary" />
-                                <label className="text-base font-medium text-white">Collection Sort</label>
+                                <label className="text-base font-medium text-white">Collection Settings</label>
                             </div>
-                            <p className="text-xs text-slate-400">Sort order for items within a collection when gets selected.</p>
-                            <div className="grid grid-cols-3 gap-2">
-                                {([
-                                    { value: null, label: "Default" },
-                                    { value: "release" as const, label: "Release" },
-                                    { value: "alpha" as const, label: "Alpha" },
-                                ]).map(({ value, label }) => {
-                                    const isSelected = form.collection_sort === value;
-                                    return (
-                                        <button
-                                            key={label}
-                                            type="button"
-                                            onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
-                                            className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 transition-all duration-200 ${
-                                                isSelected
-                                                    ? "border-primary bg-primary/15"
-                                                    : "border-slate-700 bg-slate-900 hover:border-slate-600"
-                                            }`}
-                                        >
-                                            <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>{label}</span>
-                                        </button>
-                                    );
-                                })}
+
+                            <div className="space-y-3">
+                                {/* Selection */}
+                                <div className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-sm text-slate-300">Selection</span>
+                                        <InfoTooltip text="How collections are picked from this group during rotation." />
+                                    </div>
+                                    <div className="flex gap-1.5">
+                                        {([
+                                            { value: "random" as const, label: "Random" },
+                                            { value: "lru" as const, label: "LRU" },
+                                        ]).map(({ value, label }) => {
+                                            const isSelected = form.collection_selection === value;
+                                            return (
+                                                <button
+                                                    key={label}
+                                                    type="button"
+                                                    onClick={() => setForm((p) => ({ ...p, collection_selection: value }))}
+                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                        isSelected
+                                                            ? "border-primary bg-primary/15 text-white"
+                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                    }`}
+                                                >
+                                                    {label}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+
+                                {/* Order */}
+                                <div className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-sm text-slate-300">Order</span>
+                                        <InfoTooltip text="Display order of picked collections on the homescreen within this group." />
+                                    </div>
+                                    <div className="flex gap-1.5">
+                                        {([
+                                            { value: null, label: "Random" },
+                                            { value: "alpha" as const, label: "Alpha" },
+                                        ]).map(({ value, label }) => {
+                                            const isSelected = form.collection_order === value;
+                                            return (
+                                                <button
+                                                    key={label}
+                                                    type="button"
+                                                    onClick={() => setForm((p) => ({ ...p, collection_order: value }))}
+                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                        isSelected
+                                                            ? "border-primary bg-primary/15 text-white"
+                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                    }`}
+                                                >
+                                                    {label}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+
+                                {/* Sort */}
+                                <div className="flex items-center justify-between gap-3">
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-sm text-slate-300">Sort</span>
+                                        <InfoTooltip text="Sort order for items within a collection when it gets selected." />
+                                    </div>
+                                    <div className="flex gap-1.5">
+                                        {([
+                                            { value: null, label: "Default" },
+                                            { value: "release" as const, label: "Release" },
+                                            { value: "alpha" as const, label: "Alpha" },
+                                        ]).map(({ value, label }) => {
+                                            const isSelected = form.collection_sort === value;
+                                            return (
+                                                <button
+                                                    key={label}
+                                                    type="button"
+                                                    onClick={() => setForm((p) => ({ ...p, collection_sort: value }))}
+                                                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+                                                        isSelected
+                                                            ? "border-primary bg-primary/15 text-white"
+                                                            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600"
+                                                    }`}
+                                                >
+                                                    {label}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </SheetBody>

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -175,6 +175,10 @@ class CollectionGroupConfig(BaseModel):
         default=False,
         description="Promote collections to Library Recommended section",
     )
+    collection_sort: Optional[Literal["release", "alpha"]] = Field(
+        default=None,
+        description="Sort order for items within collections in this group. None = don't change.",
+    )
     date_range: Optional[DateRange] = Field(
         default=None,
         description="Optional yearly date window when this group is active",

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -65,9 +65,9 @@ class RotationSettings(BaseModel):
         ge=1,
         description="Global cap on how many collections are featured at once",
     )
-    strategy: str = Field(
-        default="random",
-        description="Selection strategy: 'random' (random selection), 'weighted' (sort groups by weight), or 'lru' (pick least recently used collections)",
+    group_order: str = Field(
+        default="display_order",
+        description="How groups are ordered for processing: 'display_order', 'weighted', or 'random'",
     )
     allow_repeats: bool = Field(
         default=False,
@@ -85,14 +85,38 @@ class RotationSettings(BaseModel):
         default_factory=AutoRotateSettings,
         description="Settings for auto-rotate mode",
     )
-    randomize_group_order: bool = Field(
-        default=False,
-        description="Shuffle the processing order of groups each rotation instead of using display_order or weight",
-    )
     per_library_limits: Dict[str, int] = Field(
         default_factory=dict,
         description="Maximum collections per library during rotation. Keys are library names, values are max counts.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_strategy(cls, data):
+        if not isinstance(data, dict):
+            return data
+
+        # If new field already exists, clean up legacy/deprecated fields and skip migration
+        if "group_order" in data:
+            data.pop("strategy", None)
+            data.pop("randomize_group_order", None)
+            data.pop("collection_selection", None)
+            return data
+
+        old_strategy = data.pop("strategy", None)
+        old_randomize = data.pop("randomize_group_order", None)
+        data.pop("collection_selection", None)
+
+        if old_strategy is not None:
+            if old_strategy == "weighted":
+                data["group_order"] = "weighted"
+            else:
+                data["group_order"] = "display_order"
+
+        if old_randomize:
+            data["group_order"] = "random"
+
+        return data
 
 
 class SmartGroupRule(BaseModel):
@@ -151,7 +175,7 @@ class CollectionGroupConfig(BaseModel):
     weight: int = Field(
         default=1,
         ge=1,
-        description="Relative priority of this group vs other groups (used when strategy='weighted'). Higher weight = higher priority.",
+        description="Relative priority of this group vs other groups (used when group_order='weighted'). Higher weight = higher priority.",
     )
     display_order: int = Field(
         default=0,
@@ -174,6 +198,14 @@ class CollectionGroupConfig(BaseModel):
     visibility_recommended: bool = Field(
         default=False,
         description="Promote collections to Library Recommended section",
+    )
+    collection_selection: Literal["random", "lru"] = Field(
+        default="random",
+        description="How collections are picked from this group during rotation.",
+    )
+    collection_order: Optional[Literal["random", "alpha"]] = Field(
+        default=None,
+        description="Display order of picked collections on homescreen. None = random.",
     )
     collection_sort: Optional[Literal["release", "alpha"]] = Field(
         default=None,
@@ -201,6 +233,15 @@ class CollectionGroupConfig(BaseModel):
         if self.smart and not self.rules:
             raise ValueError("Smart groups must have at least one rule")
         return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_collection_selection(cls, data):
+        if not isinstance(data, dict):
+            return data
+        if data.get("collection_selection") is None:
+            data["collection_selection"] = "random"
+        return data
 
 
 class LoggingSettings(BaseModel):

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -247,6 +247,7 @@ def apply_home_screen_selection(
     *,
     dry_run: bool = False,
     smart_group_collections: Dict[str, List[str]] | None = None,
+    collection_sort: Dict[str, str] | None = None,
 ) -> List[str]:
     # Apply the chosen collections to the Plex Home screen
     #
@@ -354,6 +355,13 @@ def apply_home_screen_selection(
                     shared=visibility.get("shared", False),
                     recommended=visibility.get("recommended", False)
                 )
+                # Apply collection sort if configured for this collection's group
+                if collection_sort and name in collection_sort:
+                    try:
+                        coll.sortUpdate(sort=collection_sort[name])
+                        logger.debug("Set sort order for '%s' to '%s'", name, collection_sort[name])
+                    except Exception:
+                        logger.warning("Failed to update sort for '%s' (may be a smart collection)", name)
         else:
             # Collection is either configured but not selected, or was previously rotated but removed from config
             if name in previously_rotated_names and name not in configured_names:

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -21,71 +21,44 @@ logger = logging.getLogger(__name__)
 
 def _get_ordered_groups(
     groups: List[CollectionGroupConfig],
-    strategy: str,
+    group_order: str,
     rng: random.Random,
-    randomize: bool = False,
 ) -> List[CollectionGroupConfig]:
-    """
-    Order groups based on the selection strategy.
-
-    Args:
-        groups: List of all groups from config
-        strategy: Selection strategy ('random', 'weighted', or 'lru')
-        rng: Random number generator for reproducibility
-        randomize: Shuffle group order each rotation
-
-    Returns:
-        Ordered list of groups to process
-    """
-    if randomize:
+    # Order groups based on the group_order setting.
+    if group_order == "random":
         logger.debug("Randomizing group processing order")
         shuffled = list(groups)
         rng.shuffle(shuffled)
         return shuffled
 
-    if strategy == "weighted":
+    if group_order == "weighted":
         # Sort groups by weight (descending), then by config order for ties
         # Higher weight = processed first = higher priority
-        logger.debug("Using weighted strategy: sorting groups by weight")
+        logger.debug("Using weighted group order: sorting groups by weight")
         return sorted(groups, key=lambda g: (-g.weight, groups.index(g)))
     else:
-        # Default 'random' and 'lru' strategies: sort by display_order so
-        # drag-reordering in the UI controls processing priority too
-        logger.debug(f"Using {strategy} strategy: sorting by display_order")
+        # Default 'display_order': sort by display_order so
+        # drag-reordering in the UI controls processing priority
+        logger.debug("Using display_order group order")
         return sorted(groups, key=lambda g: g.display_order)
 
 
 def _select_collections_from_group(
     available: List[str],
     k: int,
-    strategy: str,
+    collection_selection: str,
     usage_map: Dict[str, CollectionUsage],
     rng: random.Random,
 ) -> List[str]:
-    """
-    Select k collections from the available list based on strategy.
-
-    Args:
-        available: List of collection names to choose from
-        k: Number of collections to select
-        strategy: Selection strategy ('random', 'weighted', or 'lru')
-        usage_map: Mapping of collection names to usage data
-        rng: Random number generator for reproducibility
-
-    Returns:
-        List of selected collection names
-    """
-    if strategy == "lru":
+    # Select k collections from the available list based on collection_selection method.
+    if collection_selection == "lru":
         # Sort by last_rotation_id (ascending), prioritizing least recently used
         # Collections never used (None) are sorted first
         def sort_key(collection_name: str) -> Tuple[int, int]:
             usage = usage_map.get(collection_name)
             if usage is None or usage.last_rotation_id is None:
-                # Never used - highest priority (sort first)
                 return (0, 0)
             else:
-                # Used before - sort by rotation ID (older = higher priority)
-                # Secondary sort by times_used (less used = higher priority)
                 return (1, usage.last_rotation_id)
 
         sorted_collections = sorted(available, key=sort_key)
@@ -238,10 +211,9 @@ def run_rotation_with_history(
         "Starting rotation with history: %d max rotations observed", max_rotation_id
     )
 
-    # Order groups based on strategy
+    # Order groups based on group_order setting
     ordered_groups = _get_ordered_groups(
-        config.groups, config.rotation.strategy, rng,
-        randomize=config.rotation.randomize_group_order,
+        config.groups, config.rotation.group_order, rng,
     )
 
     for group in ordered_groups:
@@ -327,7 +299,10 @@ def run_rotation_with_history(
             group_results.append(result)
             continue
 
-        # Select collections based on strategy
+        # Resolve per-group collection selection
+        group_selection = group.collection_selection
+
+        # Select collections based on collection_selection method
         # When per-library limits are set, use iterative selection to respect limits
         if per_library_limits:
             chosen = []
@@ -338,7 +313,7 @@ def run_rotation_with_history(
                 if not eligible:
                     break
                 pick = _select_collections_from_group(
-                    eligible, 1, config.rotation.strategy, usage_map, rng
+                    eligible, 1, group_selection, usage_map, rng
                 )
                 if not pick:
                     break
@@ -350,7 +325,7 @@ def run_rotation_with_history(
                     library_counts[lib] += 1
         else:
             chosen = _select_collections_from_group(
-                available, k, config.rotation.strategy, usage_map, rng
+                available, k, group_selection, usage_map, rng
             )
             # Update library counts for selected collections
             for coll in chosen:
@@ -398,7 +373,7 @@ def run_auto_rotation_with_history(
     all_collections: List[str],
     *,
     max_collections: int,
-    strategy: str,
+    collection_selection: str,
     blacklisted_collections: List[str],
     allow_repeats: bool,
     last_rotation_collections: List[str],
@@ -485,7 +460,7 @@ def run_auto_rotation_with_history(
             if not eligible:
                 break
             # Select one collection
-            chosen = _select_collections_from_group(eligible, 1, strategy, usage_map, rng)
+            chosen = _select_collections_from_group(eligible, 1, collection_selection, usage_map, rng)
             if not chosen:
                 break
             coll = chosen[0]
@@ -500,7 +475,7 @@ def run_auto_rotation_with_history(
         k = min(max_collections, len(available))
         if k > 0:
             selected = _select_collections_from_group(
-                available, k, strategy, usage_map, rng
+                available, k, collection_selection, usage_map, rng
             )
             # Track library counts for the result
             for coll in selected:
@@ -562,13 +537,11 @@ def run_rotation_dry(
     selected_set: Set[str] = set()
     group_results: List[GroupSelectionResult] = []
 
-    # Groups are ordered based on strategy (weighted or random/config order)
     logger.info("Starting dry rotation for %d groups", len(config.groups))
 
-    # Order groups based on strategy
+    # Order groups based on group_order setting
     ordered_groups = _get_ordered_groups(
-        config.groups, config.rotation.strategy, rng,
-        randomize=config.rotation.randomize_group_order,
+        config.groups, config.rotation.group_order, rng,
     )
 
     # For dry run, we don't have usage history, so use empty map
@@ -644,9 +617,11 @@ def run_rotation_dry(
             group_results.append(result)
             continue
 
-        # Select collections based on strategy
+        # Resolve per-group collection selection
+        group_selection = group.collection_selection
+
         chosen = _select_collections_from_group(
-            available, k, config.rotation.strategy, usage_map, rng
+            available, k, group_selection, usage_map, rng
         )
 
         selected.extend(chosen)
@@ -804,9 +779,15 @@ def order_collections_for_display(
         ),
     )
 
-    # Shuffle within each group bucket
-    for bucket in group_buckets.values():
-        rng.shuffle(bucket)
+    # Order collections within each group bucket based on collection_order
+    for gn in sorted_group_names:
+        bucket = group_buckets[gn]
+        group_cfg = next((g for g in config.groups if g.name == gn), None)
+        coll_order = group_cfg.collection_order if group_cfg else None
+        if coll_order == "alpha":
+            bucket.sort()
+        else:
+            rng.shuffle(bucket)
 
     if mode == "merged":
         # Round-robin across groups

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -721,6 +721,26 @@ def build_collection_visibility_map(
     return visibility_map
 
 
+def build_collection_sort_map(
+    config: AppConfig,
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
+) -> Dict[str, str]:
+    # Build a mapping from collection name to sort order based on its group.
+    # Only includes collections whose group has a collection_sort set.
+    # First group wins if a collection is in multiple groups.
+    sort_map: Dict[str, str] = {}
+
+    for group in config.groups:
+        if not group.collection_sort:
+            continue
+        pool = _get_collection_pool(group, smart_group_collections)
+        for collection_name in pool:
+            if collection_name not in sort_map:
+                sort_map[collection_name] = group.collection_sort
+
+    return sort_map
+
+
 def _build_collection_group_map(
     config: AppConfig,
     smart_group_collections: Optional[Dict[str, List[str]]] = None,

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -17,7 +17,7 @@ from .integrations import (
 from .integrations.plex_client import get_library_collections
 from .config.loader import load_config
 from .config.schema import AppConfig, RotationExecution, RotationResult
-from .rotation import run_rotation_with_history, run_auto_rotation_with_history, build_collection_visibility_map
+from .rotation import run_rotation_with_history, run_auto_rotation_with_history, build_collection_visibility_map, build_collection_sort_map
 from .smart_groups import build_collection_metadata, resolve_smart_rules
 from .db import (
     init_db,
@@ -341,6 +341,9 @@ def run_rotation_once(
     pinned_visibility = get_pinned_visibility_map()
     collection_visibility.update(pinned_visibility)
 
+    # Build sort map from group settings
+    collection_sort = build_collection_sort_map(config, smart_group_collections)
+
     # Apply the selection (or simulate if dry_run=True)
     applied = apply_home_screen_selection(
         server,
@@ -349,6 +352,7 @@ def run_rotation_once(
         collection_visibility,
         dry_run=dry_run,  # controls whether Plex is actually changed
         smart_group_collections=smart_group_collections,
+        collection_sort=collection_sort,
     )
 
     rotation_id = record_rotation(

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -115,7 +115,8 @@ def _run_auto_rotation(
     return run_auto_rotation_with_history(
         all_collection_names,
         max_collections=config.rotation.max_collections,
-        strategy=config.rotation.strategy,
+        # Auto-rotate has no groups, so collection selection is always random.
+        collection_selection="random",
         blacklisted_collections=config.rotation.blacklisted_collections,
         allow_repeats=config.rotation.allow_repeats,
         last_rotation_collections=last_rotation_collections,

--- a/homescreen_hero/web/routers/config/settings.py
+++ b/homescreen_hero/web/routers/config/settings.py
@@ -559,14 +559,18 @@ def save_rotation_settings(
             enabled=payload.enabled,
             interval_hours=payload.interval_hours,
             max_collections=payload.max_collections,
-            strategy=payload.strategy,
+            group_order=payload.group_order,
             allow_repeats=payload.allow_repeats,
             sync_all_on_rotation=payload.sync_all_on_rotation,
             blacklisted_collections=payload.blacklisted_collections,
             auto_rotate=payload.auto_rotate.model_dump(),
-            randomize_group_order=payload.randomize_group_order,
             per_library_limits=payload.per_library_limits,
         )
+
+        # Clean up legacy/deprecated fields from YAML
+        rotation_section.pop("strategy", None)
+        rotation_section.pop("randomize_group_order", None)
+        rotation_section.pop("collection_selection", None)
 
         data["rotation"] = rotation_section
         save_config_mapping(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ def sample_config():
             enabled=True,
             interval_hours=12,
             max_collections=5,
-            strategy="random",
             allow_repeats=False,
         ),
         groups=[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,7 +73,7 @@ class TestRotationSettings:
         assert rotation.enabled is True
         assert rotation.interval_hours == 12
         assert rotation.max_collections == 5
-        assert rotation.strategy == "random"
+        assert rotation.group_order == "display_order"
         assert rotation.allow_repeats is False
         assert rotation.sync_all_on_rotation is True
 
@@ -82,14 +82,14 @@ class TestRotationSettings:
             enabled=False,
             interval_hours=24,
             max_collections=10,
-            strategy="weighted",
+            group_order="weighted",
             allow_repeats=True,
             sync_all_on_rotation=False
         )
         assert rotation.enabled is False
         assert rotation.interval_hours == 24
         assert rotation.max_collections == 10
-        assert rotation.strategy == "weighted"
+        assert rotation.group_order == "weighted"
         assert rotation.allow_repeats is True
         assert rotation.sync_all_on_rotation is False
 
@@ -100,6 +100,14 @@ class TestRotationSettings:
     def test_max_collections_minimum(self):
         with pytest.raises(ValidationError):
             RotationSettings(max_collections=0)
+
+    def test_migrates_legacy_strategy_weighted(self):
+        rotation = RotationSettings.model_validate({"strategy": "weighted"})
+        assert rotation.group_order == "weighted"
+
+    def test_migrates_legacy_strategy_lru_to_display_order(self):
+        rotation = RotationSettings.model_validate({"strategy": "lru"})
+        assert rotation.group_order == "display_order"
 
 
 class TestCollectionGroupConfig:
@@ -142,6 +150,14 @@ class TestCollectionGroupConfig:
         )
         assert group.date_range is not None
         assert group.date_range.start == "12-01"
+
+    def test_collection_selection_defaults_to_random(self):
+        group = CollectionGroupConfig(name="Test", collections=["Test Collection"])
+        assert group.collection_selection == "random"
+
+    def test_collection_selection_null_migrates_to_random(self):
+        group = CollectionGroupConfig(name="Test", collection_selection=None, collections=["Test Collection"])
+        assert group.collection_selection == "random"
 
     def test_requires_name(self):
         with pytest.raises(ValidationError):

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -223,8 +223,8 @@ class TestIsBlacklisted:
 class TestGetOrderedGroups:
     """Tests for _get_ordered_groups function"""
 
-    def test_random_strategy_sorts_by_display_order(self):
-        """Random strategy should sort groups by display_order"""
+    def test_display_order_sorts_by_display_order(self):
+        """display_order group_order should sort groups by display_order"""
         groups = [
             CollectionGroupConfig(
                 name="Group A",
@@ -249,7 +249,7 @@ class TestGetOrderedGroups:
             ),
         ]
         rng = random.Random(42)
-        ordered = _get_ordered_groups(groups, "random", rng)
+        ordered = _get_ordered_groups(groups, "display_order", rng)
 
         # Should be sorted by display_order, not config order or weight
         assert ordered[0].name == "Group B"
@@ -439,7 +439,7 @@ def _make_test_config(
     groups: list,
     max_collections: int = 10,
     per_library_limits: dict = None,
-    strategy: str = "random",
+    group_order: str = "display_order",
     allow_repeats: bool = True,
     blacklisted_collections: list = None,
 ) -> AppConfig:
@@ -456,7 +456,7 @@ def _make_test_config(
         rotation=RotationSettings(
             enabled=True,
             max_collections=max_collections,
-            strategy=strategy,
+            group_order=group_order,
             allow_repeats=allow_repeats,
             blacklisted_collections=blacklisted_collections or [],
             per_library_limits=per_library_limits or {},
@@ -739,7 +739,7 @@ class TestAutoRotationPerLibraryLimits:
         result = run_auto_rotation_with_history(
             all_collections,
             max_collections=5,
-            strategy="random",
+            collection_selection="random",
             blacklisted_collections=[],
             allow_repeats=True,
             last_rotation_collections=[],
@@ -763,7 +763,7 @@ class TestAutoRotationPerLibraryLimits:
         result = run_auto_rotation_with_history(
             all_collections,
             max_collections=5,
-            strategy="random",
+            collection_selection="random",
             blacklisted_collections=[],
             allow_repeats=True,
             last_rotation_collections=[],
@@ -787,7 +787,7 @@ class TestAutoRotationPerLibraryLimits:
         result = run_auto_rotation_with_history(
             all_collections,
             max_collections=4,
-            strategy="random",
+            collection_selection="random",
             blacklisted_collections=[],
             allow_repeats=True,
             last_rotation_collections=[],
@@ -811,7 +811,7 @@ class TestAutoRotationPerLibraryLimits:
         result = run_auto_rotation_with_history(
             all_collections,
             max_collections=3,
-            strategy="random",
+            collection_selection="random",
             blacklisted_collections=[],
             allow_repeats=True,
             last_rotation_collections=[],

--- a/tests/test_rotation_full.py
+++ b/tests/test_rotation_full.py
@@ -31,7 +31,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=3,
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -66,7 +65,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=3,  # Global max
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -106,7 +104,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=2,
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -145,7 +142,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=5,
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -193,7 +189,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=5,
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -234,7 +229,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=10,
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -267,7 +261,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=5,
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -300,7 +293,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=10,
-                strategy="random"
             ),
             groups=[
                 CollectionGroupConfig(
@@ -339,7 +331,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=5,
-                strategy="random",
                 blacklisted_collections=["Blocked Movie", "Another Blocked"]
             ),
             groups=[
@@ -376,7 +367,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=5,
-                strategy="random",
                 blacklisted_collections=["Movie 1", "Movie 2"]
             ),
             groups=[
@@ -410,7 +400,6 @@ class TestRunRotationWithHistory:
             rotation=RotationSettings(
                 enabled=True,
                 max_collections=10,
-                strategy="random",
                 blacklisted_collections=["Blocked Everywhere"]
             ),
             groups=[

--- a/tests/test_tautulli_client.py
+++ b/tests/test_tautulli_client.py
@@ -337,7 +337,6 @@ def _make_config(tautulli=None):
             enabled=True,
             interval_hours=12,
             max_collections=5,
-            strategy="random",
         ),
         groups=[
             CollectionGroupConfig(


### PR DESCRIPTION
## Feature: Per-group collection ordering and sort settings

### Summary
The old rotation strategy setting tried to control too many things at once. This splits it into separate, independent controls: how groups are ordered, how collections are picked, and how they're displayed (so you can mix and match per group instead of being locked into one global behavior).

### Major Changes
- Split the single "rotation strategy" into separate group order and collection selection settings, with a migration that automatically converts existing configs
- Added per-group overrides for collection selection (random vs least recent) and display order (random vs alphabetical) in both regular and smart group settings
- Added per-group collection sort option (release date or alphabetical) that controls how items within a collection are ordered when it gets pinned to the homescreen
- Redesigned the Collection Settings section in group detail sheets with connected segmented controls instead of separate toggle buttons

### Minor Changes
- Swapped the numeric input for max collections with a slider in group settings
- Added inline help tooltips to collection settings and improved tooltip contrast against the dark sheet background
- Cleaned up unused test fixtures