### PR TITLE
Feature: Per-User Collection Targeting

### DIFF
--- a/homescreen-hero-ui/src/components/UserTargetingSelector.tsx
+++ b/homescreen-hero-ui/src/components/UserTargetingSelector.tsx
@@ -1,0 +1,126 @@
+import { Listbox } from "@headlessui/react";
+import { Check, ChevronDown, Loader2, Users } from "lucide-react";
+import type { PlexUser } from "../hooks/useTargetableUsers";
+
+type Props = {
+    mode: "everyone" | "specific";
+    selectedUsernames: string[];
+    users: PlexUser[];
+    loading: boolean;
+    onModeChange: (mode: "everyone" | "specific") => void;
+    onSelectionChange: (usernames: string[]) => void;
+};
+
+export function UserTargetingSelector({
+    mode,
+    selectedUsernames,
+    users,
+    loading,
+    onModeChange,
+    onSelectionChange,
+}: Props) {
+    const selectedCount = selectedUsernames.length;
+
+    return (
+        <div className="space-y-3">
+            <div className="flex items-center gap-2">
+                <Users className="h-4 w-4 text-primary" />
+                <label className="text-base font-medium text-white">Audience</label>
+            </div>
+            <p className="text-xs text-slate-400">Choose who can see collections from this group.</p>
+
+            {/* Everyone / Specific Users toggle */}
+            <div className="grid grid-cols-2 gap-2">
+                {(["everyone", "specific"] as const).map((opt) => {
+                    const isSelected = mode === opt;
+                    const label = opt === "everyone" ? "Everyone" : "Specific Users";
+                    return (
+                        <button
+                            key={opt}
+                            type="button"
+                            onClick={() => onModeChange(opt)}
+                            className={`flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 transition-all duration-200 ${
+                                isSelected
+                                    ? "border-primary bg-primary/15"
+                                    : "border-slate-700 bg-slate-900 hover:border-slate-600"
+                            }`}
+                        >
+                            <span className={`text-sm font-medium ${isSelected ? "text-white" : "text-slate-300"}`}>
+                                {label}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            {/* Multi-select dropdown (animated expand/collapse) */}
+            <div
+                className={`grid transition-all duration-300 ease-in-out ${
+                    mode === "specific" ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                }`}
+            >
+                <div className={mode === "specific" ? "overflow-visible" : "overflow-hidden"}>
+                    <div className="pt-1">
+                        {loading ? (
+                            <div className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2.5">
+                                <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                                <span className="text-sm text-slate-400">Loading users...</span>
+                            </div>
+                        ) : (
+                            <Listbox
+                                value={selectedUsernames}
+                                onChange={onSelectionChange}
+                                multiple
+                            >
+                                <div className="relative">
+                                    <Listbox.Button className="flex items-center gap-2 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2.5 text-sm text-white hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-primary/70 transition-colors">
+                                        <span className="flex-1 text-left">
+                                            {selectedCount === 0
+                                                ? <span className="text-slate-500">No users selected</span>
+                                                : `${selectedCount} user${selectedCount === 1 ? "" : "s"} selected`
+                                            }
+                                        </span>
+                                        <ChevronDown className="h-4 w-4 text-slate-400" />
+                                    </Listbox.Button>
+                                    <Listbox.Options className="absolute left-0 z-10 mt-1 w-full max-h-48 overflow-y-auto scrollbar-thin rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg focus:outline-none">
+                                        {users.length === 0 ? (
+                                            <div className="px-3 py-2 text-sm text-slate-400">No users found</div>
+                                        ) : (
+                                            users.map((user) => (
+                                                <Listbox.Option
+                                                    key={user.id}
+                                                    value={user.username}
+                                                    className="cursor-pointer px-3 py-2 text-sm text-white hover:bg-slate-700 flex items-center gap-2.5"
+                                                >
+                                                    {user.thumb ? (
+                                                        <img
+                                                            src={user.thumb}
+                                                            alt=""
+                                                            className="h-6 w-6 rounded-full object-cover shrink-0"
+                                                        />
+                                                    ) : (
+                                                        <div className="h-6 w-6 rounded-full bg-slate-600 flex items-center justify-center shrink-0">
+                                                            <span className="text-xs text-slate-300">
+                                                                {(user.title || user.username).charAt(0).toUpperCase()}
+                                                            </span>
+                                                        </div>
+                                                    )}
+                                                    <span className="flex-1 truncate">
+                                                        {user.title || user.username}
+                                                    </span>
+                                                    {selectedUsernames.includes(user.username) && (
+                                                        <Check className="h-4 w-4 text-primary shrink-0" />
+                                                    )}
+                                                </Listbox.Option>
+                                            ))
+                                        )}
+                                    </Listbox.Options>
+                                </div>
+                            </Listbox>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/homescreen-hero-ui/src/components/tools/ClearUserTargeting.tsx
+++ b/homescreen-hero-ui/src/components/tools/ClearUserTargeting.tsx
@@ -27,7 +27,7 @@ export default function ClearUserTargeting({ onClose }: ClearUserTargetingProps)
     const [confirming, setConfirming] = useState(false);
     const [result, setResult] = useState<ClearResult | null>(null);
     const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
-    const confirmTimeout = useRef<ReturnType<typeof setTimeout>>();
+    const confirmTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
 
     // Reset confirm state after 3 seconds
     useEffect(() => {

--- a/homescreen-hero-ui/src/components/tools/ClearUserTargeting.tsx
+++ b/homescreen-hero-ui/src/components/tools/ClearUserTargeting.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect, useRef } from "react";
+import { Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { fetchWithAuth } from "../../utils/api";
+import Toast from "../Toast";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogFooter,
+    DialogTitle,
+    DialogDescription,
+    DialogCloseButton,
+} from "@/components/ui/dialog";
+
+type ClearUserTargetingProps = {
+    onClose: () => void;
+};
+
+type ClearResult = {
+    labels_removed: number;
+    collections_cleaned: number;
+    filters_cleaned: number;
+};
+
+export default function ClearUserTargeting({ onClose }: ClearUserTargetingProps) {
+    const [clearing, setClearing] = useState(false);
+    const [confirming, setConfirming] = useState(false);
+    const [result, setResult] = useState<ClearResult | null>(null);
+    const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+    const confirmTimeout = useRef<ReturnType<typeof setTimeout>>();
+
+    // Reset confirm state after 3 seconds
+    useEffect(() => {
+        if (confirming) {
+            confirmTimeout.current = setTimeout(() => setConfirming(false), 3000);
+            return () => clearTimeout(confirmTimeout.current);
+        }
+    }, [confirming]);
+
+    const handleClear = async () => {
+        setClearing(true);
+        try {
+            const r = await fetchWithAuth("/api/admin/user-targeting/clear-all", {
+                method: "POST",
+            });
+            if (!r.ok) {
+                const text = await r.text();
+                throw new Error(text || "Failed to clear targeting");
+            }
+            const data = await r.json();
+            setResult({
+                labels_removed: data.labels_removed,
+                collections_cleaned: data.collections_cleaned,
+                filters_cleaned: data.filters_cleaned,
+            });
+            setToast({ message: "All user targeting cleared", type: "success" });
+        } catch (e) {
+            setToast({ message: String(e), type: "error" });
+        } finally {
+            setClearing(false);
+        }
+    };
+
+    return (
+        <>
+            <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+                <DialogContent className="!max-w-lg">
+                    <DialogHeader>
+                        <div>
+                            <DialogTitle>Clear User Targeting</DialogTitle>
+                            <DialogDescription>
+                                Remove all user targeting labels and user filter settings.
+                            </DialogDescription>
+                        </div>
+                        <DialogCloseButton />
+                    </DialogHeader>
+
+                    <div className="space-y-4 p-6">
+                        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+                            <div className="flex items-start gap-2.5">
+                                <AlertTriangle className="h-4 w-4 text-amber-400 mt-0.5 shrink-0" />
+                                <p className="text-sm text-slate-300">
+                                    Removes all per-user targeting labels from every collection and reset all user filter settings. Groups with <strong>Specific Users</strong> selected will re-apply labels on the next rotation.
+                                </p>
+                            </div>
+                        </div>
+
+                        {result && (
+                            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+                                <div className="flex items-center gap-2.5 mb-3">
+                                    <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />
+                                    <p className="text-sm font-medium text-emerald-300">Targeting cleared successfully</p>
+                                </div>
+                                <div className="grid grid-cols-3 gap-3">
+                                    <div className="text-center">
+                                        <p className="text-lg font-semibold text-white">{result.labels_removed}</p>
+                                        <p className="text-xs text-slate-400">label{result.labels_removed !== 1 ? "s" : ""} removed</p>
+                                    </div>
+                                    <div className="text-center">
+                                        <p className="text-lg font-semibold text-white">{result.collections_cleaned}</p>
+                                        <p className="text-xs text-slate-400">collection{result.collections_cleaned !== 1 ? "s" : ""}</p>
+                                    </div>
+                                    <div className="text-center">
+                                        <p className="text-lg font-semibold text-white">{result.filters_cleaned}</p>
+                                        <p className="text-xs text-slate-400">filter{result.filters_cleaned !== 1 ? "s" : ""} cleaned</p>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+
+                    <DialogFooter>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="rounded-lg border border-slate-700 bg-slate-800 px-4 py-2 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-colors"
+                        >
+                            {result ? "Done" : "Cancel"}
+                        </button>
+                        {!result && (
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    if (confirming) {
+                                        setConfirming(false);
+                                        handleClear();
+                                    } else {
+                                        setConfirming(true);
+                                    }
+                                }}
+                                disabled={clearing}
+                                className={`rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 transition-colors flex items-center gap-2 ${
+                                    confirming
+                                        ? "bg-red-600 hover:bg-red-500"
+                                        : "bg-amber-600 hover:bg-amber-500"
+                                }`}
+                            >
+                                {clearing && <Loader2 className="h-4 w-4 animate-spin" />}
+                                {clearing ? "Clearing..." : confirming ? "Click to Confirm" : "Clear All Targeting"}
+                            </button>
+                        )}
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+{toast && (
+                <Toast
+                    message={toast.message}
+                    type={toast.type}
+                    onClose={() => setToast(null)}
+                />
+            )}
+        </>
+    );
+}

--- a/homescreen-hero-ui/src/hooks/useTargetableUsers.ts
+++ b/homescreen-hero-ui/src/hooks/useTargetableUsers.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { fetchWithAuth } from "../utils/api";
+
+export type PlexUser = {
+    id: number;
+    username: string;
+    title: string;
+    thumb: string | null;
+    is_home: boolean;
+    is_admin: boolean;
+};
+
+export function useTargetableUsers() {
+    const [users, setUsers] = useState<PlexUser[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        fetchWithAuth("/api/admin/plex-users")
+            .then(async (r) => {
+                if (!r.ok) throw new Error(await r.text());
+                return r.json();
+            })
+            .then((data: { users: PlexUser[] }) => {
+                if (!isMounted) return;
+                // Filter out admin - they always see everything
+                setUsers(data.users.filter((u) => !u.is_admin));
+            })
+            .catch(() => {
+                // Silently fail - not critical for page load
+            })
+            .finally(() => {
+                if (isMounted) setLoading(false);
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
+    return { users, loading };
+}

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -16,6 +16,8 @@ import {
 } from "../components/ui/sheet";
 import { Slider } from "../components/ui/slider";
 import { getGroupStatus } from "../utils/dates";
+import { useTargetableUsers } from "../hooks/useTargetableUsers";
+import { UserTargetingSelector } from "../components/UserTargetingSelector";
 
 
 type DateRange = {
@@ -38,6 +40,7 @@ type CollectionGroup = {
     collection_order?: "random" | "alpha" | null;
     collection_sort?: "release" | "alpha" | null;
     date_range?: DateRange | null;
+    target_users?: string[] | null;
     collections: string[];
 };
 
@@ -94,6 +97,7 @@ const emptyGroup: CollectionGroup = {
     collection_order: null,
     collection_sort: null,
     date_range: null,
+    target_users: null,
     collections: [],
 };
 
@@ -128,6 +132,7 @@ export default function GroupDetailPage() {
     const [initialLoad, setInitialLoad] = useState(true);
     const savedFormRef = useRef<string>("");
     const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+    const { users: targetableUsers, loading: targetableUsersLoading } = useTargetableUsers();
     const itemsPerPage = 24; // 4 columns × 6 rows
 
     useEffect(() => {
@@ -208,6 +213,8 @@ export default function GroupDetailPage() {
                 ...formToSave,
                 date_range: formToSave.date_range?.start && formToSave.date_range?.end
                     ? formToSave.date_range : null,
+                // Empty target_users list means "everyone" - send null so backend removes the field
+                target_users: formToSave.target_users?.length ? formToSave.target_users : null,
             };
             const r = await fetchWithAuth(`/api/admin/config/groups/${index}`, {
                 method: "PUT",
@@ -1011,6 +1018,28 @@ export default function GroupDetailPage() {
                                 />
                             </div>
                         </div>
+
+                        <hr className="border-slate-700/50" />
+
+                        {/* Audience */}
+                        <UserTargetingSelector
+                            mode={form.target_users ? "specific" : "everyone"}
+                            selectedUsernames={form.target_users ?? []}
+                            users={targetableUsers}
+                            loading={targetableUsersLoading}
+                            onModeChange={(mode) => {
+                                setForm((p) => ({
+                                    ...p,
+                                    target_users: mode === "everyone" ? null : [],
+                                }));
+                            }}
+                            onSelectionChange={(usernames) => {
+                                setForm((p) => ({
+                                    ...p,
+                                    target_users: usernames.length > 0 ? usernames : [],
+                                }));
+                            }}
+                        />
 
                         <hr className="border-slate-700/50" />
 

--- a/homescreen-hero-ui/src/pages/ToolsPage.tsx
+++ b/homescreen-hero-ui/src/pages/ToolsPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { Calendar, Wrench, History, FileSearch, Users, ArrowLeftRight } from "lucide-react";
+import { Calendar, Wrench, History, FileSearch, Users, ArrowLeftRight, ShieldOff } from "lucide-react";
 import ToolCard from "../components/tools/ToolCard";
 import DateAddedEditor from "../components/tools/DateAddedEditor";
 import WatchHistoryCleaner from "../components/tools/WatchHistoryCleaner";
 import UnwatchedReport from "../components/tools/UnwatchedReport";
 import CopyWatchHistory from "../components/tools/CopyWatchHistory";
 import CollectionImportExport from "../components/tools/CollectionImportExport";
+import ClearUserTargeting from "../components/tools/ClearUserTargeting";
 
 type Tool = {
     id: string;
@@ -44,6 +45,12 @@ const tools: Tool[] = [
         title: "Collection Import / Export",
         description: "Share collection contents via JSON file or share code",
         icon: ArrowLeftRight,
+    },
+    {
+        id: "clear-user-targeting",
+        title: "Clear User Targeting Labels",
+        description: "Remove all hsh-hide labels and reset user filter settings",
+        icon: ShieldOff,
     },
 ];
 
@@ -96,6 +103,9 @@ export default function ToolsPage() {
             )}
             {activeTool === "collection-import-export" && (
                 <CollectionImportExport onClose={() => setActiveTool(null)} />
+            )}
+            {activeTool === "clear-user-targeting" && (
+                <ClearUserTargeting onClose={() => setActiveTool(null)} />
             )}
         </div>
     );

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -223,6 +223,10 @@ class CollectionGroupConfig(BaseModel):
         default_factory=list,
         description="Smart group filter rules (only used when smart=True)",
     )
+    target_users: Optional[List[str]] = Field(
+        default=None,
+        description="Plex usernames who should see this group's collections. None = everyone.",
+    )
     collections: List[str] = Field(
         default_factory=list,
         description="List of Plex collection names belonging to this group (ignored when smart=True)",

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -525,17 +525,56 @@ def get_plex_account(config: AppConfig) -> MyPlexAccount:
     return MyPlexAccount(token=config.plex.token)
 
 
-def get_home_users(config: AppConfig) -> List[Dict[str, Any]]:
-    # Return list of home users with id, username, title, thumb, is_admin
-    # Note: For managed users, username may be empty - use title for switchHomeUser()
+def get_all_plex_users(config: AppConfig) -> List[Dict[str, Any]]:
+    # Return all Plex users (friends + home) with id, username, title, thumb, is_home, is_admin
+    # Used by user targeting to compute exclusion sets
     account = get_plex_account(config)
     users = []
 
-    # Include the main account owner
-    # Use title as the primary identifier for consistency with managed users
+    # Admin account
     users.append({
         "id": account.id,
-        "username": account.title or account.username,  # Use title as username for consistency
+        "username": account.username or account.title,
+        "title": account.title or account.username,
+        "thumb": account.thumb,
+        "is_home": True,
+        "is_admin": True,
+    })
+
+    skipped = 0
+    for user in account.users():
+        # Skip users with no active server access (old/removed friends, pending invites)
+        servers = getattr(user, "servers", []) or []
+        if not servers or all(getattr(s, "pending", False) for s in servers):
+            skipped += 1
+            continue
+
+        username = getattr(user, "username", "") or ""
+        title = getattr(user, "title", "") or ""
+        users.append({
+            "id": user.id,
+            "username": username or title,  # Fall back to title for managed users
+            "title": title or username,
+            "thumb": getattr(user, "thumb", None),
+            "is_home": bool(getattr(user, "home", False)),
+            "is_admin": False,
+        })
+
+    if skipped:
+        logger.debug(f"Skipped {skipped} users with no active server access")
+    logger.debug(f"Found {len(users)} total Plex users")
+    return users
+
+
+def get_home_users(config: AppConfig) -> List[Dict[str, Any]]:
+    # Return list of home users with id, username, title, thumb, is_admin
+    account = get_plex_account(config)
+    users = []
+
+    # Include server owner account (unsure how I plan to handle admin account labels, will come back)
+    users.append({
+        "id": account.id,
+        "username": account.title or account.username,
         "title": account.title or account.username,
         "thumb": account.thumb,
         "is_admin": True,
@@ -558,28 +597,23 @@ def get_home_users(config: AppConfig) -> List[Dict[str, Any]]:
 
 def get_server_for_user(config: AppConfig, username: str) -> PlexServer:
     # Get PlexServer authenticated as a specific home user
-    # Uses switchHomeUser to switch context, then connects via resource
     account = get_plex_account(config)
 
-    # If it's the admin account, just return normal server
+    # Just return normal server if it's my admin account
     if username == account.username or username == account.title:
         return get_plex_server(config)
 
-    # Switch to the home user's context
+    # Switch to the home user
     logger.debug(f"Switching to home user: {username}")
     user_account = account.switchHomeUser(username)
 
-    # Find the server resource and connect
-    # For managed users, we need to go through the resource to get proper auth
     for resource in user_account.resources():
         if resource.product == "Plex Media Server":
             try:
-                # Try to connect - it will use the best available connection
                 logger.debug(f"Connecting to server as {username} via resource")
                 return resource.connect(timeout=30)
             except Exception as e:
                 logger.warning(f"Failed to connect via resource: {e}")
-                # If that fails, try forcing the configured base_url
                 try:
                     logger.debug(f"Retrying with configured base_url")
                     return PlexServer(config.plex.base_url, resource.accessToken, session=_make_session())

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -364,6 +364,16 @@ def run_rotation_once(
         collection_sort=collection_sort,
     )
 
+    # Apply per-user targeting labels and sync filter settings
+    if not dry_run:
+        try:
+            from .user_targeting import apply_rotation_targeting, sync_all_user_filters
+            apply_rotation_targeting(server, config, applied, smart_group_collections)
+            # Sync user filter settings so Plex actually hides labeled collections
+            sync_all_user_filters(config)
+        except Exception as e:
+            logger.error("Failed to apply user targeting: %s", e, exc_info=True)
+
     group_contributions = {
         g.group_name: g.chosen_collections
         for g in rotation_result.groups
@@ -557,6 +567,14 @@ def apply_simulation(
         dry_run=False,
         smart_group_collections=smart_group_collections,
     )
+
+    # Apply per-user targeting labels and sync filter settings
+    try:
+        from .user_targeting import apply_rotation_targeting, sync_all_user_filters
+        apply_rotation_targeting(server, config, applied, smart_group_collections)
+        sync_all_user_filters(config)
+    except Exception as e:
+        logger.error("Failed to apply user targeting: %s", e, exc_info=True)
 
     # Record in db as a real rotation in history
     sim_group_contributions = {

--- a/homescreen_hero/core/user_targeting.py
+++ b/homescreen_hero/core/user_targeting.py
@@ -41,31 +41,23 @@ def sync_all_user_filters(config: AppConfig) -> None:
         needs_filter = username.lower() in excluded_usernames
 
         try:
-            current = _read_current_filters(account, user)
+            current = _read_current_filters(account, username, user_id)
+            if current is None:
+                logger.warning(f"Could not read filters for {username}, skipping to avoid data loss")
+                continue
 
             if needs_filter:
                 label = _make_hide_label(username)
                 new_movies = _merge_hsh_filter(current.get("filterMovies", ""), [label])
                 new_tv = _merge_hsh_filter(current.get("filterTelevision", ""), [label])
             else:
-                # No targeting applies to this user, clean any leftover hsh filters
                 new_movies = _clean_hsh_filter(current.get("filterMovies", ""))
                 new_tv = _clean_hsh_filter(current.get("filterTelevision", ""))
 
-            # Always push - the read can return stale data so skip-if-unchanged is unreliable
-            success = False
-            if username and username != user.get("title", ""):
-                success = _set_user_filter_v2(account, username, new_movies, new_tv)
-                if success:
-                    action = "Set" if needs_filter else "Cleaned"
-                    logger.info(f"{action} filters for {username} via V2 API")
-                    continue
-
-            # V1 fallback for managed users
-            success = _set_user_filter_v1(account, user_id, new_movies, new_tv)
-            if success:
+            existing_music = current.get("filterMusic", "")
+            if _set_user_filter(account, username, user_id, new_movies, new_tv, existing_music):
                 action = "Set" if needs_filter else "Cleaned"
-                logger.info(f"{action} filters for {username} (id={user_id}) via V1 API")
+                logger.info(f"{action} filters for {username}")
             else:
                 logger.warning(f"Failed to sync filters for {username} (id={user_id})")
 
@@ -105,9 +97,7 @@ def clear_all_targeting(config: AppConfig) -> Dict[str, int]:
         except Exception as e:
             logger.error(f"Failed to clear labels from '{lib.name}': {e}")
 
-    # Clean user filter settings. We read current filters to preserve non-hsh filters,
-    # but always push the cleaned result (no skip-if-unchanged) because the read can
-    # return stale/empty data while Plex still has the restriction applied.
+    # Clean user filter settings, preserving any non-hsh filters
     filters_cleaned = 0
     account = get_plex_account(config)
     all_users = get_all_plex_users(config)
@@ -119,18 +109,16 @@ def clear_all_targeting(config: AppConfig) -> Dict[str, int]:
             username = user["username"]
             user_id = user["id"]
 
-            current = _read_current_filters(account, user)
+            current = _read_current_filters(account, username, user_id)
+            if current is None:
+                logger.warning(f"Could not read filters for {username}, skipping to avoid data loss")
+                continue
+
             clean_movies = _clean_hsh_filter(current.get("filterMovies", ""))
             clean_tv = _clean_hsh_filter(current.get("filterTelevision", ""))
+            existing_music = current.get("filterMusic", "")
 
-            success = False
-            if username and username != user.get("title", ""):
-                success = _set_user_filter_v2(account, username, clean_movies, clean_tv)
-
-            if not success:
-                success = _set_user_filter_v1(account, user_id, clean_movies, clean_tv)
-
-            if success:
+            if _set_user_filter(account, username, user_id, clean_movies, clean_tv, existing_music):
                 filters_cleaned += 1
                 logger.info(f"Cleared filters for {username}")
             else:
@@ -249,20 +237,31 @@ def _remove_hsh_labels(collection) -> None:
             collection.removeLabel(label.tag)
 
 
-def _read_current_filters(account, user: Dict[str, Any]) -> Dict[str, str]:
-    # Read a users current filter settings from Plex
-    try:
-        user_sharing = account.user(user["title"])
-        result = {"filterMovies": "", "filterTelevision": ""}
-        for section in user_sharing.servers[0].sections():
-            if hasattr(section, "filterMovies") and section.filterMovies:
-                result["filterMovies"] = section.filterMovies
-            if hasattr(section, "filterTelevision") and section.filterTelevision:
-                result["filterTelevision"] = section.filterTelevision
-        return result
-    except Exception as e:
-        logger.debug(f"Could not read current filters for {user['username']}: {e}")
-        return {"filterMovies": "", "filterTelevision": ""}
+def _read_current_filters(account, username: str, user_id: int) -> Optional[Dict[str, str]]:
+    # Read current filter settings from the V2 API.
+    # Tries invitedEmail first, falls back to invitedId for managed users.
+    base_url = (
+        "https://clients.plex.tv/api/v2/sharing_settings"
+        "?X-Plex-Product=Homescreen+Hero"
+        "&X-Plex-Client-Identifier=homescreen-hero"
+    )
+    headers = {"Accept": "application/json", "X-Plex-Token": account._token}
+
+    for param in [f"invitedEmail={username}", f"invitedId={user_id}"]:
+        try:
+            resp = requests.get(f"{base_url}&{param}", headers=headers)
+            if resp.status_code == 200:
+                data = resp.json()
+                return {
+                    "filterMovies": data.get("filterMovies", "") or "",
+                    "filterTelevision": data.get("filterTelevision", "") or "",
+                    "filterMusic": data.get("filterMusic", "") or "",
+                }
+        except Exception as e:
+            logger.debug(f"V2 read failed for {username} ({param}): {e}")
+
+    logger.warning(f"Could not read filters for {username} (id={user_id}) via V2 API")
+    return None
 
 
 def _merge_hsh_filter(existing_filter: str, hsh_labels: List[str]) -> str:
@@ -323,55 +322,38 @@ def _clean_hsh_filter(existing_filter: str) -> str:
     return "&".join(result_parts)
 
 
-def _set_user_filter_v2(
-    account, username: str, filter_movies: str, filter_tv: str
+def _set_user_filter(
+    account, username: str, user_id: int,
+    filter_movies: str, filter_tv: str, filter_music: str = "",
 ) -> bool:
-    # V2 API: POST clients.plex.tv/api/v2/sharing_settings (doesn't work for shared users, I'm pretty sure)
+    # Set user filter settings via V2 API.
+    # Tries invitedEmail first, falls back to invitedId for managed users.
     url = (
         "https://clients.plex.tv/api/v2/sharing_settings"
-        f"?X-Plex-Product=Homescreen+Hero"
-        f"&X-Plex-Client-Identifier=homescreen-hero"
-        f"&X-Plex-Token={account._token}"
+        "?X-Plex-Product=Homescreen+Hero"
+        "&X-Plex-Client-Identifier=homescreen-hero"
     )
-
-    payload = {
-        "settings": {
-            "filterMovies": filter_movies,
-            "filterTelevision": filter_tv,
-            "filterMusic": "",
-        },
-        "invitedEmail": username,
-    }
-
-    headers = {"Accept": "application/json", "Content-Type": "application/json"}
-
-    try:
-        resp = requests.post(url, json=payload, headers=headers)
-        return resp.status_code in (200, 201)
-    except Exception as e:
-        logger.debug(f"V2 API failed for {username}: {e}")
-        return False
-
-
-def _set_user_filter_v1(
-    account, user_id: int, filter_movies: str, filter_tv: str
-) -> bool:
-    # V1 API: PUT plex.tv/api/users/{id} (fallback to V1 for managed users)
-    url = f"https://plex.tv/api/users/{user_id}"
-
-    params = {
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
         "X-Plex-Token": account._token,
-        "X-Plex-Product": "Homescreen Hero",
-        "X-Plex-Client-Identifier": "homescreen-hero",
+    }
+    settings = {
         "filterMovies": filter_movies,
         "filterTelevision": filter_tv,
+        "filterMusic": filter_music,
     }
 
-    headers = {"Accept": "application/json"}
+    # Try invitedEmail first (works for friends/shared users)
+    for payload in [
+        {"settings": settings, "invitedEmail": username},
+        {"settings": settings, "invitedId": user_id},
+    ]:
+        try:
+            resp = requests.post(url, json=payload, headers=headers)
+            if resp.status_code in (200, 201):
+                return True
+        except Exception as e:
+            logger.debug(f"V2 write failed for {username}: {e}")
 
-    try:
-        resp = requests.put(url, params=params, headers=headers)
-        return resp.status_code in (200, 201)
-    except Exception as e:
-        logger.debug(f"V1 API failed for user_id={user_id}: {e}")
-        return False
+    return False

--- a/homescreen_hero/core/user_targeting.py
+++ b/homescreen_hero/core/user_targeting.py
@@ -14,40 +14,6 @@ logger = logging.getLogger(__name__)
 LABEL_PREFIX = "Hsh-hide-"  # I hate having to capitalize, but Plex likes to auto-capitalize. Yay.
 
 
-def apply_targeting(
-    config: AppConfig,
-    collections: list,
-    target_usernames: Optional[List[str]],
-) -> None:
-    # Target collections to specific users by adding exclusion labels.
-    if target_usernames is None:
-        return
-
-    all_users = get_all_plex_users(config)
-    # Inconsistent issue with Plex capitalization- make lowercase juist to be safe
-    target_lower = {u.lower() for u in target_usernames}
-
-    # Users who should NOT see these collections
-    excluded = [
-        u for u in all_users
-        if u["username"].lower() not in target_lower
-        and u["title"].lower() not in target_lower
-    ]
-
-    if not excluded:
-        logger.debug("No users to exclude, skipping label application")
-        return
-
-    for collection in collections:
-        _add_exclusion_labels(collection, excluded)
-
-
-def clear_targeting(collections: list) -> None:
-    # Remove all hsh-hide-* labels from collections
-    for collection in collections:
-        _remove_hsh_labels(collection)
-
-
 def sync_all_user_filters(config: AppConfig) -> None:
     # Make sure every user's sharing settings include their hsh-hide label exclusion.
     # Users not excluded by any group get their hsh filters cleaned instead.

--- a/homescreen_hero/core/user_targeting.py
+++ b/homescreen_hero/core/user_targeting.py
@@ -49,44 +49,59 @@ def clear_targeting(collections: list) -> None:
 
 
 def sync_all_user_filters(config: AppConfig) -> None:
-    # Make sure every users sharing settings include their hsh-hide label exclusion.
-    # V2 API doesn't work for managed users? Fallback to V1 for those guys
+    # Make sure every user's sharing settings include their hsh-hide label exclusion.
+    # Users not excluded by any group get their hsh filters cleaned instead.
     all_users = get_all_plex_users(config)
     account = get_plex_account(config)
 
+    # Build set of usernames that are excluded by at least one group's targeting
+    # (i.e. users NOT in a group's target_users list)
+    groups_with_targeting = [g for g in config.groups if g.target_users is not None]
+    excluded_usernames: set = set()
+    if groups_with_targeting:
+        for group in groups_with_targeting:
+            target_lower = {u.lower() for u in group.target_users}
+            for u in all_users:
+                if (u["username"].lower() not in target_lower
+                        and u["title"].lower() not in target_lower):
+                    excluded_usernames.add(u["username"].lower())
+
     for user in all_users:
         if user["is_admin"]:
-            continue  # Come back to this, not sure how I want to handle admin filtering yet
+            continue
 
-        label = _make_hide_label(user["username"])
         username = user["username"]
         user_id = user["id"]
+        needs_filter = username.lower() in excluded_usernames
 
         try:
-            # Read current filters to merge with
             current = _read_current_filters(account, user)
-            new_movies = _merge_hsh_filter(current.get("filterMovies", ""), [label])
-            new_tv = _merge_hsh_filter(current.get("filterTelevision", ""), [label])
 
-            # Skip if filters already correct
-            if (new_movies == current.get("filterMovies", "")
-                    and new_tv == current.get("filterTelevision", "")):
-                logger.debug(f"Filters already set for {username}, skipping")
-                continue
+            if needs_filter:
+                label = _make_hide_label(username)
+                new_movies = _merge_hsh_filter(current.get("filterMovies", ""), [label])
+                new_tv = _merge_hsh_filter(current.get("filterTelevision", ""), [label])
+            else:
+                # No targeting applies to this user, clean any leftover hsh filters
+                new_movies = _clean_hsh_filter(current.get("filterMovies", ""))
+                new_tv = _clean_hsh_filter(current.get("filterTelevision", ""))
 
-            # Try V2 first (will fail for managed users with no email)
+            # Always push - the read can return stale data so skip-if-unchanged is unreliable
+            success = False
             if username and username != user.get("title", ""):
                 success = _set_user_filter_v2(account, username, new_movies, new_tv)
                 if success:
-                    logger.info(f"Set filters for {username} via V2 API")
+                    action = "Set" if needs_filter else "Cleaned"
+                    logger.info(f"{action} filters for {username} via V2 API")
                     continue
 
             # V1 fallback for managed users
             success = _set_user_filter_v1(account, user_id, new_movies, new_tv)
             if success:
-                logger.info(f"Set filters for {username} (id={user_id}) via V1 API")
+                action = "Set" if needs_filter else "Cleaned"
+                logger.info(f"{action} filters for {username} (id={user_id}) via V1 API")
             else:
-                logger.warning(f"Failed to set filters for {username} (id={user_id})")
+                logger.warning(f"Failed to sync filters for {username} (id={user_id})")
 
         except Exception as e:
             logger.error(f"Error syncing filters for {username}: {e}")
@@ -124,7 +139,9 @@ def clear_all_targeting(config: AppConfig) -> Dict[str, int]:
         except Exception as e:
             logger.error(f"Failed to clear labels from '{lib.name}': {e}")
 
-    # Clean user filter settings
+    # Clean user filter settings. We read current filters to preserve non-hsh filters,
+    # but always push the cleaned result (no skip-if-unchanged) because the read can
+    # return stale/empty data while Plex still has the restriction applied.
     filters_cleaned = 0
     account = get_plex_account(config)
     all_users = get_all_plex_users(config)
@@ -133,18 +150,14 @@ def clear_all_targeting(config: AppConfig) -> Dict[str, int]:
         if user["is_admin"]:
             continue
         try:
+            username = user["username"]
+            user_id = user["id"]
+
             current = _read_current_filters(account, user)
             clean_movies = _clean_hsh_filter(current.get("filterMovies", ""))
             clean_tv = _clean_hsh_filter(current.get("filterTelevision", ""))
 
-            if (clean_movies == current.get("filterMovies", "")
-                    and clean_tv == current.get("filterTelevision", "")):
-                continue
-
-            username = user["username"]
-            user_id = user["id"]
             success = False
-
             if username and username != user.get("title", ""):
                 success = _set_user_filter_v2(account, username, clean_movies, clean_tv)
 
@@ -153,9 +166,9 @@ def clear_all_targeting(config: AppConfig) -> Dict[str, int]:
 
             if success:
                 filters_cleaned += 1
-                logger.info(f"Cleared filters for {user['username']}")
+                logger.info(f"Cleared filters for {username}")
             else:
-                logger.warning(f"Failed to clear filters for {user['username']}")
+                logger.warning(f"Failed to clear filters for {username}")
         except Exception as e:
             logger.error(f"Error clearing filters for {user['username']}: {e}")
 
@@ -178,11 +191,7 @@ def apply_rotation_targeting(
 ) -> None:
     # Apply user targeting for all groups that have target_users set.
 
-    # Check if any collection groups have targeting configured
-    # Side note, do I wanna stick with the term "targeting" for this? Maybe "filtering"? not sure, I'll come back
     groups_with_targeting = [g for g in config.groups if g.target_users is not None]
-    if not groups_with_targeting:
-        return
 
     applied_set = set(applied_collection_names)
 
@@ -194,13 +203,26 @@ def apply_rotation_targeting(
             except Exception as e:
                 logger.error(f"Failed to fetch collections from '{lib.name}' for targeting: {e}")
 
-    # clear any existing hsh labels from all applied collections
+    # Clean labels from collections that were removed from the homescreen
+    from .db.history import get_last_rotation_collections
+    previous = set(get_last_rotation_collections())
+    removed_from_homescreen = previous - applied_set
+
+    for name in removed_from_homescreen:
+        coll = all_collections.get(name)
+        if coll:
+            _remove_hsh_labels(coll)
+
+    # Clean labels from currently applied collections so they get a fresh set
     for name in applied_set:
         coll = all_collections.get(name)
         if coll:
             _remove_hsh_labels(coll)
 
-    # apply targeting per group
+    if not groups_with_targeting:
+        return
+
+    # Apply targeting per group
     all_users = get_all_plex_users(config)
 
     for group in groups_with_targeting:

--- a/homescreen_hero/core/user_targeting.py
+++ b/homescreen_hero/core/user_targeting.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import requests
+from plexapi.server import PlexServer
+
+from .config.schema import AppConfig
+from .integrations.plex_client import get_plex_account, get_all_plex_users, get_library_collections
+
+logger = logging.getLogger(__name__)
+
+LABEL_PREFIX = "Hsh-hide-"  # I hate having to capitalize, but Plex likes to auto-capitalize. Yay.
+
+
+def apply_targeting(
+    config: AppConfig,
+    collections: list,
+    target_usernames: Optional[List[str]],
+) -> None:
+    # Target collections to specific users by adding exclusion labels.
+    if target_usernames is None:
+        return
+
+    all_users = get_all_plex_users(config)
+    # Inconsistent issue with Plex capitalization- make lowercase juist to be safe
+    target_lower = {u.lower() for u in target_usernames}
+
+    # Users who should NOT see these collections
+    excluded = [
+        u for u in all_users
+        if u["username"].lower() not in target_lower
+        and u["title"].lower() not in target_lower
+    ]
+
+    if not excluded:
+        logger.debug("No users to exclude, skipping label application")
+        return
+
+    for collection in collections:
+        _add_exclusion_labels(collection, excluded)
+
+
+def clear_targeting(collections: list) -> None:
+    # Remove all hsh-hide-* labels from collections
+    for collection in collections:
+        _remove_hsh_labels(collection)
+
+
+def sync_all_user_filters(config: AppConfig) -> None:
+    # Make sure every users sharing settings include their hsh-hide label exclusion.
+    # V2 API doesn't work for managed users? Fallback to V1 for those guys
+    all_users = get_all_plex_users(config)
+    account = get_plex_account(config)
+
+    for user in all_users:
+        if user["is_admin"]:
+            continue  # Come back to this, not sure how I want to handle admin filtering yet
+
+        label = _make_hide_label(user["username"])
+        username = user["username"]
+        user_id = user["id"]
+
+        try:
+            # Read current filters to merge with
+            current = _read_current_filters(account, user)
+            new_movies = _merge_hsh_filter(current.get("filterMovies", ""), [label])
+            new_tv = _merge_hsh_filter(current.get("filterTelevision", ""), [label])
+
+            # Skip if filters already correct
+            if (new_movies == current.get("filterMovies", "")
+                    and new_tv == current.get("filterTelevision", "")):
+                logger.debug(f"Filters already set for {username}, skipping")
+                continue
+
+            # Try V2 first (will fail for managed users with no email)
+            if username and username != user.get("title", ""):
+                success = _set_user_filter_v2(account, username, new_movies, new_tv)
+                if success:
+                    logger.info(f"Set filters for {username} via V2 API")
+                    continue
+
+            # V1 fallback for managed users
+            success = _set_user_filter_v1(account, user_id, new_movies, new_tv)
+            if success:
+                logger.info(f"Set filters for {username} (id={user_id}) via V1 API")
+            else:
+                logger.warning(f"Failed to set filters for {username} (id={user_id})")
+
+        except Exception as e:
+            logger.error(f"Error syncing filters for {username}: {e}")
+
+
+def get_targetable_users(config: AppConfig) -> List[Dict[str, Any]]:
+    # Return all Plex users (shared and managed) available for targeting.
+    return get_all_plex_users(config)
+
+
+def clear_all_targeting(config: AppConfig) -> Dict[str, int]:
+    # Remove all Hsh-hide-* labels from every collection and clean user filter settings.
+    from .integrations.plex_client import get_plex_server
+
+    server = get_plex_server(config)
+    labels_removed = 0
+    collections_cleaned = 0
+
+    for lib in config.plex.libraries:
+        if not lib.enabled:
+            continue
+        try:
+            colls = get_library_collections(server, lib.name)
+            for name, coll in colls.items():
+                hsh_labels = [
+                    label.tag for label in coll.labels
+                    if label.tag.lower().startswith(LABEL_PREFIX.lower())
+                ]
+                if hsh_labels:
+                    for tag in hsh_labels:
+                        coll.removeLabel(tag)
+                        labels_removed += 1
+                    collections_cleaned += 1
+                    logger.debug(f"Cleared {len(hsh_labels)} labels from '{name}'")
+        except Exception as e:
+            logger.error(f"Failed to clear labels from '{lib.name}': {e}")
+
+    # Clean user filter settings
+    filters_cleaned = 0
+    account = get_plex_account(config)
+    all_users = get_all_plex_users(config)
+
+    for user in all_users:
+        if user["is_admin"]:
+            continue
+        try:
+            current = _read_current_filters(account, user)
+            clean_movies = _clean_hsh_filter(current.get("filterMovies", ""))
+            clean_tv = _clean_hsh_filter(current.get("filterTelevision", ""))
+
+            if (clean_movies == current.get("filterMovies", "")
+                    and clean_tv == current.get("filterTelevision", "")):
+                continue
+
+            username = user["username"]
+            user_id = user["id"]
+            success = False
+
+            if username and username != user.get("title", ""):
+                success = _set_user_filter_v2(account, username, clean_movies, clean_tv)
+
+            if not success:
+                success = _set_user_filter_v1(account, user_id, clean_movies, clean_tv)
+
+            if success:
+                filters_cleaned += 1
+                logger.info(f"Cleared filters for {user['username']}")
+            else:
+                logger.warning(f"Failed to clear filters for {user['username']}")
+        except Exception as e:
+            logger.error(f"Error clearing filters for {user['username']}: {e}")
+
+    logger.info(
+        f"Clear all targeting: {labels_removed} labels removed from "
+        f"{collections_cleaned} collections, {filters_cleaned} user filters cleaned"
+    )
+    return {
+        "labels_removed": labels_removed,
+        "collections_cleaned": collections_cleaned,
+        "filters_cleaned": filters_cleaned,
+    }
+
+
+def apply_rotation_targeting(
+    server: PlexServer,
+    config: AppConfig,
+    applied_collection_names: List[str],
+    smart_group_collections: Optional[Dict[str, List[str]]] = None,
+) -> None:
+    # Apply user targeting for all groups that have target_users set.
+
+    # Check if any collection groups have targeting configured
+    # Side note, do I wanna stick with the term "targeting" for this? Maybe "filtering"? not sure, I'll come back
+    groups_with_targeting = [g for g in config.groups if g.target_users is not None]
+    if not groups_with_targeting:
+        return
+
+    applied_set = set(applied_collection_names)
+
+    all_collections: Dict[str, object] = {}
+    for lib in config.plex.libraries:
+        if lib.enabled:
+            try:
+                all_collections.update(get_library_collections(server, lib.name))
+            except Exception as e:
+                logger.error(f"Failed to fetch collections from '{lib.name}' for targeting: {e}")
+
+    # clear any existing hsh labels from all applied collections
+    for name in applied_set:
+        coll = all_collections.get(name)
+        if coll:
+            _remove_hsh_labels(coll)
+
+    # apply targeting per group
+    all_users = get_all_plex_users(config)
+
+    for group in groups_with_targeting:
+        # Get this collections from the gorup
+        if group.smart and smart_group_collections:
+            pool = smart_group_collections.get(group.name, [])
+        else:
+            pool = group.collections
+
+        # Filter to only collections that were actually applied this rotation
+        targeted_collections = []
+        for name in pool:
+            if name in applied_set:
+                coll = all_collections.get(name)
+                if coll:
+                    targeted_collections.append(coll)
+
+        if not targeted_collections:
+            continue
+
+        logger.info(
+            f"Applying user targeting for group '{group.name}': "
+            f"{len(targeted_collections)} collections targeted to {group.target_users}"
+        )
+
+        target_lower = {u.lower() for u in group.target_users}
+        excluded = [
+            u for u in all_users
+            if u["username"].lower() not in target_lower
+            and u["title"].lower() not in target_lower
+        ]
+
+        for coll in targeted_collections:
+            _add_exclusion_labels(coll, excluded)
+
+
+def _make_hide_label(username: str) -> str:
+    # Build the exclusion label for a username
+    return f"{LABEL_PREFIX}{username}"
+
+
+def _add_exclusion_labels(collection, excluded_users: List[Dict[str, Any]]) -> None:
+    # Add hsh-hide-{username} labels to a collection for each excluded user
+    existing_labels = {label.tag.lower() for label in collection.labels}
+
+    for user in excluded_users:
+        label = _make_hide_label(user["username"])
+        if label.lower() not in existing_labels:
+            logger.debug(f"Adding label '{label}' to '{collection.title}'")
+            collection.addLabel(label)
+
+
+def _remove_hsh_labels(collection) -> None:
+    # Strip all Hsh-hide-* labels from a collection, leaving other labels intact
+    for label in collection.labels:
+        if label.tag.lower().startswith(LABEL_PREFIX.lower()):
+            logger.debug(f"Removing label '{label.tag}' from '{collection.title}'")
+            collection.removeLabel(label.tag)
+
+
+def _read_current_filters(account, user: Dict[str, Any]) -> Dict[str, str]:
+    # Read a users current filter settings from Plex
+    try:
+        user_sharing = account.user(user["title"])
+        result = {"filterMovies": "", "filterTelevision": ""}
+        for section in user_sharing.servers[0].sections():
+            if hasattr(section, "filterMovies") and section.filterMovies:
+                result["filterMovies"] = section.filterMovies
+            if hasattr(section, "filterTelevision") and section.filterTelevision:
+                result["filterTelevision"] = section.filterTelevision
+        return result
+    except Exception as e:
+        logger.debug(f"Could not read current filters for {user['username']}: {e}")
+        return {"filterMovies": "", "filterTelevision": ""}
+
+
+def _merge_hsh_filter(existing_filter: str, hsh_labels: List[str]) -> str:
+    # Merge our hsh labels into an existing filter string, preserving non-hsh filters.
+    # Not sure how many people are using labels, but just to be safe lol
+
+    if not existing_filter:
+        # No existing filter, just create the label exclusion
+        return f"label!={','.join(hsh_labels)}"
+
+    parts = existing_filter.split("&")
+    label_part = None
+    other_parts = []
+
+    for part in parts:
+        if part.startswith("label!="):
+            label_part = part
+        else:
+            other_parts.append(part)
+
+    # Extract existing non-hsh specific labels
+    existing_labels = []
+    if label_part:
+        label_values = label_part[len("label!="):]
+        for lbl in label_values.split(","):
+            lbl = lbl.strip()
+            if lbl and not lbl.lower().startswith(LABEL_PREFIX.lower()):
+                existing_labels.append(lbl)
+
+    # Combine non-hsh labels with new hsh labels
+    all_labels = existing_labels + hsh_labels
+    new_label_part = f"label!={','.join(all_labels)}"
+
+    all_parts = other_parts + [new_label_part]
+    return "&".join(all_parts)
+
+
+def _clean_hsh_filter(existing_filter: str) -> str:
+    # Remove all hsh labels from a filter string, keeping everything else
+    if not existing_filter:
+        return ""
+
+    parts = existing_filter.split("&")
+    result_parts = []
+
+    for part in parts:
+        if part.startswith("label!="):
+            label_values = part[len("label!="):]
+            non_hsh = [
+                lbl.strip() for lbl in label_values.split(",")
+                if lbl.strip() and not lbl.strip().lower().startswith(LABEL_PREFIX.lower())
+            ]
+            if non_hsh:
+                result_parts.append(f"label!={','.join(non_hsh)}")
+        else:
+            result_parts.append(part)
+
+    return "&".join(result_parts)
+
+
+def _set_user_filter_v2(
+    account, username: str, filter_movies: str, filter_tv: str
+) -> bool:
+    # V2 API: POST clients.plex.tv/api/v2/sharing_settings (doesn't work for shared users, I'm pretty sure)
+    url = (
+        "https://clients.plex.tv/api/v2/sharing_settings"
+        f"?X-Plex-Product=Homescreen+Hero"
+        f"&X-Plex-Client-Identifier=homescreen-hero"
+        f"&X-Plex-Token={account._token}"
+    )
+
+    payload = {
+        "settings": {
+            "filterMovies": filter_movies,
+            "filterTelevision": filter_tv,
+            "filterMusic": "",
+        },
+        "invitedEmail": username,
+    }
+
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    try:
+        resp = requests.post(url, json=payload, headers=headers)
+        return resp.status_code in (200, 201)
+    except Exception as e:
+        logger.debug(f"V2 API failed for {username}: {e}")
+        return False
+
+
+def _set_user_filter_v1(
+    account, user_id: int, filter_movies: str, filter_tv: str
+) -> bool:
+    # V1 API: PUT plex.tv/api/users/{id} (fallback to V1 for managed users)
+    url = f"https://plex.tv/api/users/{user_id}"
+
+    params = {
+        "X-Plex-Token": account._token,
+        "X-Plex-Product": "Homescreen Hero",
+        "X-Plex-Client-Identifier": "homescreen-hero",
+        "filterMovies": filter_movies,
+        "filterTelevision": filter_tv,
+    }
+
+    headers = {"Accept": "application/json"}
+
+    try:
+        resp = requests.put(url, params=params, headers=headers)
+        return resp.status_code in (200, 201)
+    except Exception as e:
+        logger.debug(f"V1 API failed for user_id={user_id}: {e}")
+        return False

--- a/homescreen_hero/web/app.py
+++ b/homescreen_hero/web/app.py
@@ -118,14 +118,12 @@ def create_app() -> FastAPI:
         except Exception as exc:  # pragma: no cover
             logger.exception("Failed to start rotation scheduler: %s", exc)
 
-        # Sync user filter settings for per-user targeting (hsh-hide-{username} labels)
+        # Sync user filter settings for per-user targeting (hsh-hide-{username} labels).
         try:
             config = load_config()
-            # Only sync if there is a group that has targeting configured
-            if any(g.target_users is not None for g in config.groups):
-                from homescreen_hero.core.user_targeting import sync_all_user_filters
-                sync_all_user_filters(config)
-                logger.info("User targeting filters synced on startup")
+            from homescreen_hero.core.user_targeting import sync_all_user_filters
+            sync_all_user_filters(config)
+            logger.info("User targeting filters synced on startup")
         except Exception as exc:
             logger.warning("Failed to sync user targeting filters on startup: %s", exc)
 

--- a/homescreen_hero/web/app.py
+++ b/homescreen_hero/web/app.py
@@ -30,6 +30,7 @@ from homescreen_hero.web.routers import (
     seerr_router,
     version_router,
     library_stats_router,
+    user_targeting_router,
 )
 from homescreen_hero.web.routers.version import get_current_version
 from homescreen_hero.web.routers.collections import invalidate_collections_cache
@@ -68,6 +69,7 @@ def create_app() -> FastAPI:
     app.include_router(seerr_router, prefix="/api")
     app.include_router(version_router, prefix="/api")
     app.include_router(library_stats_router, prefix="/api")
+    app.include_router(user_targeting_router, prefix="/api")
 
     # Frontend (serve only if build exists)
     logger.info(
@@ -116,8 +118,19 @@ def create_app() -> FastAPI:
         except Exception as exc:  # pragma: no cover
             logger.exception("Failed to start rotation scheduler: %s", exc)
 
+        # Sync user filter settings for per-user targeting (hsh-hide-{username} labels)
+        try:
+            config = load_config()
+            # Only sync if there is a group that has targeting configured
+            if any(g.target_users is not None for g in config.groups):
+                from homescreen_hero.core.user_targeting import sync_all_user_filters
+                sync_all_user_filters(config)
+                logger.info("User targeting filters synced on startup")
+        except Exception as exc:
+            logger.warning("Failed to sync user targeting filters on startup: %s", exc)
+
     @app.on_event("shutdown")
-    async def _stop_scheduler() -> None:  # pragma: no cover
+    async def _stop_scheduler() -> None:
         stop_rotation_scheduler()
 
     return app

--- a/homescreen_hero/web/routers/__init__.py
+++ b/homescreen_hero/web/routers/__init__.py
@@ -14,6 +14,7 @@ from .seerr import router as seerr_router
 from .collection_io import router as collection_io_router
 from .version import router as version_router
 from .library_stats import router as library_stats_router
+from .user_targeting import router as user_targeting_router
 
 __all__ = [
     "analytics_router",
@@ -29,5 +30,6 @@ __all__ = [
     "rotation_router",
     "seerr_router",
     "tools_router",
+    "user_targeting_router",
     "version_router",
 ]

--- a/homescreen_hero/web/routers/config/groups.py
+++ b/homescreen_hero/web/routers/config/groups.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends
 
-from homescreen_hero.core.auth import CurrentUser, get_current_user, require_admin
+from homescreen_hero.core.auth import CurrentUser, require_admin
 from homescreen_hero.core.config.loader import (
     CONFIG_ENV_VAR,
     get_config_path,
@@ -27,6 +27,7 @@ from .helpers import load_config_mapping, save_config_mapping, load_group_list
 from .schemas import (
     ConfigSaveResponse,
     CollectionGroupPayload,
+    GroupTargetUsersPayload,
     GroupValidationResult,
     CollectionSourcesResponse,
     GroupReorderRequest,
@@ -144,6 +145,47 @@ def delete_group(
             path=str(config_path),
             env_override=CONFIG_ENV_VAR in os.environ,
             message=f"Group '{name or index}' deleted.",
+        )
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.patch("/groups/{index}/target-users", response_model=ConfigSaveResponse)
+def set_group_target_users(
+    index: int,
+    payload: GroupTargetUsersPayload,
+    current_user: CurrentUser = Depends(require_admin),
+) -> ConfigSaveResponse:
+    # Set target_users on a group without replacing the whole group
+    try:
+        data = load_config_mapping()
+        groups = load_group_list(data)
+
+        if index < 0 or index >= len(groups):
+            raise HTTPException(status_code=404, detail="Group not found")
+
+        group = groups[index]
+        if payload.target_users is not None:
+            group["target_users"] = payload.target_users
+        else:
+            group.pop("target_users", None)
+
+        config_path = get_config_path()
+        save_config_mapping({**data, "groups": groups})
+
+        name = group.get("name", index)
+        action = f"set to {payload.target_users}" if payload.target_users else "cleared"
+        return ConfigSaveResponse(
+            ok=True,
+            path=str(config_path),
+            env_override=CONFIG_ENV_VAR in os.environ,
+            message=f"Target users for '{name}' {action}.",
         )
     except HTTPException:
         raise

--- a/homescreen_hero/web/routers/config/schemas.py
+++ b/homescreen_hero/web/routers/config/schemas.py
@@ -121,6 +121,11 @@ class CollectionGroupPayload(CollectionGroupConfig):
     pass
 
 
+# Partial update for target_users on a group.
+class GroupTargetUsersPayload(BaseModel):
+    target_users: Optional[List[str]] = None
+
+
 # Incoming payload for rotation settings updates.
 class RotationConfigSaveRequest(RotationSettings):
     pass

--- a/homescreen_hero/web/routers/user_targeting.py
+++ b/homescreen_hero/web/routers/user_targeting.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from homescreen_hero.core.config.loader import load_config
+from homescreen_hero.core.auth import CurrentUser, require_admin
+from homescreen_hero.core.user_targeting import get_targetable_users, sync_all_user_filters, clear_all_targeting
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["user-targeting"])
+
+
+class PlexUserResponse(BaseModel):
+    id: int
+    username: str
+    title: str
+    thumb: Optional[str]
+    is_home: bool
+    is_admin: bool
+
+
+class PlexUsersListResponse(BaseModel):
+    users: List[PlexUserResponse]
+
+
+class SyncResult(BaseModel):
+    status: str
+    message: str
+
+
+class ClearTargetingResult(BaseModel):
+    status: str
+    labels_removed: int
+    collections_cleaned: int
+    filters_cleaned: int
+
+
+@router.get("/plex-users", response_model=PlexUsersListResponse)
+def list_plex_users(
+    current_user: CurrentUser = Depends(require_admin),
+) -> PlexUsersListResponse:
+    # List all Plex users available for targeting (friends + home)
+    config = load_config()
+    try:
+        users = get_targetable_users(config)
+        return PlexUsersListResponse(
+            users=[PlexUserResponse(**u) for u in users]
+        )
+    except Exception as e:
+        logger.error(f"Failed to fetch Plex users: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/user-targeting/sync", response_model=SyncResult)
+def sync_user_filters(
+    current_user: CurrentUser = Depends(require_admin),
+) -> SyncResult:
+    # Force sync of all user filter settings
+    config = load_config()
+    try:
+        sync_all_user_filters(config)
+        return SyncResult(status="ok", message="User filters synced successfully")
+    except Exception as e:
+        logger.error(f"Failed to sync user filters: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/user-targeting/clear-all", response_model=ClearTargetingResult)
+def clear_all_user_targeting(
+    current_user: CurrentUser = Depends(require_admin),
+) -> ClearTargetingResult:
+    # Remove all hsh-hide labels from collections and clean filters for all users
+    config = load_config()
+    try:
+        result = clear_all_targeting(config)
+        return ClearTargetingResult(status="ok", **result)
+    except Exception as e:
+        logger.error(f"Failed to clear targeting: {e}")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Feature: Per-User Collection Targeting

### Summary
Adds the ability to target collection groups to specific Plex users. When a group is set to `Specific Users`, collections from that group will only be visible to the selected users. Everyone else gets them hidden automatically using Plex's label-based content filtering.

### Major Changes
- New **Audience** section in the Group Settings sheet lets you choose between `Everyone `and `Specific Users`, with a multi-select user picker
- Backend targeting engine that applies `hsh-hide-{username}` labels to collections during rotation for excluded users, then syncs to Plex so the collections are actually hidden per-user. Filter sync also runs on startup to stay in sync.
- New **Clear User Targeting tool** on the Tools page to bulk-remove all targeting labels and reset filter settings across every collection and user

### Notes
- All non hsh- labels are preserved. Change is still being tested, but homescreen-hero should not remove any of your pre-existing labels.
- Cleaned up some comments in the Plex client

## IMPORTANT!
This feature **requires** Plex Media Server 1.43.1+. The label related bug (forum post [here](https://forums.plex.tv/t/privacy-issue-label-restrictions-not-respected-for-collections-on-the-home-recommended-pages/933544)) was just resolved in the latest PMS Beta release, so per-user labels will only work if your server is running `1.43.1.10540-3972d551c` (beta versions of PMS require Plex Pass)