### PR TITLE
Feature: Auto-Request Missing Items via Seerr

### DIFF
--- a/homescreen-hero-ui/src/components/dashboard/AutoRequestActivityCard.tsx
+++ b/homescreen-hero-ui/src/components/dashboard/AutoRequestActivityCard.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from "react";
+import { Film, Tv, AlertCircle, RefreshCw } from "lucide-react";
+import { fetchWithAuth } from "../../utils/api";
+import { normalizeIso, timeAgo } from "../../utils/dates";
+
+type AutoRequestItem = {
+    id: number;
+    tmdb_id: number;
+    media_type: "movie" | "tv";
+    title: string;
+    year: number | null;
+    integration_type: string;
+    source_name: string;
+    status: string;
+    error_message: string | null;
+    requested_at: string;
+    downloaded_at: string | null;
+};
+
+type AutoRequestSummary = {
+    requested: number;
+    downloaded: number;
+    failed: number;
+    already_exists: number;
+};
+
+type AutoRequestResponse = {
+    items: AutoRequestItem[];
+    summary: AutoRequestSummary;
+};
+
+const STATUS_STYLES: Record<string, { bg: string; text: string; ring: string; label: string }> = {
+    requested: { bg: "bg-blue-500/15", text: "text-blue-300", ring: "ring-blue-500/30", label: "Requested" },
+    downloaded: { bg: "bg-emerald-500/15", text: "text-emerald-300", ring: "ring-emerald-500/30", label: "Downloaded" },
+    failed: { bg: "bg-rose-500/15", text: "text-rose-300", ring: "ring-rose-500/30", label: "Failed" },
+    already_exists: { bg: "bg-amber-500/15", text: "text-amber-300", ring: "ring-amber-500/30", label: "Exists" },
+};
+
+function StatusBadge({ status }: { status: string }) {
+    const style = STATUS_STYLES[status] || STATUS_STYLES.requested;
+    return (
+        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ring-1 whitespace-nowrap ${style.bg} ${style.text} ${style.ring}`}>
+            {style.label}
+        </span>
+    );
+}
+
+function SkeletonItem() {
+    return (
+        <div className="flex items-start gap-2.5 rounded-xl border border-slate-800/60 bg-slate-800/30 p-2.5 animate-pulse">
+            <div className="mt-1 h-3.5 w-3.5 rounded bg-slate-700" />
+            <div className="flex-1 space-y-2">
+                <div className="h-3 w-3/4 rounded bg-slate-800" />
+                <div className="h-2.5 w-1/2 rounded bg-slate-800" />
+            </div>
+        </div>
+    );
+}
+
+function formatSource(integrationType: string, sourceName: string): string {
+    const label = integrationType.charAt(0).toUpperCase() + integrationType.slice(1);
+    return `${label}: ${sourceName}`;
+}
+
+function formatTimestamp(iso: string) {
+    const parsed = new Date(normalizeIso(iso));
+    if (Number.isNaN(parsed.getTime())) return iso;
+    return parsed.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+    });
+}
+
+export default function AutoRequestActivityCard() {
+    const [items, setItems] = useState<AutoRequestItem[]>([]);
+    const [summary, setSummary] = useState<AutoRequestSummary | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [seerrEnabled, setSeerrEnabled] = useState<boolean | null>(null);
+
+    useEffect(() => {
+        loadData();
+    }, []);
+
+    const loadData = async () => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const configRes = await fetchWithAuth("/api/admin/config/seerr");
+            if (!configRes.ok) throw new Error("Failed to load Seerr configuration");
+            const config = await configRes.json();
+
+            if (!config.enabled) {
+                setSeerrEnabled(false);
+                setLoading(false);
+                return;
+            }
+            setSeerrEnabled(true);
+
+            const res = await fetchWithAuth("/api/admin/integrations/auto-request/history?limit=50");
+            if (!res.ok) throw new Error("Failed to load auto-request history");
+
+            const data: AutoRequestResponse = await res.json();
+            setItems(data.items);
+            setSummary(data.summary);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load data");
+            setSeerrEnabled(true);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // Seerr not configured
+    if (seerrEnabled === false) {
+        return (
+            <div className="rounded-xl border border-slate-800 bg-gradient-to-br from-slate-900/50 via-slate-900/50 to-slate-900/50 shadow-lg p-5 h-[420px] flex flex-col items-center justify-center text-center gap-3">
+                <Film className="h-8 w-8 text-slate-600" />
+                <div>
+                    <p className="text-sm font-medium text-slate-400">Seerr not configured</p>
+                    <p className="text-xs text-slate-500 mt-1">Configure Seerr in Integrations to enable auto-requests.</p>
+                </div>
+            </div>
+        );
+    }
+
+    const total = summary ? summary.requested + summary.downloaded + summary.failed + summary.already_exists : 0;
+
+    return (
+        <div className="rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 via-slate-900/50 to-slate-900/50 shadow-lg shadow-primary/5 p-5 space-y-4 transition-all duration-300 hover:bg-slate-800/30 h-[420px] flex flex-col">
+            {/* Header */}
+            <div className="flex items-start justify-between gap-3">
+                <div>
+                    <h3 className="text-lg font-bold text-white tracking-tight">Auto-Request Activity</h3>
+                    <p className="text-sm text-slate-400 mt-0.5">Items automatically requested via Seerr.</p>
+                </div>
+                {summary && total > 0 && (
+                    <div className="flex items-center gap-2 text-xs text-slate-400 flex-shrink-0">
+                        {summary.downloaded > 0 && (
+                            <span className="text-emerald-400">{summary.downloaded} downloaded</span>
+                        )}
+                        {summary.requested > 0 && (
+                            <span className="text-blue-400">{summary.requested} pending</span>
+                        )}
+                        {summary.failed > 0 && (
+                            <span className="text-rose-400">{summary.failed} failed</span>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* Loading */}
+            {loading ? (
+                <div className="space-y-3">
+                    {Array.from({ length: 4 }).map((_, idx) => (
+                        <SkeletonItem key={idx} />
+                    ))}
+                </div>
+            ) : error ? (
+                /* Error state */
+                <div className="flex-1 flex flex-col items-center justify-center text-center gap-3">
+                    <AlertCircle className="h-6 w-6 text-rose-400" />
+                    <p className="text-sm text-rose-300">{error}</p>
+                    <button
+                        onClick={loadData}
+                        className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-white transition-colors"
+                    >
+                        <RefreshCw className="h-3.5 w-3.5" />
+                        Retry
+                    </button>
+                </div>
+            ) : items.length === 0 ? (
+                /* Empty state */
+                <div className="rounded-xl border border-slate-800 bg-slate-900/50 px-4 py-6 text-center text-sm text-slate-400">
+                    No auto-requested items yet. Enable auto-request on a source to get started.
+                </div>
+            ) : (
+                /* Items list */
+                <ul className="space-y-2 flex-1 overflow-y-auto scrollbar-hover-only pr-1">
+                    {items.map((item) => (
+                        <li
+                            key={item.id}
+                            className="group flex items-start gap-2.5 rounded-xl border border-slate-800/80 bg-slate-800/30 px-2.5 py-1.5 hover:border-slate-700 hover:bg-slate-800/50 transition-all duration-200"
+                        >
+                            {/* Media type icon */}
+                            <div className="pt-1">
+                                {item.media_type === "movie" ? (
+                                    <Film className="h-3.5 w-3.5 text-slate-400" />
+                                ) : (
+                                    <Tv className="h-3.5 w-3.5 text-slate-400" />
+                                )}
+                            </div>
+
+                            {/* Content */}
+                            <div className="flex-1 min-w-0 space-y-1">
+                                <div className="flex items-center justify-between gap-2">
+                                    <p className="text-sm font-semibold text-white truncate">
+                                        {item.title}
+                                        {item.year && (
+                                            <span className="text-slate-400 font-normal ml-1">({item.year})</span>
+                                        )}
+                                    </p>
+                                    <StatusBadge status={item.status} />
+                                </div>
+
+                                <div className="flex items-center gap-1 text-xs text-slate-400">
+                                    <span className="truncate">{formatSource(item.integration_type, item.source_name)}</span>
+                                    <span className="text-slate-600">·</span>
+                                    <span className="whitespace-nowrap" title={formatTimestamp(item.requested_at)}>
+                                        {timeAgo(item.requested_at)}
+                                    </span>
+                                </div>
+
+                                {item.error_message && (
+                                    <p className="text-xs text-rose-300 leading-relaxed line-clamp-1">
+                                        {item.error_message}
+                                    </p>
+                                )}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/LetterboxdIntegration.tsx
@@ -104,6 +104,8 @@ export function LetterboxdIntegration() {
                                     statuses={integration.statuses}
                                     onSyncSource={integration.syncSource}
                                     onRemoveSource={integration.removeSource}
+                                    onUpdateSource={integration.updateSource}
+                                    showAutoRequest
                                     loadingSources={integration.loadingSources}
                                     syncingSource={integration.syncingSource}
                                     deletingSource={integration.deletingSource}

--- a/homescreen-hero-ui/src/components/integrations/MDBListIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/MDBListIntegration.tsx
@@ -163,6 +163,8 @@ export function MDBListIntegration() {
                 onAddSource={() => integration.addSource()}
                 onSyncSource={integration.syncSource}
                 onRemoveSource={integration.removeSource}
+                onUpdateSource={integration.updateSource}
+                showAutoRequest
                 loadingSources={integration.loadingSources}
                 savingSource={integration.savingSource}
                 syncingSource={integration.syncingSource}

--- a/homescreen-hero-ui/src/components/integrations/TraktIntegration.tsx
+++ b/homescreen-hero-ui/src/components/integrations/TraktIntegration.tsx
@@ -164,6 +164,8 @@ export function TraktIntegration() {
                 onAddSource={() => integration.addSource()}
                 onSyncSource={integration.syncSource}
                 onRemoveSource={integration.removeSource}
+                onUpdateSource={integration.updateSource}
+                showAutoRequest
                 loadingSources={integration.loadingSources}
                 savingSource={integration.savingSource}
                 syncingSource={integration.syncingSource}

--- a/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
-import { RefreshCw, ChevronRight, ChevronLeft, ListPlus } from "lucide-react";
+import { RefreshCw, ChevronRight, ChevronLeft, ListPlus, Send } from "lucide-react";
+import { Switch } from "@headlessui/react";
 import type { Source, SourceStatus, BaseMissingItem, PlexLibraryConfig } from "../../../types/integrations";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 import { LibrarySelect } from "./LibrarySelect";
@@ -11,6 +12,7 @@ export interface SourceListProps<TMissing extends BaseMissingItem> {
     statuses: Map<number, SourceStatus>;
     onSyncSource: (index: number) => void;
     onRemoveSource: (index: number) => void;
+    onUpdateSource?: (index: number, source: Source) => void;
     loadingSources: boolean;
     syncingSource: number | null;
     deletingSource: number | null;
@@ -22,6 +24,7 @@ export interface SourceListProps<TMissing extends BaseMissingItem> {
     onSetMissingPage: (index: number, page: number) => void;
     renderMissingItem: (item: TMissing, index: number) => ReactNode;
     itemsPerPage?: number;
+    showAutoRequest?: boolean;
 }
 
 export function SourceList<TMissing extends BaseMissingItem>(
@@ -32,6 +35,7 @@ export function SourceList<TMissing extends BaseMissingItem>(
         statuses,
         onSyncSource,
         onRemoveSource,
+        onUpdateSource,
         loadingSources,
         syncingSource,
         deletingSource,
@@ -43,6 +47,7 @@ export function SourceList<TMissing extends BaseMissingItem>(
         onSetMissingPage,
         renderMissingItem,
         itemsPerPage = 10,
+        showAutoRequest = false,
     } = props;
 
     if (loadingSources) {
@@ -88,6 +93,7 @@ export function SourceList<TMissing extends BaseMissingItem>(
                         status={status}
                         onSync={() => onSyncSource(idx)}
                         onRemove={() => onRemoveSource(idx)}
+                        onUpdate={onUpdateSource ? (s) => onUpdateSource(idx, s) : undefined}
                         isSyncing={syncingSource === idx}
                         isDeleting={deletingSource === idx}
                         missingItems={missing}
@@ -98,6 +104,7 @@ export function SourceList<TMissing extends BaseMissingItem>(
                         onToggleMissing={() => onToggleMissing(idx)}
                         onSetPage={(page) => onSetMissingPage(idx, page)}
                         renderMissingItem={renderMissingItem}
+                        showAutoRequest={showAutoRequest}
                     />
                 );
             })}
@@ -126,6 +133,7 @@ interface SourceListManagerProps<TMissing extends BaseMissingItem> {
     // Actions
     onSyncSource: (index: number) => void;
     onRemoveSource: (index: number) => void;
+    onUpdateSource?: (index: number, source: Source) => void;
 
     // Loading states
     loadingSources: boolean;
@@ -147,6 +155,9 @@ interface SourceListManagerProps<TMissing extends BaseMissingItem> {
 
     // Optional note (like Letterboxd's scraping disclaimer)
     note?: ReactNode;
+
+    // Auto-request feature (Seerr)
+    showAutoRequest?: boolean;
 }
 
 export function SourceListManager<TMissing extends BaseMissingItem>(
@@ -164,6 +175,7 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
         onAddSource,
         onSyncSource,
         onRemoveSource,
+        onUpdateSource,
         loadingSources,
         savingSource,
         syncingSource,
@@ -177,6 +189,7 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
         renderMissingItem,
         itemsPerPage = 10,
         note,
+        showAutoRequest = false,
     } = props;
 
     const canAdd = newSource.name && newSource.url && newSource.plex_library;
@@ -234,6 +247,7 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
                 statuses={statuses}
                 onSyncSource={onSyncSource}
                 onRemoveSource={onRemoveSource}
+                onUpdateSource={onUpdateSource}
                 loadingSources={loadingSources}
                 syncingSource={syncingSource}
                 deletingSource={deletingSource}
@@ -245,6 +259,7 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
                 onSetMissingPage={onSetMissingPage}
                 renderMissingItem={renderMissingItem}
                 itemsPerPage={itemsPerPage}
+                showAutoRequest={showAutoRequest}
             />
         </div>
     );
@@ -257,6 +272,7 @@ interface SourceCardProps<TMissing> {
     status: SourceStatus | undefined;
     onSync: () => void;
     onRemove: () => void;
+    onUpdate?: (source: Source) => void;
     isSyncing: boolean;
     isDeleting: boolean;
     missingItems: TMissing[] | undefined;
@@ -267,6 +283,7 @@ interface SourceCardProps<TMissing> {
     onToggleMissing: () => void;
     onSetPage: (page: number) => void;
     renderMissingItem: (item: TMissing, index: number) => ReactNode;
+    showAutoRequest?: boolean;
 }
 
 function formatDate(dateString: string | null): string {
@@ -282,6 +299,7 @@ function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMi
         status,
         onSync,
         onRemove,
+        onUpdate,
         isSyncing,
         isDeleting,
         missingItems,
@@ -292,6 +310,7 @@ function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMi
         onToggleMissing,
         onSetPage,
         renderMissingItem,
+        showAutoRequest = false,
     } = props;
 
     const totalPages = missingItems ? Math.ceil(missingItems.length / itemsPerPage) : 0;
@@ -316,6 +335,30 @@ function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMi
                             <p className="text-xs text-slate-500">
                                 Last synced: {formatDate(status.last_sync_time)}
                             </p>
+                        )}
+                        {showAutoRequest && (
+                            <div className="flex items-center gap-2 mt-1">
+                                <Send size={12} className="text-slate-500" />
+                                <span className="text-xs text-slate-400">Auto-request via Seerr</span>
+                                <Switch
+                                    checked={source.auto_request ?? false}
+                                    onChange={() => {
+                                        if (onUpdate) {
+                                            onUpdate({ ...source, auto_request: !source.auto_request });
+                                        }
+                                    }}
+                                    disabled={!onUpdate}
+                                    className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors duration-200 ${
+                                        source.auto_request ? "bg-primary" : "bg-slate-600"
+                                    } ${!onUpdate ? "opacity-50 cursor-not-allowed" : ""}`}
+                                >
+                                    <span
+                                        className={`inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                                            source.auto_request ? "translate-x-4" : "translate-x-0.5"
+                                        }`}
+                                    />
+                                </Switch>
+                            </div>
                         )}
                     </div>
 

--- a/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
@@ -339,7 +339,7 @@ function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMi
                         {showAutoRequest && (
                             <div className="flex items-center gap-2 mt-1">
                                 <Send size={12} className="text-slate-500" />
-                                <span className="text-xs text-slate-400">Auto-request via Seerr</span>
+                                <span className="text-xs text-slate-400">Auto-request missing items via Seerr</span>
                                 <Switch
                                     checked={source.auto_request ?? false}
                                     onChange={() => {

--- a/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SourceListManager.tsx
@@ -1,9 +1,12 @@
-import type { ReactNode } from "react";
-import { RefreshCw, ChevronRight, ChevronLeft, ListPlus, Send } from "lucide-react";
+import { Fragment, type ReactNode } from "react";
+import { RefreshCw, ChevronRight, ChevronLeft, ListPlus, Trash2 } from "lucide-react";
 import { Switch } from "@headlessui/react";
 import type { Source, SourceStatus, BaseMissingItem, PlexLibraryConfig } from "../../../types/integrations";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 import { LibrarySelect } from "./LibrarySelect";
+
+// Grid column template shared by header and rows
+const TABLE_GRID = "md:grid md:grid-cols-[minmax(0,2fr)_140px_150px_180px_80px] md:gap-x-4 md:items-center";
 
 // ─── SourceList (reusable source list without the add form) ─────────────────
 
@@ -56,29 +59,19 @@ export function SourceList<TMissing extends BaseMissingItem>(
 
     if (sources.length === 0) {
         return (
-            <div className="rounded-lg border border-dashed border-slate-700 bg-slate-950/30 px-4 py-6 flex items-center gap-4">
-                <div className="space-y-2 flex-1">
-                    <div className="flex items-center gap-2">
-                        <div className="h-4 w-32 rounded bg-slate-800" />
-                        <div className="h-4 w-16 rounded-full bg-slate-800/60" />
-                    </div>
-                    <div className="h-3 w-56 rounded bg-slate-800/40" />
-                    <div className="h-3 w-28 rounded bg-slate-800/40" />
-                </div>
-                <div className="flex flex-col items-center gap-1.5 px-4">
-                    <ListPlus className="h-7 w-7 text-slate-700" />
-                    <p className="text-sm text-slate-400 whitespace-nowrap">No lists added yet</p>
-                </div>
-                <div className="flex gap-2 flex-1 justify-end">
-                    <div className="h-7 w-20 rounded-lg bg-slate-800/40" />
-                    <div className="h-7 w-16 rounded-lg bg-slate-800/40" />
+            <div className="rounded-lg border border-slate-800/60 overflow-hidden">
+                <SourceTableHeader showAutoRequest={showAutoRequest} />
+                <div className="px-4 py-6 flex items-center justify-center gap-3">
+                    <ListPlus className="h-6 w-6 text-slate-700" />
+                    <p className="text-sm text-slate-400">No lists added yet</p>
                 </div>
             </div>
         );
     }
 
     return (
-        <div className="space-y-3">
+        <div className="rounded-lg border border-slate-800/60 overflow-hidden">
+            <SourceTableHeader showAutoRequest={showAutoRequest} />
             {sources.map((source, idx) => {
                 const status = statuses.get(idx);
                 const missing = missingItems.get(idx);
@@ -87,25 +80,31 @@ export function SourceList<TMissing extends BaseMissingItem>(
                 const currentPage = missingPages.get(idx) || 0;
 
                 return (
-                    <SourceCard
-                        key={`${source.name}-${idx}`}
-                        source={source}
-                        status={status}
-                        onSync={() => onSyncSource(idx)}
-                        onRemove={() => onRemoveSource(idx)}
-                        onUpdate={onUpdateSource ? (s) => onUpdateSource(idx, s) : undefined}
-                        isSyncing={syncingSource === idx}
-                        isDeleting={deletingSource === idx}
-                        missingItems={missing}
-                        isExpanded={isExpanded}
-                        isLoadingMissing={isLoadingMissing}
-                        currentPage={currentPage}
-                        itemsPerPage={itemsPerPage}
-                        onToggleMissing={() => onToggleMissing(idx)}
-                        onSetPage={(page) => onSetMissingPage(idx, page)}
-                        renderMissingItem={renderMissingItem}
-                        showAutoRequest={showAutoRequest}
-                    />
+                    <Fragment key={`${source.name}-${idx}`}>
+                        <SourceTableRow
+                            source={source}
+                            status={status}
+                            onSync={() => onSyncSource(idx)}
+                            onRemove={() => onRemoveSource(idx)}
+                            onUpdate={onUpdateSource ? (s) => onUpdateSource(idx, s) : undefined}
+                            isSyncing={syncingSource === idx}
+                            isDeleting={deletingSource === idx}
+                            isExpanded={isExpanded}
+                            isLoadingMissing={isLoadingMissing}
+                            onToggleMissing={() => onToggleMissing(idx)}
+                            showAutoRequest={showAutoRequest}
+                        />
+                        {isExpanded && (
+                            <ExpandedDetailRow
+                                missingItems={missing}
+                                isLoadingMissing={isLoadingMissing}
+                                currentPage={currentPage}
+                                itemsPerPage={itemsPerPage}
+                                onSetPage={(page) => onSetMissingPage(idx, page)}
+                                renderMissingItem={renderMissingItem}
+                            />
+                        )}
+                    </Fragment>
                 );
             })}
         </div>
@@ -265,9 +264,23 @@ export function SourceListManager<TMissing extends BaseMissingItem>(
     );
 }
 
-// ─── SourceCard (internal) ──────────────────────────────────────────────────
+// ─── Table Header ───────────────────────────────────────────────────────────
 
-interface SourceCardProps<TMissing> {
+function SourceTableHeader({ showAutoRequest }: { showAutoRequest: boolean }) {
+    return (
+        <div className={`hidden ${TABLE_GRID} px-4 py-2.5 text-[11px] font-medium text-slate-500 uppercase tracking-wider border-b border-slate-800/60 bg-slate-900/30`}>
+            <span>List Name & URL</span>
+            <span>Plex Library</span>
+            <span>Last Synced</span>
+            <span>{showAutoRequest ? "Auto-Request" : "Matched"}</span>
+            <span className="text-right">Actions</span>
+        </div>
+    );
+}
+
+// ─── Table Row ──────────────────────────────────────────────────────────────
+
+interface SourceTableRowProps {
     source: Source;
     status: SourceStatus | undefined;
     onSync: () => void;
@@ -275,25 +288,13 @@ interface SourceCardProps<TMissing> {
     onUpdate?: (source: Source) => void;
     isSyncing: boolean;
     isDeleting: boolean;
-    missingItems: TMissing[] | undefined;
     isExpanded: boolean;
     isLoadingMissing: boolean;
-    currentPage: number;
-    itemsPerPage: number;
     onToggleMissing: () => void;
-    onSetPage: (page: number) => void;
-    renderMissingItem: (item: TMissing, index: number) => ReactNode;
-    showAutoRequest?: boolean;
+    showAutoRequest: boolean;
 }
 
-function formatDate(dateString: string | null): string {
-    if (!dateString) return "Never";
-    // Backend stores UTC but without a timezone suffix, so append Z
-    const utcString = dateString.endsWith("Z") ? dateString : dateString + "Z";
-    return new Date(utcString).toLocaleString();
-}
-
-function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMissing>) {
+function SourceTableRow(props: SourceTableRowProps) {
     const {
         source,
         status,
@@ -302,157 +303,280 @@ function SourceCard<TMissing extends BaseMissingItem>(props: SourceCardProps<TMi
         onUpdate,
         isSyncing,
         isDeleting,
-        missingItems,
         isExpanded,
         isLoadingMissing,
-        currentPage,
-        itemsPerPage,
         onToggleMissing,
-        onSetPage,
-        renderMissingItem,
-        showAutoRequest = false,
+        showAutoRequest,
     } = props;
+
+    return (
+        <>
+            {/* Desktop row */}
+            <div className={`hidden ${TABLE_GRID} px-4 py-3 border-b border-slate-800/40 hover:bg-slate-900/30 transition-colors`}>
+                {/* List Name & URL */}
+                <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                        <p className="text-sm font-semibold text-slate-100 truncate">{source.name}</p>
+                        {status && <SyncStatusBadge status={status.sync_status} />}
+                    </div>
+                    <p className="text-xs text-slate-500 truncate mt-0.5">{source.url}</p>
+                </div>
+
+                {/* Plex Library */}
+                <span className="text-xs text-slate-300 truncate">{source.plex_library || "(none)"}</span>
+
+                {/* Last Synced */}
+                <span className="text-xs text-slate-400">{formatDate(status?.last_sync_time ?? null)}</span>
+
+                {/* Auto-Request / Matched */}
+                <AutoRequestCell
+                    source={source}
+                    status={status}
+                    showAutoRequest={showAutoRequest}
+                    onUpdate={onUpdate}
+                    isExpanded={isExpanded}
+                    isLoadingMissing={isLoadingMissing}
+                    onToggleMissing={onToggleMissing}
+                />
+
+                {/* Actions */}
+                <div className="flex items-center justify-end gap-1">
+                    <button
+                        type="button"
+                        onClick={onSync}
+                        disabled={isSyncing}
+                        title="Sync now"
+                        className="p-1.5 rounded-md text-slate-400 hover:text-primary hover:bg-primary/10 transition disabled:opacity-50"
+                    >
+                        <RefreshCw className={`h-4 w-4 ${isSyncing ? "animate-spin" : ""}`} />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onRemove}
+                        disabled={isDeleting}
+                        title="Remove list"
+                        className="p-1.5 rounded-md text-slate-400 hover:text-rose-400 hover:bg-rose-500/10 transition disabled:opacity-50"
+                    >
+                        <Trash2 className="h-4 w-4" />
+                    </button>
+                </div>
+            </div>
+
+            {/* Mobile row */}
+            <div className="md:hidden px-4 py-3 border-b border-slate-800/40 space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                        <p className="text-sm font-semibold text-slate-100 truncate">{source.name}</p>
+                        {status && <SyncStatusBadge status={status.sync_status} />}
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                        <button
+                            type="button"
+                            onClick={onSync}
+                            disabled={isSyncing}
+                            title="Sync now"
+                            className="p-1.5 rounded-md text-slate-400 hover:text-primary hover:bg-primary/10 transition disabled:opacity-50"
+                        >
+                            <RefreshCw className={`h-4 w-4 ${isSyncing ? "animate-spin" : ""}`} />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onRemove}
+                            disabled={isDeleting}
+                            title="Remove list"
+                            className="p-1.5 rounded-md text-slate-400 hover:text-rose-400 hover:bg-rose-500/10 transition disabled:opacity-50"
+                        >
+                            <Trash2 className="h-4 w-4" />
+                        </button>
+                    </div>
+                </div>
+                <p className="text-xs text-slate-500 truncate">{source.url}</p>
+                <div className="flex items-center gap-3 flex-wrap">
+                    <span className="text-xs text-slate-400">{source.plex_library || "(none)"}</span>
+                    <span className="text-xs text-slate-500">
+                        Synced: {formatDate(status?.last_sync_time ?? null)}
+                    </span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <AutoRequestCell
+                        source={source}
+                        status={status}
+                        showAutoRequest={showAutoRequest}
+                        onUpdate={onUpdate}
+                        isExpanded={isExpanded}
+                        isLoadingMissing={isLoadingMissing}
+                        onToggleMissing={onToggleMissing}
+                    />
+                </div>
+            </div>
+        </>
+    );
+}
+
+// ─── Auto-Request Cell ──────────────────────────────────────────────────────
+
+interface AutoRequestCellProps {
+    source: Source;
+    status: SourceStatus | undefined;
+    showAutoRequest: boolean;
+    onUpdate?: (source: Source) => void;
+    isExpanded: boolean;
+    isLoadingMissing: boolean;
+    onToggleMissing: () => void;
+}
+
+function AutoRequestCell(props: AutoRequestCellProps) {
+    const { source, status, showAutoRequest, onUpdate, isExpanded, isLoadingMissing, onToggleMissing } = props;
+
+    if (!showAutoRequest) {
+        // No auto-request: just show the matched chip
+        return (
+            <MatchedChip
+                status={status}
+                isExpanded={isExpanded}
+                isLoading={isLoadingMissing}
+                onClick={onToggleMissing}
+            />
+        );
+    }
+
+    // Auto-request enabled: show toggle + matched chip or "Disabled"
+    return (
+        <div className="flex items-center gap-2">
+            <Switch
+                checked={source.auto_request ?? false}
+                onChange={() => {
+                    if (onUpdate) {
+                        onUpdate({ ...source, auto_request: !source.auto_request });
+                    }
+                }}
+                disabled={!onUpdate}
+                className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 ${
+                    source.auto_request ? "bg-primary" : "bg-slate-600"
+                } ${!onUpdate ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+            >
+                <span
+                    className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                        source.auto_request ? "translate-x-[18px]" : "translate-x-0.5"
+                    }`}
+                />
+            </Switch>
+            <MatchedChip
+                status={status}
+                isExpanded={isExpanded}
+                isLoading={isLoadingMissing}
+                onClick={onToggleMissing}
+            />
+        </div>
+    );
+}
+
+// ─── Matched Chip ───────────────────────────────────────────────────────────
+
+interface MatchedChipProps {
+    status: SourceStatus | undefined;
+    isExpanded: boolean;
+    isLoading: boolean;
+    onClick: () => void;
+}
+
+function MatchedChip({ status, isExpanded, isLoading, onClick }: MatchedChipProps) {
+    if (!status || status.sync_status === "never_synced") {
+        return <span className="text-xs text-slate-600">-</span>;
+    }
+
+    const allMatched = status.items_matched === status.items_total;
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={isLoading}
+            className={`inline-flex w-fit items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium transition cursor-pointer ${
+                allMatched
+                    ? "bg-emerald-900/40 text-emerald-300 border border-emerald-800/50 hover:bg-emerald-900/60"
+                    : "bg-amber-900/30 text-amber-300 border border-amber-800/40 hover:bg-amber-900/50"
+            } disabled:opacity-50`}
+        >
+            <ChevronRight
+                className={`h-3 w-3 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`}
+            />
+            {status.items_matched}/{status.items_total} matched
+        </button>
+    );
+}
+
+// ─── Expanded Detail Row ────────────────────────────────────────────────────
+
+interface ExpandedDetailRowProps<TMissing> {
+    missingItems: TMissing[] | undefined;
+    isLoadingMissing: boolean;
+    currentPage: number;
+    itemsPerPage: number;
+    onSetPage: (page: number) => void;
+    renderMissingItem: (item: TMissing, index: number) => ReactNode;
+}
+
+function ExpandedDetailRow<TMissing extends BaseMissingItem>(
+    props: ExpandedDetailRowProps<TMissing>
+) {
+    const { missingItems, isLoadingMissing, currentPage, itemsPerPage, onSetPage, renderMissingItem } = props;
 
     const totalPages = missingItems ? Math.ceil(missingItems.length / itemsPerPage) : 0;
     const paginatedItems =
         missingItems?.slice(currentPage * itemsPerPage, (currentPage + 1) * itemsPerPage) || [];
 
     return (
-        <div className="rounded-lg border border-slate-800 bg-slate-950/50 overflow-hidden">
-            <div className="p-4 space-y-3">
-                {/* Source info and actions */}
-                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                    <div className="space-y-1 flex-1">
-                        <div className="flex items-center gap-2">
-                            <p className="text-sm font-semibold text-slate-100">{source.name}</p>
-                            {status && <SyncStatusBadge status={status.sync_status} />}
-                        </div>
-                        <p className="text-xs text-slate-400 break-all">{source.url}</p>
-                        <p className="text-xs text-slate-500">
-                            Plex library: {source.plex_library || "(none)"}
-                        </p>
-                        {status?.last_sync_time && (
-                            <p className="text-xs text-slate-500">
-                                Last synced: {formatDate(status.last_sync_time)}
-                            </p>
-                        )}
-                        {showAutoRequest && (
-                            <div className="flex items-center gap-2 mt-1">
-                                <Send size={12} className="text-slate-500" />
-                                <span className="text-xs text-slate-400">Auto-request missing items via Seerr</span>
-                                <Switch
-                                    checked={source.auto_request ?? false}
-                                    onChange={() => {
-                                        if (onUpdate) {
-                                            onUpdate({ ...source, auto_request: !source.auto_request });
-                                        }
-                                    }}
-                                    disabled={!onUpdate}
-                                    className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors duration-200 ${
-                                        source.auto_request ? "bg-primary" : "bg-slate-600"
-                                    } ${!onUpdate ? "opacity-50 cursor-not-allowed" : ""}`}
-                                >
-                                    <span
-                                        className={`inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${
-                                            source.auto_request ? "translate-x-4" : "translate-x-0.5"
-                                        }`}
-                                    />
-                                </Switch>
-                            </div>
-                        )}
+        <div className="border-b border-slate-800/40 bg-slate-900/20 px-4 py-3">
+            {isLoadingMissing ? (
+                <p className="text-xs text-slate-400">Loading missing items…</p>
+            ) : missingItems && missingItems.length > 0 ? (
+                <div className="space-y-2">
+                    <p className="text-xs text-slate-400 mb-2">
+                        {missingItems.length} {missingItems.length === 1 ? "item" : "items"} not found
+                        in Plex
+                    </p>
+                    <div className="space-y-1.5">
+                        {paginatedItems.map((item, i) => renderMissingItem(item, i))}
                     </div>
-
-                    <div className="flex gap-2 flex-wrap">
-                        <button
-                            type="button"
-                            onClick={onSync}
-                            disabled={isSyncing}
-                            className="rounded-lg border border-primary/50 bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary transition hover:bg-primary/20 disabled:opacity-60 flex items-center gap-1"
-                        >
-                            <RefreshCw className={`h-3 w-3 ${isSyncing ? "animate-spin" : ""}`} />
-                            {isSyncing ? "Syncing…" : "Sync Now"}
-                        </button>
-                        <button
-                            type="button"
-                            onClick={onRemove}
-                            disabled={isDeleting}
-                            className="rounded-lg border border-rose-800 px-3 py-1.5 text-xs font-semibold text-rose-100 transition hover:bg-rose-900/40 disabled:opacity-60"
-                        >
-                            {isDeleting ? "Removing…" : "Remove"}
-                        </button>
-                    </div>
-                </div>
-
-                {/* Missing items section */}
-                <div className="pt-3 border-t border-slate-800">
-                    <button
-                        type="button"
-                        onClick={onToggleMissing}
-                        disabled={isLoadingMissing}
-                        className="flex items-center gap-2 text-xs font-medium text-slate-300 hover:text-slate-100 transition disabled:opacity-50"
-                    >
-                        <ChevronRight
-                            className={`h-4 w-4 transition-transform duration-200 ${
-                                isExpanded ? "rotate-90" : ""
-                            }`}
-                        />
-                        Missing items
-                        {status && status.sync_status !== "never_synced" && (
-                            <span className="text-slate-500 font-normal">
-                                · {status.items_matched}/{status.items_total} matched
+                    {totalPages > 1 && (
+                        <div className="flex items-center justify-center gap-3 pt-2">
+                            <button
+                                type="button"
+                                onClick={() => onSetPage(Math.max(0, currentPage - 1))}
+                                disabled={currentPage === 0}
+                                className="p-1 text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded disabled:opacity-50 disabled:cursor-not-allowed transition"
+                                aria-label="Previous page"
+                            >
+                                <ChevronLeft size={16} />
+                            </button>
+                            <span className="text-xs text-slate-400">
+                                Page {currentPage + 1} of {totalPages}
                             </span>
-                        )}
-                    </button>
-
-                    {isExpanded && (
-                        <div className="mt-2 rounded-lg border border-slate-800/60 bg-slate-900/30 p-3">
-                            {isLoadingMissing ? (
-                                <p className="text-xs text-slate-400">Loading missing items…</p>
-                            ) : missingItems && missingItems.length > 0 ? (
-                                <div className="space-y-2">
-                                    <p className="text-xs text-slate-400 mb-2">
-                                        {missingItems.length}{" "}
-                                        {missingItems.length === 1 ? "item" : "items"} not found in
-                                        Plex
-                                    </p>
-                                    <div className="space-y-1.5">
-                                        {paginatedItems.map((item, i) => renderMissingItem(item, i))}
-                                    </div>
-                                    {totalPages > 1 && (
-                                        <div className="flex items-center justify-center gap-3 pt-2">
-                                            <button
-                                                type="button"
-                                                onClick={() => onSetPage(Math.max(0, currentPage - 1))}
-                                                disabled={currentPage === 0}
-                                                className="p-1 text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded disabled:opacity-50 disabled:cursor-not-allowed transition"
-                                                aria-label="Previous page"
-                                            >
-                                                <ChevronLeft size={16} />
-                                            </button>
-                                            <span className="text-xs text-slate-400">
-                                                Page {currentPage + 1} of {totalPages}
-                                            </span>
-                                            <button
-                                                type="button"
-                                                onClick={() =>
-                                                    onSetPage(Math.min(totalPages - 1, currentPage + 1))
-                                                }
-                                                disabled={currentPage >= totalPages - 1}
-                                                className="p-1 text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded disabled:opacity-50 disabled:cursor-not-allowed transition"
-                                                aria-label="Next page"
-                                            >
-                                                <ChevronRight size={16} />
-                                            </button>
-                                        </div>
-                                    )}
-                                </div>
-                            ) : (
-                                <p className="text-xs text-emerald-400">All items found in Plex!</p>
-                            )}
+                            <button
+                                type="button"
+                                onClick={() => onSetPage(Math.min(totalPages - 1, currentPage + 1))}
+                                disabled={currentPage >= totalPages - 1}
+                                className="p-1 text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded disabled:opacity-50 disabled:cursor-not-allowed transition"
+                                aria-label="Next page"
+                            >
+                                <ChevronRight size={16} />
+                            </button>
                         </div>
                     )}
                 </div>
-            </div>
+            ) : (
+                <p className="text-xs text-emerald-400">All items found in Plex!</p>
+            )}
         </div>
     );
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function formatDate(dateString: string | null): string {
+    if (!dateString) return "Never";
+    // Backend stores UTC but without a timezone suffix, so append Z
+    const utcString = dateString.endsWith("Z") ? dateString : dateString + "Z";
+    return new Date(utcString).toLocaleString();
 }

--- a/homescreen-hero-ui/src/components/integrations/shared/SyncStatusBadge.tsx
+++ b/homescreen-hero-ui/src/components/integrations/shared/SyncStatusBadge.tsx
@@ -8,26 +8,26 @@ export function SyncStatusBadge({ status }: SyncStatusBadgeProps) {
     switch (status) {
         case "success":
             return (
-                <span className="inline-flex items-center gap-1 rounded-md bg-emerald-900/50 px-2 py-1 text-xs font-medium text-emerald-100 border border-emerald-700">
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-900/50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-100 border border-emerald-700">
                     Success
                 </span>
             );
         case "error":
             return (
-                <span className="inline-flex items-center gap-1 rounded-md bg-rose-900/50 px-2 py-1 text-xs font-medium text-rose-100 border border-rose-700">
+                <span className="inline-flex items-center gap-1 rounded-full bg-rose-900/50 px-1.5 py-0.5 text-[10px] font-medium text-rose-100 border border-rose-700">
                     Error
                 </span>
             );
         case "pending":
             return (
-                <span className="inline-flex items-center gap-1 rounded-md bg-amber-900/50 px-2 py-1 text-xs font-medium text-amber-100 border border-amber-700">
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-900/50 px-1.5 py-0.5 text-[10px] font-medium text-amber-100 border border-amber-700">
                     Pending
                 </span>
             );
         case "never_synced":
         default:
             return (
-                <span className="inline-flex items-center gap-1 rounded-md bg-slate-800/50 px-2 py-1 text-xs font-medium text-slate-300 border border-slate-700">
+                <span className="inline-flex items-center gap-1 rounded-full bg-slate-800/50 px-1.5 py-0.5 text-[10px] font-medium text-slate-300 border border-slate-700">
                     Never Synced
                 </span>
             );

--- a/homescreen-hero-ui/src/components/tools/CollectionImportExport.tsx
+++ b/homescreen-hero-ui/src/components/tools/CollectionImportExport.tsx
@@ -413,7 +413,9 @@ function ImportTab({
     const [selectedForImport, setSelectedForImport] = useState<Set<string>>(new Set());
     const [importing, setImporting] = useState(false);
     const [importResults, setImportResults] = useState<ImportResult[] | null>(null);
+    const [autoRequestResults, setAutoRequestResults] = useState<{ requested: number; skipped: number; already_exists: number; failed: number } | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const [autoRequest, setAutoRequest] = useState(false);
 
     const hasInput = importMode === "file" ? selectedFile !== null : shareCode.trim().length > 0;
     const canPreview = hasInput && selectedLibrary;
@@ -476,6 +478,9 @@ function ImportTab({
                 if (selected) {
                     url += selected.map((n) => `&selected_collections=${encodeURIComponent(n)}`).join("");
                 }
+                if (autoRequest) {
+                    url += "&auto_request=true";
+                }
                 res = await fetchWithAuth(url, { method: "POST", body: formData });
             } else {
                 res = await fetchWithAuth("/api/collections/io/import/apply/share-code", {
@@ -485,6 +490,7 @@ function ImportTab({
                         share_code: shareCode.trim(),
                         target_library: selectedLibrary,
                         selected_collections: selected,
+                        auto_request: autoRequest,
                     }),
                 });
             }
@@ -492,12 +498,17 @@ function ImportTab({
             if (!res.ok) throw new Error(await res.text());
             const data = await res.json();
             setImportResults(data.collections);
+            setAutoRequestResults(data.auto_request || null);
             setPreviewResults(null);
 
             const totalMatched = data.collections.reduce((s: number, c: ImportResult) => s + c.matched, 0);
             const totalMissing = data.collections.reduce((s: number, c: ImportResult) => s + c.missing, 0);
+            let message = `Imported ${data.collections.length} collection(s): ${totalMatched} items matched, ${totalMissing} missing`;
+            if (data.auto_request?.requested > 0) {
+                message += `, ${data.auto_request.requested} requested via Seerr`;
+            }
             setToast({
-                message: `Imported ${data.collections.length} collection(s): ${totalMatched} items matched, ${totalMissing} missing`,
+                message,
                 type: totalMissing > 0 ? "error" : "success",
             });
         } catch (e: unknown) {
@@ -689,6 +700,31 @@ function ImportTab({
                 </div>
             )}
 
+            {/* Auto-request toggle (shown when preview has missing items) */}
+            {previewResults && previewResults.some((c) => c.missing > 0) && (
+                <label className="flex items-center gap-3 cursor-pointer group">
+                    <div
+                        className={`w-5 h-5 rounded border flex items-center justify-center transition-all ${
+                            autoRequest
+                                ? "bg-primary border-primary"
+                                : "border-slate-600 group-hover:border-slate-500"
+                        }`}
+                    >
+                        {autoRequest && <Check size={14} className="text-white" />}
+                    </div>
+                    <div>
+                        <span className="text-sm text-slate-200">Auto-request missing items</span>
+                        <p className="text-xs text-slate-500">Request missing items via Seerr after import</p>
+                    </div>
+                    <input
+                        type="checkbox"
+                        className="sr-only"
+                        checked={autoRequest}
+                        onChange={(e) => setAutoRequest(e.target.checked)}
+                    />
+                </label>
+            )}
+
             {/* Import results */}
             {importResults && (
                 <div className="space-y-3">
@@ -709,6 +745,11 @@ function ImportTab({
                             </div>
                         ))}
                     </div>
+                    {autoRequestResults && autoRequestResults.requested > 0 && (
+                        <p className="text-xs text-primary">
+                            {autoRequestResults.requested} item{autoRequestResults.requested !== 1 ? "s" : ""} requested via Seerr
+                        </p>
+                    )}
                 </div>
             )}
 

--- a/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
+++ b/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
@@ -385,24 +385,20 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         [basePath]
     );
 
-    // Toggle missing items (load if needed, then expand/collapse)
+    // Toggle missing items (always re-fetch when expanding to avoid stale data)
     const toggleMissingItems = useCallback(
         async (index: number) => {
-            // If already loaded, just toggle visibility
-            if (missingItems.has(index)) {
+            // If expanded, just collapse
+            if (expandedMissing.has(index)) {
                 setExpandedMissing((prev) => {
                     const newSet = new Set(prev);
-                    if (newSet.has(index)) {
-                        newSet.delete(index);
-                    } else {
-                        newSet.add(index);
-                    }
+                    newSet.delete(index);
                     return newSet;
                 });
                 return;
             }
 
-            // Load missing items
+            // Fetch fresh missing items and expand
             try {
                 setLoadingMissing((prev) => new Set(prev).add(index));
 
@@ -422,7 +418,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
                 });
             }
         },
-        [basePath, missingItems]
+        [basePath, expandedMissing]
     );
 
     // Set missing items page

--- a/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
+++ b/homescreen-hero-ui/src/hooks/integrations/useListIntegration.ts
@@ -58,6 +58,7 @@ export interface UseListIntegrationReturn<TSettings, TMissing> {
     newSource: Source;
     setNewSource: React.Dispatch<React.SetStateAction<Source>>;
     addSource: (sourceOverride?: Source) => Promise<boolean>;
+    updateSource: (index: number, source: Source) => Promise<void>;
     removeSource: (index: number) => Promise<void>;
     syncSource: (index: number) => Promise<void>;
     savingSource: boolean;
@@ -283,6 +284,31 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         }
     }, [basePath, newSource]);
 
+    // Update source (e.g., toggle auto_request)
+    const updateSource = useCallback(
+        async (index: number, source: Source) => {
+            try {
+                const r = await fetchWithAuth(`${basePath}/sources/${index}`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(source),
+                });
+
+                if (!r.ok) throw new Error(await extractError(r));
+
+                // Reload sources
+                const refreshR = await fetchWithAuth(`${basePath}/sources`);
+                if (refreshR.ok) {
+                    const refreshedSources: Source[] = await refreshR.json();
+                    setSources(refreshedSources || []);
+                }
+            } catch (e) {
+                setToast({ message: String(e), type: "error" });
+            }
+        },
+        [basePath]
+    );
+
     // Remove source
     const removeSource = useCallback(
         async (index: number) => {
@@ -428,6 +454,7 @@ export function useListIntegration<TSettings, TMissing extends BaseMissingItem>(
         newSource,
         setNewSource,
         addSource,
+        updateSource,
         removeSource,
         syncSource,
         savingSource,

--- a/homescreen-hero-ui/src/pages/DashboardPage.tsx
+++ b/homescreen-hero-ui/src/pages/DashboardPage.tsx
@@ -17,6 +17,7 @@ import RotationStatusCard from "../components/RotationStatusCard";
 import RecentRotationsCard from "../components/RecentRotationsCard";
 import IntegrationsHealthCard from "../components/IntegrationsHealthCard";
 import SeerrCarouselCard from "../components/SeerrCarouselCard";
+import AutoRequestActivityCard from "../components/dashboard/AutoRequestActivityCard";
 import Toast from "../components/Toast";
 import { timeAgo } from "../utils/dates";
 import { fetchWithAuth } from "../utils/api";
@@ -536,6 +537,8 @@ export default function Dashboard() {
                 );
             case "seerr-carousel":
                 return <SeerrCarouselCard key={widgetId} loading={healthLoading} />;
+            case "auto-request-activity":
+                return <AutoRequestActivityCard key={widgetId} />;
             default:
                 return null;
         }

--- a/homescreen-hero-ui/src/types/integrations.ts
+++ b/homescreen-hero-ui/src/types/integrations.ts
@@ -9,6 +9,7 @@ export interface Source {
     url: string;
     plex_library: string;
     max_items?: number;
+    auto_request?: boolean;
 }
 
 // Generic source status (identical for all list-based integrations)

--- a/homescreen-hero-ui/src/widgets/registry.ts
+++ b/homescreen-hero-ui/src/widgets/registry.ts
@@ -94,6 +94,15 @@ export const widgetRegistry: Record<string, WidgetDefinition> = {
         requiresIntegration: "seerr",
         colSpan: 2,
     },
+    "auto-request-activity": {
+        id: "auto-request-activity",
+        name: "Auto-Request Activity",
+        description: "Recent items automatically requested via Seerr",
+        category: "integrations",
+        section: "main",
+        requiresIntegration: "seerr",
+        colSpan: 2,
+    },
 };
 
 // Section configuration

--- a/homescreen_hero/core/collection_io.py
+++ b/homescreen_hero/core/collection_io.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from homescreen_hero.core.db.base import get_session
-from homescreen_hero.core.db.models import ImportMissingItem
+from homescreen_hero.core.db.models import ImportMissingItem, SeerrAutoRequest
 from homescreen_hero.core.integrations.plex_match import (
     build_guid_map,
     find_movie,
@@ -248,6 +248,8 @@ def apply_import(
     target_library: str,
     import_name: Optional[str] = None,
     selected_collections: Optional[list[str]] = None,
+    auto_request: bool = False,
+    config: Optional[Any] = None,
 ) -> dict[str, Any]:
     # Import collections into Plex, creating them and adding matched items
     section = server.library.section(target_library)
@@ -326,7 +328,15 @@ def apply_import(
     # Persist missing items
     _record_import_missing_items(import_name, all_missing)
 
-    return {"collections": results, "import_name": import_name}
+    # Auto-request missing items via Seerr if enabled
+    ar_stats = None
+    if auto_request and all_missing and config:
+        ar_stats = _auto_request_missing_items(config, all_missing, section.type, import_name)
+
+    result = {"collections": results, "import_name": import_name}
+    if ar_stats:
+        result["auto_request"] = ar_stats
+    return result
 
 
 # ------------------------------------------------------------------
@@ -468,6 +478,89 @@ def _record_import_missing_items(
                 session.add(row)
 
         session.commit()
+
+
+def _auto_request_missing_items(
+    config: Any,
+    missing_items: list[dict[str, Any]],
+    library_type: str,
+    import_name: str,
+) -> dict[str, int]:
+    # Request missing import items via Seerr. Returns stats dict.
+    from homescreen_hero.core.integrations.seerr_client import get_seerr_client
+
+    seerr_client = get_seerr_client(config)
+    if seerr_client is None:
+        logger.debug("Seerr not configured; skipping auto-request for import")
+        return {"requested": 0, "skipped": 0, "already_exists": 0, "failed": 0}
+
+    stats = {"requested": 0, "skipped": 0, "already_exists": 0, "failed": 0}
+
+    with get_session() as session:
+        for item in missing_items:
+            tmdb_id = item.get("tmdb_id")
+            if not tmdb_id:
+                continue
+
+            item_type = item.get("type", "movie")
+            media_type = "movie" if item_type == "movie" else "tv"
+
+            # Check if already requested
+            existing = (
+                session.query(SeerrAutoRequest)
+                .filter(
+                    SeerrAutoRequest.tmdb_id == tmdb_id,
+                    SeerrAutoRequest.media_type == media_type,
+                )
+                .first()
+            )
+            if existing:
+                stats["skipped"] += 1
+                continue
+
+            success, error_msg, _response = seerr_client.create_request(
+                media_type=media_type,
+                media_id=tmdb_id,
+            )
+
+            if success:
+                status = "requested"
+                stats["requested"] += 1
+                logger.info(
+                    "Requested %s '%s' (%s) via Seerr [tmdb:%d]",
+                    media_type, item["title"], item.get("year"), tmdb_id,
+                )
+            elif error_msg and "already requested" in error_msg.lower():
+                status = "already_exists"
+                stats["already_exists"] += 1
+            else:
+                status = "failed"
+                stats["failed"] += 1
+                logger.warning(
+                    "Failed to request '%s' (%s) via Seerr: %s",
+                    item["title"], item.get("year"), error_msg,
+                )
+
+            record = SeerrAutoRequest(
+                tmdb_id=tmdb_id,
+                media_type=media_type,
+                title=item["title"],
+                year=item.get("year"),
+                integration_type="import",
+                source_name=import_name,
+                status=status,
+                error_message=error_msg if status == "failed" else None,
+                requested_at=datetime.utcnow(),
+            )
+            session.add(record)
+
+        session.commit()
+
+    logger.info(
+        "Import auto-request: %d requested, %d skipped, %d already exist, %d failed",
+        stats["requested"], stats["skipped"], stats["already_exists"], stats["failed"],
+    )
+    return stats
 
 
 def get_import_missing_items(import_name: Optional[str] = None) -> list[dict[str, Any]]:

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -315,6 +315,10 @@ class LetterboxdSource(BaseModel):
     name: str = Field(..., description="Display name for this list")
     url: str = Field(..., description="Full or short Letterboxd list URL")
     plex_library: str = Field(..., description="Target Plex library name")
+    auto_request: bool = Field(
+        default=False,
+        description="Automatically request missing items via Seerr after sync",
+    )
 
 
 class LetterboxdSettings(BaseModel):

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -288,6 +288,10 @@ class TraktSource(BaseModel):
     name: str
     url: str
     plex_library: str
+    auto_request: bool = Field(
+        default=False,
+        description="Automatically request missing items via Seerr after sync",
+    )
 
 
 class TraktSettings(BaseModel):
@@ -322,6 +326,10 @@ class MDBListSource(BaseModel):
     name: str = Field(..., description="Display name for this list")
     url: str = Field(..., description="MDBList URL (e.g., https://mdblist.com/lists/username/listname)")
     plex_library: str = Field(..., description="Target Plex library name")
+    auto_request: bool = Field(
+        default=False,
+        description="Automatically request missing items via Seerr after sync",
+    )
 
 
 class MDBListSettings(BaseModel):

--- a/homescreen_hero/core/db/history.py
+++ b/homescreen_hero/core/db/history.py
@@ -24,6 +24,7 @@ def init_db() -> None:
     _migrate_collection_analytics(engine)
     _migrate_pinned_collections_visibility(engine)
     _migrate_users_status(engine)
+    _migrate_seerr_auto_requests_downloaded_at(engine)
 
 
 def _migrate_collection_analytics(engine) -> None:
@@ -95,6 +96,25 @@ def _migrate_users_status(engine) -> None:
     logger.info("Migrating users: adding status column")
     with engine.connect() as conn:
         conn.execute(text("ALTER TABLE users ADD COLUMN status VARCHAR NOT NULL DEFAULT 'approved'"))
+        conn.commit()
+
+
+def _migrate_seerr_auto_requests_downloaded_at(engine) -> None:
+    # Add downloaded_at column to seerr_auto_requests if it doesn't exist
+    from sqlalchemy import text, inspect
+
+    inspector = inspect(engine)
+
+    if "seerr_auto_requests" not in inspector.get_table_names():
+        return
+
+    columns = [col["name"] for col in inspector.get_columns("seerr_auto_requests")]
+    if "downloaded_at" in columns:
+        return
+
+    logger.info("Migrating seerr_auto_requests: adding downloaded_at column")
+    with engine.connect() as conn:
+        conn.execute(text("ALTER TABLE seerr_auto_requests ADD COLUMN downloaded_at DATETIME"))
         conn.commit()
 
 

--- a/homescreen_hero/core/db/history.py
+++ b/homescreen_hero/core/db/history.py
@@ -25,6 +25,7 @@ def init_db() -> None:
     _migrate_pinned_collections_visibility(engine)
     _migrate_users_status(engine)
     _migrate_seerr_auto_requests_downloaded_at(engine)
+    _migrate_letterboxd_missing_items_tmdb_id(engine)
 
 
 def _migrate_collection_analytics(engine) -> None:
@@ -115,6 +116,25 @@ def _migrate_seerr_auto_requests_downloaded_at(engine) -> None:
     logger.info("Migrating seerr_auto_requests: adding downloaded_at column")
     with engine.connect() as conn:
         conn.execute(text("ALTER TABLE seerr_auto_requests ADD COLUMN downloaded_at DATETIME"))
+        conn.commit()
+
+
+def _migrate_letterboxd_missing_items_tmdb_id(engine) -> None:
+    # Add tmdb_id column to letterboxd_missing_items if it doesn't exist
+    from sqlalchemy import text, inspect
+
+    inspector = inspect(engine)
+
+    if "letterboxd_missing_items" not in inspector.get_table_names():
+        return
+
+    columns = [col["name"] for col in inspector.get_columns("letterboxd_missing_items")]
+    if "tmdb_id" in columns:
+        return
+
+    logger.info("Migrating letterboxd_missing_items: adding tmdb_id column")
+    with engine.connect() as conn:
+        conn.execute(text("ALTER TABLE letterboxd_missing_items ADD COLUMN tmdb_id INTEGER"))
         conn.commit()
 
 

--- a/homescreen_hero/core/db/history.py
+++ b/homescreen_hero/core/db/history.py
@@ -20,122 +20,46 @@ def init_db() -> None:
     logger.debug("Ensuring database schema is initialized")
     Base.metadata.create_all(bind=engine)
 
-    # Run schema migrations for existing tables
-    _migrate_collection_analytics(engine)
-    _migrate_pinned_collections_visibility(engine)
-    _migrate_users_status(engine)
-    _migrate_seerr_auto_requests_downloaded_at(engine)
-    _migrate_letterboxd_missing_items_tmdb_id(engine)
+    # Auto-add any new columns defined in models but missing from existing tables
+    _auto_migrate_columns(engine, Base)
 
 
-def _migrate_collection_analytics(engine) -> None:
-    # Add media_type column to collection_analytics if it doesn't exist
-    # This handles the case where the table was created before the column was added
-    from sqlalchemy import text, inspect
+def _auto_migrate_columns(engine, Base) -> None:
+    # Compare SQLAlchemy model columns against actual DB and add any missing ones.
+    # create_all() handles new tables; this handles new columns on existing tables.
+    from sqlalchemy import text, inspect as sa_inspect
 
-    inspector = inspect(engine)
+    inspector = sa_inspect(engine)
+    existing_tables = set(inspector.get_table_names())
 
-    # Check if table exists
-    if "collection_analytics" not in inspector.get_table_names():
-        return
+    for table in Base.metadata.sorted_tables:
+        if table.name not in existing_tables:
+            continue
 
-    # Check if column already exists
-    columns = [col["name"] for col in inspector.get_columns("collection_analytics")]
-    if "media_type" in columns:
-        return
+        existing_cols = {col["name"] for col in inspector.get_columns(table.name)}
 
-    logger.info("Migrating collection_analytics: adding media_type column")
-    with engine.connect() as conn:
-        conn.execute(text("ALTER TABLE collection_analytics ADD COLUMN media_type VARCHAR"))
-        conn.commit()
+        for column in table.columns:
+            if column.name in existing_cols:
+                continue
 
+            col_type = column.type.compile(dialect=engine.dialect)
+            sql = f"ALTER TABLE {table.name} ADD COLUMN {column.name} {col_type}"
 
-def _migrate_pinned_collections_visibility(engine) -> None:
-    # Add visibility columns to pinned_collections if they don't exist
-    from sqlalchemy import text, inspect
+            # NOT NULL columns need a DEFAULT for SQLite ALTER TABLE
+            if not column.nullable and column.default is not None:
+                default_val = column.default.arg
+                if not callable(default_val):
+                    if isinstance(default_val, bool):
+                        sql += f" NOT NULL DEFAULT {1 if default_val else 0}"
+                    elif isinstance(default_val, str):
+                        sql += f" NOT NULL DEFAULT '{default_val}'"
+                    elif isinstance(default_val, (int, float)):
+                        sql += f" NOT NULL DEFAULT {default_val}"
 
-    inspector = inspect(engine)
-
-    # Check if table exists
-    if "pinned_collections" not in inspector.get_table_names():
-        return
-
-    # Check which columns need to be added
-    columns = [col["name"] for col in inspector.get_columns("pinned_collections")]
-    columns_to_add = []
-
-    if "visibility_home" not in columns:
-        columns_to_add.append(("visibility_home", "BOOLEAN", "1"))  # default True
-    if "visibility_shared" not in columns:
-        columns_to_add.append(("visibility_shared", "BOOLEAN", "0"))  # default False
-    if "visibility_recommended" not in columns:
-        columns_to_add.append(("visibility_recommended", "BOOLEAN", "0"))  # default False
-
-    if not columns_to_add:
-        return
-
-    logger.info("Migrating pinned_collections: adding visibility columns")
-    with engine.connect() as conn:
-        for col_name, col_type, default_val in columns_to_add:
-            conn.execute(text(f"ALTER TABLE pinned_collections ADD COLUMN {col_name} {col_type} NOT NULL DEFAULT {default_val}"))
-        conn.commit()
-
-
-def _migrate_users_status(engine) -> None:
-    # Add status column to users table if it doesn't exist
-    from sqlalchemy import text, inspect
-
-    inspector = inspect(engine)
-
-    if "users" not in inspector.get_table_names():
-        return
-
-    columns = [col["name"] for col in inspector.get_columns("users")]
-    if "status" in columns:
-        return
-
-    logger.info("Migrating users: adding status column")
-    with engine.connect() as conn:
-        conn.execute(text("ALTER TABLE users ADD COLUMN status VARCHAR NOT NULL DEFAULT 'approved'"))
-        conn.commit()
-
-
-def _migrate_seerr_auto_requests_downloaded_at(engine) -> None:
-    # Add downloaded_at column to seerr_auto_requests if it doesn't exist
-    from sqlalchemy import text, inspect
-
-    inspector = inspect(engine)
-
-    if "seerr_auto_requests" not in inspector.get_table_names():
-        return
-
-    columns = [col["name"] for col in inspector.get_columns("seerr_auto_requests")]
-    if "downloaded_at" in columns:
-        return
-
-    logger.info("Migrating seerr_auto_requests: adding downloaded_at column")
-    with engine.connect() as conn:
-        conn.execute(text("ALTER TABLE seerr_auto_requests ADD COLUMN downloaded_at DATETIME"))
-        conn.commit()
-
-
-def _migrate_letterboxd_missing_items_tmdb_id(engine) -> None:
-    # Add tmdb_id column to letterboxd_missing_items if it doesn't exist
-    from sqlalchemy import text, inspect
-
-    inspector = inspect(engine)
-
-    if "letterboxd_missing_items" not in inspector.get_table_names():
-        return
-
-    columns = [col["name"] for col in inspector.get_columns("letterboxd_missing_items")]
-    if "tmdb_id" in columns:
-        return
-
-    logger.info("Migrating letterboxd_missing_items: adding tmdb_id column")
-    with engine.connect() as conn:
-        conn.execute(text("ALTER TABLE letterboxd_missing_items ADD COLUMN tmdb_id INTEGER"))
-        conn.commit()
+            logger.info("Auto-migrate: %s.%s (%s)", table.name, column.name, col_type)
+            with engine.connect() as conn:
+                conn.execute(text(sql))
+                conn.commit()
 
 
 def record_rotation(

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -113,6 +113,9 @@ class LetterboxdMissingItem(Base):
     slug: Mapped[str] = mapped_column(String, nullable=False)
     letterboxd_url: Mapped[str | None] = mapped_column(String, nullable=True)
 
+    # TMDb ID resolved via Seerr search (for auto-request)
+    tmdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Tracking
     first_seen: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=datetime.utcnow

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -360,3 +360,28 @@ class CollectionDisplayOrder(Base):
     collection_name = Column(String, nullable=False, unique=True, index=True)
     display_order = Column(Integer, nullable=False, default=0, index=True)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class SeerrAutoRequest(Base):
+    # Tracks items automatically requested via Seerr to avoid duplicates
+    __tablename__ = "seerr_auto_requests"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # What was requested
+    tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    media_type: Mapped[str] = mapped_column(String, nullable=False)  # "movie" or "tv"
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    year: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Which source first triggered this request
+    integration_type: Mapped[str] = mapped_column(String, nullable=False)  # "trakt", "mdblist", etc.
+    source_name: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Result
+    status: Mapped[str] = mapped_column(String, nullable=False)  # "requested", "already_exists", "failed"
+    error_message: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )

--- a/homescreen_hero/core/db/models.py
+++ b/homescreen_hero/core/db/models.py
@@ -379,9 +379,10 @@ class SeerrAutoRequest(Base):
     source_name: Mapped[str] = mapped_column(String, nullable=False)
 
     # Result
-    status: Mapped[str] = mapped_column(String, nullable=False)  # "requested", "already_exists", "failed"
+    status: Mapped[str] = mapped_column(String, nullable=False)  # "requested", "already_exists", "failed", "downloaded"
     error_message: Mapped[str | None] = mapped_column(String, nullable=True)
 
     requested_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=datetime.utcnow
     )
+    downloaded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/homescreen_hero/core/integrations/anilist_sync.py
+++ b/homescreen_hero/core/integrations/anilist_sync.py
@@ -294,12 +294,11 @@ def record_missing_items_in_db(
     source: AniListSource,
     missing_items: List[Dict[str, Any]],
 ) -> None:
-    if not missing_items:
-        return
-
     from homescreen_hero.core.db import get_session
 
     with get_session() as session:
+        now = datetime.utcnow()
+
         for m in missing_items:
             anilist_id = m.get("anilist_id")
             title = m.get("title")
@@ -314,7 +313,7 @@ def record_missing_items_in_db(
             ).first()
 
             if existing:
-                existing.last_seen = datetime.utcnow()
+                existing.last_seen = now
                 existing.times_seen += 1
             else:
                 row = AniListMissingItem(
@@ -330,10 +329,17 @@ def record_missing_items_in_db(
                     tmdb_id=m.get("tmdb_id"),
                     imdb_id=m.get("imdb_id"),
                     tvdb_id=m.get("tvdb_id"),
-                    first_seen=datetime.utcnow(),
-                    last_seen=datetime.utcnow(),
+                    first_seen=now,
+                    last_seen=now,
                     times_seen=1,
                 )
                 session.add(row)
+
+        # Remove items no longer missing (not seen in this sync)
+        session.query(AniListMissingItem).filter(
+            AniListMissingItem.source_name == source.name,
+            AniListMissingItem.source_url == source.url,
+            AniListMissingItem.last_seen < now,
+        ).delete()
 
         session.commit()

--- a/homescreen_hero/core/integrations/anilist_sync.py
+++ b/homescreen_hero/core/integrations/anilist_sync.py
@@ -254,7 +254,10 @@ def sync_single_anilist_source(
                 m.get("title"), m.get("year"), m.get("anilist_id"),
             )
 
-    record_missing_items_in_db(source, missing_items)
+    # Skip on empty upstream to avoid wiping previously tracked items
+    # on transient API failures
+    if items:
+        record_missing_items_in_db(source, missing_items)
 
     return total, matched
 

--- a/homescreen_hero/core/integrations/letterboxd_sync.py
+++ b/homescreen_hero/core/integrations/letterboxd_sync.py
@@ -311,4 +311,11 @@ def record_missing_items_in_db(
                 )
                 session.add(new_item)
 
+        # Remove items no longer missing (not seen in this sync)
+        session.query(LetterboxdMissingItem).filter(
+            LetterboxdMissingItem.source_name == source.name,
+            LetterboxdMissingItem.source_url == source.url,
+            LetterboxdMissingItem.last_seen < now,
+        ).delete()
+
         session.commit()

--- a/homescreen_hero/core/integrations/letterboxd_sync.py
+++ b/homescreen_hero/core/integrations/letterboxd_sync.py
@@ -197,8 +197,10 @@ def sync_single_letterboxd_source(
                 m.get("slug"),
             )
 
-    # Persist missing items in the database
-    record_missing_items_in_db(source, missing_items)
+    # Persist missing items in the database (skip on empty upstream to avoid
+    # wiping previously tracked items on transient API failures)
+    if movies:
+        record_missing_items_in_db(source, missing_items)
 
     # Auto-request missing items via Seerr if enabled for this source
     if source.auto_request and missing_items:

--- a/homescreen_hero/core/integrations/letterboxd_sync.py
+++ b/homescreen_hero/core/integrations/letterboxd_sync.py
@@ -200,6 +200,32 @@ def sync_single_letterboxd_source(
     # Persist missing items in the database
     record_missing_items_in_db(source, missing_items)
 
+    # Auto-request missing items via Seerr if enabled for this source
+    if source.auto_request and missing_items:
+        try:
+            from .seerr_resolve import resolve_letterboxd_tmdb_ids
+            resolve_count = resolve_letterboxd_tmdb_ids(config, source.name)
+            if resolve_count:
+                logger.info("Resolved %d TMDb IDs for '%s' via Seerr search", resolve_count, source.name)
+
+            from .seerr_auto_request import process_auto_requests_for_source
+            ar_result = process_auto_requests_for_source(
+                config=config,
+                integration_type="letterboxd",
+                source_name=source.name,
+                library_type=library.type,
+            )
+            logger.info(
+                "Seerr auto-request for '%s': %d requested, %d skipped, %d already exist, %d failed",
+                source.name,
+                ar_result.requested,
+                ar_result.skipped,
+                ar_result.already_exists,
+                ar_result.failed,
+            )
+        except Exception as e:
+            logger.error("Seerr auto-request failed for '%s': %s", source.name, e)
+
     return total, matched
 
 

--- a/homescreen_hero/core/integrations/mal_sync.py
+++ b/homescreen_hero/core/integrations/mal_sync.py
@@ -291,12 +291,11 @@ def record_missing_items_in_db(
     source: MALSource,
     missing_items: List[Dict[str, Any]],
 ) -> None:
-    if not missing_items:
-        return
-
     from homescreen_hero.core.db import get_session
 
     with get_session() as session:
+        now = datetime.utcnow()
+
         for m in missing_items:
             mal_id = m.get("mal_id")
             title = m.get("title")
@@ -311,7 +310,7 @@ def record_missing_items_in_db(
             ).first()
 
             if existing:
-                existing.last_seen = datetime.utcnow()
+                existing.last_seen = now
                 existing.times_seen += 1
             else:
                 row = MALMissingItem(
@@ -327,10 +326,17 @@ def record_missing_items_in_db(
                     tmdb_id=m.get("tmdb_id"),
                     imdb_id=m.get("imdb_id"),
                     tvdb_id=m.get("tvdb_id"),
-                    first_seen=datetime.utcnow(),
-                    last_seen=datetime.utcnow(),
+                    first_seen=now,
+                    last_seen=now,
                     times_seen=1,
                 )
                 session.add(row)
+
+        # Remove items no longer missing (not seen in this sync)
+        session.query(MALMissingItem).filter(
+            MALMissingItem.source_name == source.name,
+            MALMissingItem.source_url == source.url,
+            MALMissingItem.last_seen < now,
+        ).delete()
 
         session.commit()

--- a/homescreen_hero/core/integrations/mal_sync.py
+++ b/homescreen_hero/core/integrations/mal_sync.py
@@ -251,7 +251,10 @@ def sync_single_mal_source(
                 m.get("title"), m.get("year"), m.get("mal_id"),
             )
 
-    record_missing_items_in_db(source, missing_items)
+    # Skip on empty upstream to avoid wiping previously tracked items
+    # on transient API failures
+    if items:
+        record_missing_items_in_db(source, missing_items)
 
     return total, matched
 

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -250,13 +250,13 @@ def record_missing_items_in_db(
     source: MDBListSource,
     missing_items: list[dict[str, any]],
 ) -> None:
-    # Store/update records for MDBList titles that weren't found in Plex library
-    if not missing_items:
-        return
-
+    # Store/update records for MDBList titles that weren't found in Plex library,
+    # and remove any previously-missing items that are now matched.
     from homescreen_hero.core.db import get_session
 
     with get_session() as session:
+        now = datetime.utcnow()
+
         for m in missing_items:
             imdb_id = m.get("imdb_id")
             tmdb_id = m.get("tmdb_id")
@@ -283,7 +283,7 @@ def record_missing_items_in_db(
             existing = query.first()
 
             if existing:
-                existing.last_seen = datetime.utcnow()
+                existing.last_seen = now
                 existing.times_seen += 1
             else:
                 row = MDBListMissingItem(
@@ -297,10 +297,17 @@ def record_missing_items_in_db(
                     tmdb_id=tmdb_id,
                     trakt_id=trakt_id,
                     mdblist_id=mdblist_id,
-                    first_seen=datetime.utcnow(),
-                    last_seen=datetime.utcnow(),
+                    first_seen=now,
+                    last_seen=now,
                     times_seen=1,
                 )
                 session.add(row)
+
+        # Remove items no longer missing (not seen in this sync)
+        session.query(MDBListMissingItem).filter(
+            MDBListMissingItem.source_name == source.name,
+            MDBListMissingItem.source_url == source.url,
+            MDBListMissingItem.last_seen < now,
+        ).delete()
 
         session.commit()

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -173,8 +173,10 @@ def sync_single_mdblist_source(
                 m.get("tmdb_id"),
             )
 
-    # Also persist them in the database
-    record_missing_items_in_db(source, missing_items)
+    # Persist missing items in the database (skip on empty upstream to avoid
+    # wiping previously tracked items on transient API failures)
+    if items:
+        record_missing_items_in_db(source, missing_items)
 
     # Auto-request missing items via Seerr if enabled for this source
     if source.auto_request and missing_items:

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -173,6 +173,27 @@ def sync_single_mdblist_source(
     # Also persist them in the database
     record_missing_items_in_db(source, missing_items)
 
+    # Auto-request missing items via Seerr if enabled for this source
+    if source.auto_request and missing_items:
+        try:
+            from .seerr_auto_request import process_auto_requests_for_source
+            ar_result = process_auto_requests_for_source(
+                config=config,
+                integration_type="mdblist",
+                source_name=source.name,
+                library_type=library.type,
+            )
+            logger.info(
+                "Seerr auto-request for '%s': %d requested, %d skipped, %d already exist, %d failed",
+                source.name,
+                ar_result.requested,
+                ar_result.skipped,
+                ar_result.already_exists,
+                ar_result.failed,
+            )
+        except Exception as e:
+            logger.error("Seerr auto-request failed for '%s': %s", source.name, e)
+
     return total, matched
 
 

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -89,6 +89,7 @@ def sync_single_mdblist_source(
     existing_ids = {item.ratingKey for item in existing_collection_items}
 
     matched_items = []
+    matched_tmdb_ids: set[int] = set()
     missing_items: List[Dict[str, Any]] = []
 
     for item in items:
@@ -106,6 +107,8 @@ def sync_single_mdblist_source(
 
         if plex_item is not None:
             matched_items.append(plex_item)
+            if tmdb_id:
+                matched_tmdb_ids.add(tmdb_id)
         else:
             missing_items.append(
                 {
@@ -193,6 +196,17 @@ def sync_single_mdblist_source(
             )
         except Exception as e:
             logger.error("Seerr auto-request failed for '%s': %s", source.name, e)
+
+    # Mark previously-requested items as downloaded if they now exist in Plex
+    if source.auto_request and matched_tmdb_ids:
+        try:
+            from .seerr_auto_request import mark_auto_requests_downloaded
+            media_type = "movie" if library.type == "movie" else "tv"
+            downloaded = mark_auto_requests_downloaded(matched_tmdb_ids, media_type)
+            if downloaded:
+                logger.info("Marked %d auto-requested items as downloaded for '%s'", downloaded, source.name)
+        except Exception as e:
+            logger.error("Failed to mark downloaded items for '%s': %s", source.name, e)
 
     return total, matched
 

--- a/homescreen_hero/core/integrations/seerr_auto_request.py
+++ b/homescreen_hero/core/integrations/seerr_auto_request.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+import logging
+
+from homescreen_hero.core.config.schema import AppConfig
+from homescreen_hero.core.db.models import SeerrAutoRequest, TraktMissingItem, MDBListMissingItem
+from homescreen_hero.core.integrations.seerr_client import get_seerr_client
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AutoRequestResult:
+    requested: int = 0
+    skipped: int = 0       # already requested previously
+    already_exists: int = 0  # Seerr says already requested/available (409)
+    failed: int = 0
+    no_tmdb_id: int = 0
+
+
+# Map integration type to its missing item model class
+_MISSING_ITEM_MODELS = {
+    "trakt": TraktMissingItem,
+    "mdblist": MDBListMissingItem,
+}
+
+
+def process_auto_requests_for_source(
+    config: AppConfig,
+    integration_type: str,
+    source_name: str,
+    library_type: str,
+) -> AutoRequestResult:
+    # Send Seerr requests for missing items from a synced source.
+    # library_type is the Plex library type ("movie" or "show").
+    result = AutoRequestResult()
+
+    seerr_client = get_seerr_client(config)
+    if seerr_client is None:
+        logger.debug("Seerr not configured; skipping auto-request for '%s'", source_name)
+        return result
+
+    model_cls = _MISSING_ITEM_MODELS.get(integration_type)
+    if model_cls is None:
+        logger.warning("No missing item model for integration type '%s'", integration_type)
+        return result
+
+    media_type = "movie" if library_type == "movie" else "tv"
+
+    from homescreen_hero.core.db import get_session
+
+    with get_session() as session:
+        # Get all missing items for this source that have a TMDb ID
+        missing_items = (
+            session.query(model_cls)
+            .filter(
+                model_cls.source_name == source_name,
+                model_cls.tmdb_id.isnot(None),
+            )
+            .all()
+        )
+
+        if not missing_items:
+            logger.debug("No missing items with TMDb IDs for source '%s'", source_name)
+            return result
+
+        for item in missing_items:
+            tmdb_id = item.tmdb_id
+
+            # Check if we already requested this
+            existing = (
+                session.query(SeerrAutoRequest)
+                .filter(
+                    SeerrAutoRequest.tmdb_id == tmdb_id,
+                    SeerrAutoRequest.media_type == media_type,
+                )
+                .first()
+            )
+
+            if existing:
+                result.skipped += 1
+                continue
+
+            # Send request to Seerr
+            success, error_msg, _response = seerr_client.create_request(
+                media_type=media_type,
+                media_id=tmdb_id,
+            )
+
+            if success:
+                status = "requested"
+                result.requested += 1
+                logger.info(
+                    "Requested %s '%s' (%s) via Seerr [tmdb:%d]",
+                    media_type, item.title, item.year, tmdb_id,
+                )
+            elif error_msg and "already requested" in error_msg.lower():
+                status = "already_exists"
+                result.already_exists += 1
+                logger.debug(
+                    "Already requested/available in Seerr: '%s' (%s) [tmdb:%d]",
+                    item.title, item.year, tmdb_id,
+                )
+            else:
+                status = "failed"
+                result.failed += 1
+                logger.warning(
+                    "Failed to request '%s' (%s) via Seerr: %s",
+                    item.title, item.year, error_msg,
+                )
+
+            # Record the request attempt
+            record = SeerrAutoRequest(
+                tmdb_id=tmdb_id,
+                media_type=media_type,
+                title=item.title,
+                year=item.year,
+                integration_type=integration_type,
+                source_name=source_name,
+                status=status,
+                error_message=error_msg if status == "failed" else None,
+                requested_at=datetime.utcnow(),
+            )
+            session.add(record)
+
+        session.commit()
+
+    return result
+
+
+def process_all_auto_requests(config: AppConfig) -> dict[str, AutoRequestResult]:
+    # Process auto-requests for all sources across all integrations that have auto_request enabled.
+    # Returns a dict of source_name -> AutoRequestResult.
+    from homescreen_hero.core.integrations.plex_client import get_plex_server
+
+    results: dict[str, AutoRequestResult] = {}
+
+    seerr_client = get_seerr_client(config)
+    if seerr_client is None:
+        logger.info("Seerr not configured; skipping all auto-requests")
+        return results
+
+    server = get_plex_server(config)
+
+    # Trakt sources
+    if config.trakt and config.trakt.enabled and config.trakt.sources:
+        for source in config.trakt.sources:
+            if not source.auto_request:
+                continue
+            try:
+                library = server.library.section(source.plex_library)
+                result = process_auto_requests_for_source(
+                    config=config,
+                    integration_type="trakt",
+                    source_name=source.name,
+                    library_type=library.type,
+                )
+                results[f"trakt:{source.name}"] = result
+            except Exception as e:
+                logger.error("Auto-request failed for Trakt source '%s': %s", source.name, e)
+                results[f"trakt:{source.name}"] = AutoRequestResult(failed=-1)
+
+    # MDBList sources
+    if config.mdblist and config.mdblist.enabled and config.mdblist.sources:
+        for source in config.mdblist.sources:
+            if not source.auto_request:
+                continue
+            try:
+                library = server.library.section(source.plex_library)
+                result = process_auto_requests_for_source(
+                    config=config,
+                    integration_type="mdblist",
+                    source_name=source.name,
+                    library_type=library.type,
+                )
+                results[f"mdblist:{source.name}"] = result
+            except Exception as e:
+                logger.error("Auto-request failed for MDBList source '%s': %s", source.name, e)
+                results[f"mdblist:{source.name}"] = AutoRequestResult(failed=-1)
+
+    return results

--- a/homescreen_hero/core/integrations/seerr_auto_request.py
+++ b/homescreen_hero/core/integrations/seerr_auto_request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Set
 
 import logging
 
@@ -130,6 +130,37 @@ def process_auto_requests_for_source(
         session.commit()
 
     return result
+
+
+def mark_auto_requests_downloaded(tmdb_ids: Set[int], media_type: str) -> int:
+    # Mark previously-requested items as downloaded when they appear in Plex.
+    # Returns the number of rows updated.
+    if not tmdb_ids:
+        return 0
+
+    from homescreen_hero.core.db import get_session
+
+    with get_session() as session:
+        rows = (
+            session.query(SeerrAutoRequest)
+            .filter(
+                SeerrAutoRequest.tmdb_id.in_(tmdb_ids),
+                SeerrAutoRequest.media_type == media_type,
+                SeerrAutoRequest.status == "requested",
+            )
+            .all()
+        )
+
+        for row in rows:
+            row.status = "downloaded"
+            row.downloaded_at = datetime.utcnow()
+            logger.info(
+                "Marked auto-request as downloaded: '%s' (%s) [tmdb:%d]",
+                row.title, row.year, row.tmdb_id,
+            )
+
+        session.commit()
+        return len(rows)
 
 
 def process_all_auto_requests(config: AppConfig) -> dict[str, AutoRequestResult]:

--- a/homescreen_hero/core/integrations/seerr_auto_request.py
+++ b/homescreen_hero/core/integrations/seerr_auto_request.py
@@ -7,7 +7,7 @@ from typing import Optional, Set
 import logging
 
 from homescreen_hero.core.config.schema import AppConfig
-from homescreen_hero.core.db.models import SeerrAutoRequest, TraktMissingItem, MDBListMissingItem
+from homescreen_hero.core.db.models import SeerrAutoRequest, TraktMissingItem, MDBListMissingItem, LetterboxdMissingItem
 from homescreen_hero.core.integrations.seerr_client import get_seerr_client
 
 logger = logging.getLogger(__name__)
@@ -26,6 +26,7 @@ class AutoRequestResult:
 _MISSING_ITEM_MODELS = {
     "trakt": TraktMissingItem,
     "mdblist": MDBListMissingItem,
+    "letterboxd": LetterboxdMissingItem,
 }
 
 
@@ -212,5 +213,27 @@ def process_all_auto_requests(config: AppConfig) -> dict[str, AutoRequestResult]
             except Exception as e:
                 logger.error("Auto-request failed for MDBList source '%s': %s", source.name, e)
                 results[f"mdblist:{source.name}"] = AutoRequestResult(failed=-1)
+
+    # Letterboxd sources
+    if config.letterboxd and config.letterboxd.sources:
+        for source in config.letterboxd.sources:
+            if not source.auto_request:
+                continue
+            try:
+                library = server.library.section(source.plex_library)
+                # Resolve TMDb IDs via Seerr search before requesting
+                from homescreen_hero.core.integrations.seerr_resolve import resolve_letterboxd_tmdb_ids
+                resolve_letterboxd_tmdb_ids(config, source.name)
+
+                result = process_auto_requests_for_source(
+                    config=config,
+                    integration_type="letterboxd",
+                    source_name=source.name,
+                    library_type=library.type,
+                )
+                results[f"letterboxd:{source.name}"] = result
+            except Exception as e:
+                logger.error("Auto-request failed for Letterboxd source '%s': %s", source.name, e)
+                results[f"letterboxd:{source.name}"] = AutoRequestResult(failed=-1)
 
     return results

--- a/homescreen_hero/core/integrations/seerr_resolve.py
+++ b/homescreen_hero/core/integrations/seerr_resolve.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import logging
+
+from homescreen_hero.core.config.schema import AppConfig
+from homescreen_hero.core.db.models import LetterboxdMissingItem
+from homescreen_hero.core.integrations.seerr_client import get_seerr_client, SeerrClient
+
+logger = logging.getLogger(__name__)
+
+
+def _match_tmdb_id_from_seerr(
+    seerr_client: SeerrClient,
+    title: str,
+    year: Optional[int],
+) -> Optional[int]:
+    # Search Seerr for a movie by title and return the TMDb ID of the best match.
+    response = seerr_client.search(title)
+    results = response.get("results", [])
+
+    # Letterboxd is movie-only
+    movie_results = [r for r in results if r.get("mediaType") == "movie"]
+
+    if not movie_results:
+        return None
+
+    # If we have a year, prefer an exact year match
+    if year:
+        for result in movie_results:
+            release_date = result.get("releaseDate", "")
+            if release_date and release_date.startswith(str(year)):
+                return result.get("id")
+
+    # Fall back to first movie result (Seerr ranks by relevance)
+    return movie_results[0].get("id")
+
+
+def resolve_letterboxd_tmdb_ids(config: AppConfig, source_name: str) -> int:
+    # Resolve TMDb IDs for Letterboxd missing items that don't have one yet.
+    # Uses Seerr search to find the TMDb ID from title + year.
+    # Returns the number of items successfully resolved.
+    seerr_client = get_seerr_client(config)
+    if seerr_client is None:
+        logger.debug("Seerr not configured; skipping TMDb ID resolution for '%s'", source_name)
+        return 0
+
+    from homescreen_hero.core.db import get_session
+
+    resolved = 0
+
+    with get_session() as session:
+        items = (
+            session.query(LetterboxdMissingItem)
+            .filter(
+                LetterboxdMissingItem.source_name == source_name,
+                LetterboxdMissingItem.tmdb_id.is_(None),
+            )
+            .all()
+        )
+
+        if not items:
+            logger.debug("No unresolved Letterboxd items for source '%s'", source_name)
+            return 0
+
+        logger.info("Resolving TMDb IDs for %d Letterboxd items via Seerr search", len(items))
+
+        for item in items:
+            tmdb_id = _match_tmdb_id_from_seerr(seerr_client, item.title, item.year)
+
+            if tmdb_id is not None:
+                item.tmdb_id = tmdb_id
+                resolved += 1
+                logger.debug(
+                    "Resolved '%s' (%s) -> tmdb:%d",
+                    item.title, item.year, tmdb_id,
+                )
+            else:
+                logger.debug(
+                    "Could not resolve TMDb ID for '%s' (%s)",
+                    item.title, item.year,
+                )
+
+        session.commit()
+
+    logger.info("Resolved %d/%d TMDb IDs for Letterboxd source '%s'", resolved, len(items), source_name)
+    return resolved

--- a/homescreen_hero/core/integrations/trakt_sync.py
+++ b/homescreen_hero/core/integrations/trakt_sync.py
@@ -163,8 +163,10 @@ def sync_single_trakt_source(
                 m.get("ids"),
             )
 
-    # Persist missing items in the database
-    record_missing_items_in_db(source, missing_items)
+    # Persist missing items in the database (skip on empty upstream to avoid
+    # wiping previously tracked items on transient API failures)
+    if items:
+        record_missing_items_in_db(source, missing_items)
 
     # Auto-request missing items via Seerr if enabled for this source
     if source.auto_request and missing_items:

--- a/homescreen_hero/core/integrations/trakt_sync.py
+++ b/homescreen_hero/core/integrations/trakt_sync.py
@@ -240,13 +240,13 @@ def record_missing_items_in_db(
     source: TraktSource,
     missing_items: list[dict[str, any]],
 ) -> None:
-    # Store/update records for Trakt titles that weren't found in Plex library
-    if not missing_items:
-        return
-
+    # Store/update records for Trakt titles that weren't found in Plex library,
+    # and remove any previously-missing items that are now matched.
     from homescreen_hero.core.db import get_session
 
     with get_session() as session:
+        now = datetime.utcnow()
+
         for m in missing_items:
             ids = m.get("ids") or {}
             trakt_id = ids.get("trakt")
@@ -269,7 +269,7 @@ def record_missing_items_in_db(
             existing = query.first()
 
             if existing:
-                existing.last_seen = datetime.utcnow()
+                existing.last_seen = now
                 existing.times_seen += 1
             else:
                 row = TraktMissingItem(
@@ -283,10 +283,17 @@ def record_missing_items_in_db(
                     slug=slug,
                     imdb_id=imdb_id,
                     tmdb_id=tmdb_id,
-                    first_seen=datetime.utcnow(),
-                    last_seen=datetime.utcnow(),
+                    first_seen=now,
+                    last_seen=now,
                     times_seen=1,
                 )
                 session.add(row)
+
+        # Remove items no longer missing (not seen in this sync)
+        session.query(TraktMissingItem).filter(
+            TraktMissingItem.source_name == source.name,
+            TraktMissingItem.source_url == source.url,
+            TraktMissingItem.last_seen < now,
+        ).delete()
 
         session.commit()

--- a/homescreen_hero/core/integrations/trakt_sync.py
+++ b/homescreen_hero/core/integrations/trakt_sync.py
@@ -80,6 +80,7 @@ def sync_single_trakt_source(
     existing_ids = {item.ratingKey for item in existing_collection_items}
 
     matched_items = []
+    matched_tmdb_ids: set[int] = set()
     missing_items: List[Dict[str, Any]] = []
 
     for item in items:
@@ -102,6 +103,8 @@ def sync_single_trakt_source(
 
         if plex_item is not None:
             matched_items.append(plex_item)
+            if ids.get("tmdb"):
+                matched_tmdb_ids.add(ids["tmdb"])
         else:
             missing_items.append(
                 {
@@ -183,6 +186,17 @@ def sync_single_trakt_source(
             )
         except Exception as e:
             logger.error("Seerr auto-request failed for '%s': %s", source.name, e)
+
+    # Mark previously-requested items as downloaded if they now exist in Plex
+    if source.auto_request and matched_tmdb_ids:
+        try:
+            from .seerr_auto_request import mark_auto_requests_downloaded
+            media_type = "movie" if library.type == "movie" else "tv"
+            downloaded = mark_auto_requests_downloaded(matched_tmdb_ids, media_type)
+            if downloaded:
+                logger.info("Marked %d auto-requested items as downloaded for '%s'", downloaded, source.name)
+        except Exception as e:
+            logger.error("Failed to mark downloaded items for '%s': %s", source.name, e)
 
     return total, matched
 

--- a/homescreen_hero/core/integrations/trakt_sync.py
+++ b/homescreen_hero/core/integrations/trakt_sync.py
@@ -151,8 +151,6 @@ def sync_single_trakt_source(
         missing,
     )
 
-    # Logs missing item from Trakt Collection
-    # Future plan: automatically send requests to Sonarr/Radarr to add them
     if missing_items:
         for m in missing_items:
             logger.debug(
@@ -162,8 +160,29 @@ def sync_single_trakt_source(
                 m.get("ids"),
             )
 
-    # Also persist them in the database
+    # Persist missing items in the database
     record_missing_items_in_db(source, missing_items)
+
+    # Auto-request missing items via Seerr if enabled for this source
+    if source.auto_request and missing_items:
+        try:
+            from .seerr_auto_request import process_auto_requests_for_source
+            ar_result = process_auto_requests_for_source(
+                config=config,
+                integration_type="trakt",
+                source_name=source.name,
+                library_type=library.type,
+            )
+            logger.info(
+                "Seerr auto-request for '%s': %d requested, %d skipped, %d already exist, %d failed",
+                source.name,
+                ar_result.requested,
+                ar_result.skipped,
+                ar_result.already_exists,
+                ar_result.failed,
+            )
+        except Exception as e:
+            logger.error("Seerr auto-request failed for '%s': %s", source.name, e)
 
     return total, matched
 

--- a/homescreen_hero/web/routers/collection_io.py
+++ b/homescreen_hero/web/routers/collection_io.py
@@ -50,6 +50,7 @@ class ImportApplyShareCodeRequest(BaseModel):
     target_library: str
     import_name: Optional[str] = None
     selected_collections: Optional[List[str]] = None
+    auto_request: bool = False
 
 
 class CollectionImportResult(BaseModel):
@@ -68,6 +69,7 @@ class ImportPreviewResponse(BaseModel):
 class ImportApplyResponse(BaseModel):
     collections: List[CollectionImportResult]
     import_name: str
+    auto_request: Optional[dict] = None
 
 
 class MissingItemsResponse(BaseModel):
@@ -188,6 +190,7 @@ async def import_apply_file(
     target_library: str,
     import_name: Optional[str] = None,
     selected_collections: Optional[List[str]] = Query(None),
+    auto_request: bool = False,
     file: UploadFile = File(...),
     _current_user: CurrentUser = Depends(require_admin),
 ) -> ImportApplyResponse:
@@ -208,6 +211,8 @@ async def import_apply_file(
             server, import_data, target_library,
             import_name=import_name,
             selected_collections=selected_collections,
+            auto_request=auto_request,
+            config=config,
         )
     except Exception as e:
         logger.error("Import apply failed: %s", e)
@@ -216,6 +221,7 @@ async def import_apply_file(
     return ImportApplyResponse(
         collections=result["collections"],
         import_name=result["import_name"],
+        auto_request=result.get("auto_request"),
     )
 
 
@@ -237,6 +243,8 @@ def import_apply_share_code(
             server, import_data, request.target_library,
             import_name=request.import_name,
             selected_collections=request.selected_collections,
+            auto_request=request.auto_request,
+            config=config,
         )
     except Exception as e:
         logger.error("Import apply failed: %s", e)
@@ -245,6 +253,7 @@ def import_apply_share_code(
     return ImportApplyResponse(
         collections=result["collections"],
         import_name=result["import_name"],
+        auto_request=result.get("auto_request"),
     )
 
 

--- a/homescreen_hero/web/routers/integrations.py
+++ b/homescreen_hero/web/routers/integrations.py
@@ -262,6 +262,19 @@ class AutoRequestHistoryItem(BaseModel):
     status: str
     error_message: Optional[str] = None
     requested_at: datetime
+    downloaded_at: Optional[datetime] = None
+
+
+class AutoRequestSummary(BaseModel):
+    requested: int = 0
+    downloaded: int = 0
+    failed: int = 0
+    already_exists: int = 0
+
+
+class AutoRequestHistoryResponse(BaseModel):
+    items: List[AutoRequestHistoryItem]
+    summary: AutoRequestSummary
 
 
 @router.post("/auto-request", response_model=AutoRequestResponse)
@@ -309,16 +322,32 @@ def trigger_auto_requests(
     return AutoRequestResponse(ok=True, message=message, results=results)
 
 
-@router.get("/auto-request/history", response_model=List[AutoRequestHistoryItem])
+@router.get("/auto-request/history", response_model=AutoRequestHistoryResponse)
 def get_auto_request_history(
     limit: int = Query(default=50, ge=1, le=200),
     current_user: CurrentUser = Depends(require_admin),
-) -> List[AutoRequestHistoryItem]:
-    # Get recent auto-request records
+) -> AutoRequestHistoryResponse:
+    # Get recent auto-request records with summary stats
     from ...core.db import get_session
     from ...core.db.models import SeerrAutoRequest
+    from sqlalchemy import func
 
     with get_session() as session:
+        # Summary counts across all records
+        counts = (
+            session.query(SeerrAutoRequest.status, func.count(SeerrAutoRequest.id))
+            .group_by(SeerrAutoRequest.status)
+            .all()
+        )
+        count_map = dict(counts)
+        summary = AutoRequestSummary(
+            requested=count_map.get("requested", 0),
+            downloaded=count_map.get("downloaded", 0),
+            failed=count_map.get("failed", 0),
+            already_exists=count_map.get("already_exists", 0),
+        )
+
+        # Recent items
         records = (
             session.query(SeerrAutoRequest)
             .order_by(SeerrAutoRequest.requested_at.desc())
@@ -326,7 +355,7 @@ def get_auto_request_history(
             .all()
         )
 
-        return [
+        items = [
             AutoRequestHistoryItem(
                 id=r.id,
                 tmdb_id=r.tmdb_id,
@@ -338,6 +367,9 @@ def get_auto_request_history(
                 status=r.status,
                 error_message=r.error_message,
                 requested_at=r.requested_at,
+                downloaded_at=r.downloaded_at,
             )
             for r in records
         ]
+
+    return AutoRequestHistoryResponse(items=items, summary=summary)

--- a/homescreen_hero/web/routers/integrations.py
+++ b/homescreen_hero/web/routers/integrations.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from ...core.auth import CurrentUser, get_current_user, require_admin
@@ -231,3 +231,113 @@ def get_integrations_health(
         overall_status=overall_status,
         integrations=integrations,
     )
+
+
+# ========================================================================
+# AUTO-REQUEST VIA SEERR
+# ========================================================================
+
+class AutoRequestSourceResult(BaseModel):
+    requested: int = 0
+    skipped: int = 0
+    already_exists: int = 0
+    failed: int = 0
+    no_tmdb_id: int = 0
+
+
+class AutoRequestResponse(BaseModel):
+    ok: bool
+    message: str
+    results: Dict[str, AutoRequestSourceResult] = {}
+
+
+class AutoRequestHistoryItem(BaseModel):
+    id: int
+    tmdb_id: int
+    media_type: str
+    title: str
+    year: Optional[int] = None
+    integration_type: str
+    source_name: str
+    status: str
+    error_message: Optional[str] = None
+    requested_at: datetime
+
+
+@router.post("/auto-request", response_model=AutoRequestResponse)
+def trigger_auto_requests(
+    current_user: CurrentUser = Depends(require_admin),
+) -> AutoRequestResponse:
+    # Manually trigger auto-requests for all sources with auto_request enabled
+    from ...core.config.loader import load_config
+    from ...core.integrations.seerr_auto_request import process_all_auto_requests
+
+    try:
+        config = load_config()
+    except Exception as exc:
+        return AutoRequestResponse(ok=False, message=f"Config load failed: {exc}")
+
+    try:
+        raw_results = process_all_auto_requests(config)
+    except Exception as exc:
+        logger.error("Auto-request processing failed: %s", exc, exc_info=True)
+        return AutoRequestResponse(ok=False, message=f"Auto-request failed: {exc}")
+
+    results = {
+        key: AutoRequestSourceResult(
+            requested=r.requested,
+            skipped=r.skipped,
+            already_exists=r.already_exists,
+            failed=r.failed,
+            no_tmdb_id=r.no_tmdb_id,
+        )
+        for key, r in raw_results.items()
+    }
+
+    total_requested = sum(r.requested for r in raw_results.values())
+    total_failed = sum(r.failed for r in raw_results.values())
+
+    if not raw_results:
+        message = "No sources have auto-request enabled"
+    elif total_failed and not total_requested:
+        message = f"All requests failed ({total_failed} failures)"
+    else:
+        message = f"Requested {total_requested} items via Seerr"
+        if total_failed:
+            message += f" ({total_failed} failures)"
+
+    return AutoRequestResponse(ok=True, message=message, results=results)
+
+
+@router.get("/auto-request/history", response_model=List[AutoRequestHistoryItem])
+def get_auto_request_history(
+    limit: int = Query(default=50, ge=1, le=200),
+    current_user: CurrentUser = Depends(require_admin),
+) -> List[AutoRequestHistoryItem]:
+    # Get recent auto-request records
+    from ...core.db import get_session
+    from ...core.db.models import SeerrAutoRequest
+
+    with get_session() as session:
+        records = (
+            session.query(SeerrAutoRequest)
+            .order_by(SeerrAutoRequest.requested_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+        return [
+            AutoRequestHistoryItem(
+                id=r.id,
+                tmdb_id=r.tmdb_id,
+                media_type=r.media_type,
+                title=r.title,
+                year=r.year,
+                integration_type=r.integration_type,
+                source_name=r.source_name,
+                status=r.status,
+                error_message=r.error_message,
+                requested_at=r.requested_at,
+            )
+            for r in records
+        ]


### PR DESCRIPTION
## Feature: Auto-Request Missing Items via Seerr

### Summary
When syncing lists or importing collections, items not found in Plex can now be a**utomatically requested through Seerr**. Each list source gets its own toggle, and a new dashboard widget keeps you in the loop on what's been requested.

### Major Changes
- Per-source auto-request toggle for **Trakt**, **MDBList**, and **Letterboxd** lists. Missing items get sent to Seerr after each sync (when enabled)
- Auto-request option during collection imports, shown when the preview has missing items.
- New "Auto-Request Activity" dashboard widget with summary stats and recent request history (WIP)

### Minor Changes
- Refactored layout of individual list records across integration pages.
- Replaced manual DB migrations with a generic auto-migrate system.

### Notes
- DB migration runs automatically on startup.
- AniList and MAL don't support auto-request since anime isn't a typical Seerr use case.