### PR TITLE
Fix: Post-release bug fixes and reliability improvements

### DIFF
--- a/homescreen-hero-ui/src/pages/DashboardPage.tsx
+++ b/homescreen-hero-ui/src/pages/DashboardPage.tsx
@@ -671,9 +671,9 @@ export default function Dashboard() {
                         <div className="p-4 space-y-6 max-h-[70vh] overflow-y-auto scrollbar-hover-only">
                             <div>
                                 <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-100 mb-2">Selected Collections</h4>
-                                {simulation.rotation.selected_collections.length ? (
+                                {simulation.applied_collections.length ? (
                                     <ul className="list-disc list-inside text-slate-700 dark:text-slate-200 space-y-1">
-                                        {simulation.rotation.selected_collections.map((name) => (
+                                        {simulation.applied_collections.map((name) => (
                                             <li key={name}>{name}</li>
                                         ))}
                                     </ul>

--- a/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
+++ b/homescreen-hero-ui/src/pages/GroupDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchWithAuth } from "../utils/api";
 import { useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, ArrowUpDown, Check, ChevronDown, Compass, Eye, Home, LayoutGrid, List, Loader2, Minus, Plus, Search, Share2, SlidersHorizontal, Trash2, X } from "lucide-react";
+import { ArrowLeft, ArrowUpDown, Check, ChevronDown, Compass, Eye, GripVertical, Home, LayoutGrid, List, Loader2, Minus, Plus, Search, Share2, SlidersHorizontal, Trash2, X } from "lucide-react";
 import { InfoTooltip } from "../components/ui/info-tooltip";
 import { Listbox } from "@headlessui/react";
 import { ConfirmDialog } from "../components/ui/confirm-dialog";
@@ -18,6 +18,23 @@ import { Slider } from "../components/ui/slider";
 import { getGroupStatus } from "../utils/dates";
 import { useTargetableUsers } from "../hooks/useTargetableUsers";
 import { UserTargetingSelector } from "../components/UserTargetingSelector";
+import {
+    DndContext,
+    closestCenter,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+    arrayMove,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    useSortable,
+    verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 
 type DateRange = {
@@ -37,7 +54,7 @@ type CollectionGroup = {
     visibility_shared: boolean;
     visibility_recommended: boolean;
     collection_selection?: "random" | "lru";
-    collection_order?: "random" | "alpha" | null;
+    collection_order?: "random" | "alpha" | "custom" | null;
     collection_sort?: "release" | "alpha" | null;
     date_range?: DateRange | null;
     target_users?: string[] | null;
@@ -101,6 +118,75 @@ const emptyGroup: CollectionGroup = {
     collections: [],
 };
 
+function SortableCollectionItem({
+    name,
+    meta,
+    isExiting,
+    isNew,
+    onRemove,
+    showDragHandle,
+}: {
+    name: string;
+    meta: { color: string; label: string } | null;
+    isExiting: boolean;
+    isNew: boolean;
+    onRemove: () => void;
+    showDragHandle: boolean;
+}) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: name, disabled: !showDragHandle });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition: transition ?? "transform 200ms ease",
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className={`group flex items-center gap-2 px-4 py-2.5 hover:bg-slate-800/40 transition-colors ${
+                isExiting ? "sidebar-item-exit" : isNew ? "sidebar-item-enter" : ""
+            } ${isDragging ? "z-50 bg-slate-800 rounded-lg shadow-lg shadow-black/30 border border-slate-600/50" : ""}`}
+        >
+            {showDragHandle && (
+                <button
+                    type="button"
+                    className="touch-none p-0.5 text-slate-600 hover:text-slate-400 cursor-grab active:cursor-grabbing shrink-0"
+                    {...attributes}
+                    {...listeners}
+                >
+                    <GripVertical className="h-3.5 w-3.5" />
+                </button>
+            )}
+            <div className="min-w-0 flex-1">
+                <p className="text-sm text-slate-200 truncate">{name}</p>
+            </div>
+            {meta && (
+                <span
+                    className="rounded-full px-1.5 py-0.5 text-[9px] font-bold text-white shrink-0"
+                    style={{ backgroundColor: meta.color }}
+                >
+                    {meta.label}
+                </span>
+            )}
+            <button
+                type="button"
+                onClick={onRemove}
+                className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-slate-500 hover:text-red-400 transition-all"
+            >
+                <X className="h-3.5 w-3.5" />
+            </button>
+        </div>
+    );
+}
+
 export default function GroupDetailPage() {
     const navigate = useNavigate();
     const { groupId } = useParams();
@@ -134,6 +220,22 @@ export default function GroupDetailPage() {
     const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
     const { users: targetableUsers, loading: targetableUsersLoading } = useTargetableUsers();
     const itemsPerPage = 24; // 4 columns × 6 rows
+
+    const dndSensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
+
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+        const { active, over } = event;
+        if (over && active.id !== over.id) {
+            setForm((prev) => {
+                const oldIndex = prev.collections.indexOf(active.id as string);
+                const newIndex = prev.collections.indexOf(over.id as string);
+                return { ...prev, collections: arrayMove(prev.collections, oldIndex, newIndex) };
+            });
+        }
+    }, []);
 
     useEffect(() => {
         setLoading(true);
@@ -851,41 +953,27 @@ export default function GroupDetailPage() {
                         {/* Selected list */}
                         <div className="max-h-[480px] overflow-y-auto scrollbar-thin">
                             {form.collections.length ? (
-                                <div className="divide-y divide-slate-800/60">
-                                    {form.collections.map((name) => {
-                                        const matchedSource = sources.find((s) => s.name === name);
-                                        const meta = matchedSource ? (sourceMeta[matchedSource.source] ?? { color: "#4284c9", label: matchedSource.source }) : null;
-                                        const isExiting = exitingSidebar.has(name);
-                                        const isNew = recentlyAdded.has(name);
-                                        return (
-                                            <div
-                                                key={name}
-                                                className={`group flex items-center gap-2 px-4 py-2.5 hover:bg-slate-800/40 transition-colors ${
-                                                    isExiting ? "sidebar-item-exit" : isNew ? "sidebar-item-enter" : ""
-                                                }`}
-                                            >
-                                                <div className="min-w-0 flex-1">
-                                                    <p className="text-sm text-slate-200 truncate">{name}</p>
-                                                </div>
-                                                {meta && (
-                                                    <span
-                                                        className="rounded-full px-1.5 py-0.5 text-[9px] font-bold text-white shrink-0"
-                                                        style={{ backgroundColor: meta.color }}
-                                                    >
-                                                        {meta.label}
-                                                    </span>
-                                                )}
-                                                <button
-                                                    type="button"
-                                                    onClick={() => removeCollection(name)}
-                                                    className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-slate-500 hover:text-red-400 transition-all"
-                                                >
-                                                    <X className="h-3.5 w-3.5" />
-                                                </button>
-                                            </div>
-                                        );
-                                    })}
-                                </div>
+                                <DndContext sensors={dndSensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                                    <SortableContext items={form.collections} strategy={verticalListSortingStrategy}>
+                                        <div className="divide-y divide-slate-800/60">
+                                            {form.collections.map((name) => {
+                                                const matchedSource = sources.find((s) => s.name === name);
+                                                const meta = matchedSource ? (sourceMeta[matchedSource.source] ?? { color: "#4284c9", label: matchedSource.source }) : null;
+                                                return (
+                                                    <SortableCollectionItem
+                                                        key={name}
+                                                        name={name}
+                                                        meta={meta}
+                                                        isExiting={exitingSidebar.has(name)}
+                                                        isNew={recentlyAdded.has(name)}
+                                                        onRemove={() => removeCollection(name)}
+                                                        showDragHandle={form.collection_order === "custom"}
+                                                    />
+                                                );
+                                            })}
+                                        </div>
+                                    </SortableContext>
+                                </DndContext>
                             ) : (
                                 <div className="px-4 py-10 text-center">
                                     <p className="text-xs text-slate-500">Click collections to add them</p>
@@ -1093,6 +1181,7 @@ export default function GroupDetailPage() {
                                         {([
                                             { value: null, label: "Random" },
                                             { value: "alpha" as const, label: "Alpha" },
+                                            { value: "custom" as const, label: "Custom" },
                                         ]).map(({ value, label }, i, arr) => {
                                             const isSelected = form.collection_order === value;
                                             return (

--- a/homescreen_hero/core/config/schema.py
+++ b/homescreen_hero/core/config/schema.py
@@ -203,9 +203,9 @@ class CollectionGroupConfig(BaseModel):
         default="random",
         description="How collections are picked from this group during rotation.",
     )
-    collection_order: Optional[Literal["random", "alpha"]] = Field(
+    collection_order: Optional[Literal["random", "alpha", "custom"]] = Field(
         default=None,
-        description="Display order of picked collections on homescreen. None = random.",
+        description="Display order of picked collections on homescreen. 'custom' preserves the order defined in the collections list. None = random.",
     )
     collection_sort: Optional[Literal["release", "alpha"]] = Field(
         default=None,

--- a/homescreen_hero/core/integrations/anilist_sync.py
+++ b/homescreen_hero/core/integrations/anilist_sync.py
@@ -338,6 +338,9 @@ def record_missing_items_in_db(
                 )
                 session.add(row)
 
+        # Flush updates so last_seen values are in the DB before bulk delete
+        session.flush()
+
         # Remove items no longer missing (not seen in this sync)
         session.query(AniListMissingItem).filter(
             AniListMissingItem.source_name == source.name,

--- a/homescreen_hero/core/integrations/letterboxd_sync.py
+++ b/homescreen_hero/core/integrations/letterboxd_sync.py
@@ -339,6 +339,9 @@ def record_missing_items_in_db(
                 )
                 session.add(new_item)
 
+        # Flush updates so last_seen values are in the DB before bulk delete
+        session.flush()
+
         # Remove items no longer missing (not seen in this sync)
         session.query(LetterboxdMissingItem).filter(
             LetterboxdMissingItem.source_name == source.name,

--- a/homescreen_hero/core/integrations/mal_sync.py
+++ b/homescreen_hero/core/integrations/mal_sync.py
@@ -335,6 +335,9 @@ def record_missing_items_in_db(
                 )
                 session.add(row)
 
+        # Flush updates so last_seen values are in the DB before bulk delete
+        session.flush()
+
         # Remove items no longer missing (not seen in this sync)
         session.query(MALMissingItem).filter(
             MALMissingItem.source_name == source.name,

--- a/homescreen_hero/core/integrations/mdblist_sync.py
+++ b/homescreen_hero/core/integrations/mdblist_sync.py
@@ -305,6 +305,9 @@ def record_missing_items_in_db(
                 )
                 session.add(row)
 
+        # Flush updates so last_seen values are in the DB before bulk delete
+        session.flush()
+
         # Remove items no longer missing (not seen in this sync)
         session.query(MDBListMissingItem).filter(
             MDBListMissingItem.source_name == source.name,

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -17,6 +17,10 @@ from ..config.schema import AppConfig
 
 logger = logging.getLogger(__name__)
 
+_REORDER_MOVE_DELAY_SECONDS = 0.2
+_REORDER_SETTLE_DELAY_SECONDS = 0.35
+_REORDER_MAX_ATTEMPTS = 2
+
 
 def _make_session() -> requests.Session:
     # Shared session that skips SSL cert verification for local Plex connections.
@@ -396,6 +400,132 @@ def apply_home_screen_selection(
     return applied
 
 
+def _get_managed_hubs_for_library(server: PlexServer, library_name: str) -> List[Any]:
+    library = server.library.section(library_name)
+    return [hub for hub in library.managedHubs() if hasattr(hub, "title")]
+
+
+def _get_target_hub_order_for_library(
+    managed_hubs: List[Any],
+    ordered_collection_names: List[str],
+) -> List[str]:
+    hub_titles = {hub.title for hub in managed_hubs}
+    return [name for name in ordered_collection_names if name in hub_titles]
+
+
+def _get_current_hub_order_for_library(
+    server: PlexServer,
+    library_name: str,
+    target_names: List[str],
+) -> List[str]:
+    target_set = set(target_names)
+    return [
+        hub.title
+        for hub in _get_managed_hubs_for_library(server, library_name)
+        if hub.title in target_set
+    ]
+
+
+def _reorder_library_hubs(
+    server: PlexServer,
+    library_name: str,
+    target_order: List[str],
+) -> List[str]:
+    if len(target_order) < 2:
+        return list(target_order)
+
+    current_order = _get_current_hub_order_for_library(server, library_name, target_order)
+    if current_order == target_order:
+        logger.debug(
+            "Managed hub order already correct for '%s': %s",
+            library_name,
+            target_order,
+        )
+        return current_order
+
+    # Move first item to top, then chain each subsequent item after the previous one.
+    # This gives Plex an explicit anchor for each move rather than racing for position 0.
+    for attempt in range(1, _REORDER_MAX_ATTEMPTS + 1):
+        hub_map = {
+            hub.title: hub
+            for hub in _get_managed_hubs_for_library(server, library_name)
+        }
+
+        first_hub = hub_map.get(target_order[0])
+        if first_hub is None:
+            logger.warning(
+                "First collection '%s' not found in managed hubs for '%s'",
+                target_order[0],
+                library_name,
+            )
+            break
+
+        try:
+            first_hub.move(after=None)
+            logger.debug("Moved '%s' to top in '%s'", target_order[0], library_name)
+        except Exception as e:
+            logger.warning("Failed to move collection '%s' in '%s': %s", target_order[0], library_name, e)
+            break
+
+        prev_hub = first_hub
+        for name in target_order[1:]:
+            hub = hub_map.get(name)
+            if hub is None:
+                logger.debug(
+                    "Skipping '%s' during reorder for '%s' - not found in managed hubs",
+                    name,
+                    library_name,
+                )
+                continue
+
+            try:
+                time.sleep(_REORDER_MOVE_DELAY_SECONDS)
+                hub.move(after=prev_hub)
+                logger.debug(
+                    "Moved '%s' after '%s' in '%s' (attempt %d/%d)",
+                    name,
+                    prev_hub.title,
+                    library_name,
+                    attempt,
+                    _REORDER_MAX_ATTEMPTS,
+                )
+                prev_hub = hub
+            except Exception as e:
+                logger.warning(
+                    "Failed to move collection '%s' in '%s': %s",
+                    name,
+                    library_name,
+                    e,
+                )
+
+        time.sleep(_REORDER_SETTLE_DELAY_SECONDS)
+        current_order = _get_current_hub_order_for_library(
+            server,
+            library_name,
+            target_order,
+        )
+        if current_order == target_order:
+            logger.debug(
+                "Verified managed hub order for '%s' on attempt %d/%d",
+                library_name,
+                attempt,
+                _REORDER_MAX_ATTEMPTS,
+            )
+            return current_order
+
+        logger.warning(
+            "Managed hub order mismatch for '%s' after attempt %d/%d. "
+            "Requested=%s Current=%s",
+            library_name,
+            attempt,
+            _REORDER_MAX_ATTEMPTS,
+            target_order,
+            current_order,
+        )
+
+    return current_order
+
+
 def reorder_homescreen_collections(
     server: PlexServer,
     config: AppConfig,
@@ -407,69 +537,45 @@ def reorder_homescreen_collections(
     # Plex keeps libraries separate, so we reorder within each library.
     enabled_libraries = [lib.name for lib in config.plex.libraries if lib.enabled]
 
-    # Build map: collection_name -> (ManagedHub, library_name)
-    hub_map: Dict[str, tuple[Any, str]] = {}
+    library_orders: Dict[str, List[str]] = {}
+    total_hubs = 0
     for library_name in enabled_libraries:
         try:
-            library = server.library.section(library_name)
-            hubs = library.managedHubs()
-            for hub in hubs:
-                if hasattr(hub, "title"):
-                    hub_map[hub.title] = (hub, library_name)
+            hubs = _get_managed_hubs_for_library(server, library_name)
+            total_hubs += len(hubs)
+            target_order = _get_target_hub_order_for_library(
+                hubs,
+                ordered_collection_names,
+            )
+            if target_order:
+                library_orders[library_name] = target_order
         except Exception as e:
             logger.warning(
                 "Could not get managed hubs for library %s: %s", library_name, e
             )
 
-    logger.debug("Found %d managed hubs for reordering, requested order: %s", len(hub_map), ordered_collection_names)
+    logger.debug(
+        "Found %d managed hubs for reordering, requested order: %s",
+        total_hubs,
+        ordered_collection_names,
+    )
 
     if dry_run:
         logger.info("Dry run - would reorder collections: %s", ordered_collection_names)
         return ordered_collection_names
 
-    # Group requested collections by library, preserving order within each library
-    library_orders: Dict[str, List[tuple[str, Any]]] = {}
-    for name in ordered_collection_names:
-        if name not in hub_map:
-            # Collection might be a built-in Plex hub (not a custom collection)
-            logger.debug("Skipping '%s' - not found in managed hubs", name)
-            continue
-        hub, library_name = hub_map[name]
-        if library_name not in library_orders:
-            library_orders[library_name] = []
-        library_orders[library_name].append((name, hub))
-
     # Reorder within each library
     applied_order: List[str] = []
-    for library_name, collections in library_orders.items():
-        logger.debug("Reordering %d collections in '%s': %s", len(collections), library_name, [n for n, _ in collections])
-
-        if len(collections) < 2:
-            for name, _ in collections:
-                applied_order.append(name)
-            continue
-
-        # Move first item to top, then position others relative to it
-        first_name, first_hub = collections[0]
-        try:
-            first_hub.move(after=None)
-            applied_order.append(first_name)
-            logger.debug("Moved '%s' to top", first_name)
-        except Exception as e:
-            logger.warning("Failed to move collection '%s': %s", first_name, e)
-            continue
-
-        # Move subsequent items after the previous one
-        prev_hub = first_hub
-        for name, hub in collections[1:]:
-            try:
-                time.sleep(0.15)
-                hub.move(after=prev_hub)
-                applied_order.append(name)
-                logger.debug("Moved '%s' after '%s'", name, prev_hub.title)
-                prev_hub = hub
-            except Exception as e:
-                logger.warning("Failed to move collection '%s': %s", name, e)
+    for library_name, target_order in library_orders.items():
+        logger.debug(
+            "Reordering %d collections in '%s': %s",
+            len(target_order),
+            library_name,
+            target_order,
+        )
+        applied_order.extend(
+            _reorder_library_hubs(server, library_name, target_order)
+        )
 
     if applied_order:
         logger.info("Reordered %d collections on homescreen", len(applied_order))

--- a/homescreen_hero/core/integrations/plex_client.py
+++ b/homescreen_hero/core/integrations/plex_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Dict, Iterable, List, Set
 
 import requests
@@ -420,7 +421,7 @@ def reorder_homescreen_collections(
                 "Could not get managed hubs for library %s: %s", library_name, e
             )
 
-    logger.debug("Found %d collections available for reordering", len(hub_map))
+    logger.debug("Found %d managed hubs for reordering, requested order: %s", len(hub_map), ordered_collection_names)
 
     if dry_run:
         logger.info("Dry run - would reorder collections: %s", ordered_collection_names)
@@ -431,7 +432,7 @@ def reorder_homescreen_collections(
     for name in ordered_collection_names:
         if name not in hub_map:
             # Collection might be a built-in Plex hub (not a custom collection)
-            logger.debug("Skipping '%s' - not a custom collection or not found", name)
+            logger.debug("Skipping '%s' - not found in managed hubs", name)
             continue
         hub, library_name = hub_map[name]
         if library_name not in library_orders:
@@ -441,7 +442,7 @@ def reorder_homescreen_collections(
     # Reorder within each library
     applied_order: List[str] = []
     for library_name, collections in library_orders.items():
-        logger.debug("Reordering %d collections in '%s'", len(collections), library_name)
+        logger.debug("Reordering %d collections in '%s': %s", len(collections), library_name, [n for n, _ in collections])
 
         if len(collections) < 2:
             for name, _ in collections:
@@ -462,6 +463,7 @@ def reorder_homescreen_collections(
         prev_hub = first_hub
         for name, hub in collections[1:]:
             try:
+                time.sleep(0.15)
                 hub.move(after=prev_hub)
                 applied_order.append(name)
                 logger.debug("Moved '%s' after '%s'", name, prev_hub.title)

--- a/homescreen_hero/core/integrations/tmdb_sync.py
+++ b/homescreen_hero/core/integrations/tmdb_sync.py
@@ -282,6 +282,9 @@ def record_missing_items_in_db(
                 )
                 session.add(row)
 
+        # Flush updates so last_seen values are in the DB before bulk delete
+        session.flush()
+
         # Remove items no longer missing
         session.query(TMDbMissingItem).filter(
             TMDbMissingItem.source_name == source.name,

--- a/homescreen_hero/core/integrations/trakt_sync.py
+++ b/homescreen_hero/core/integrations/trakt_sync.py
@@ -291,6 +291,9 @@ def record_missing_items_in_db(
                 )
                 session.add(row)
 
+        # Flush updates so last_seen values are in the DB before bulk delete
+        session.flush()
+
         # Remove items no longer missing (not seen in this sync)
         session.query(TraktMissingItem).filter(
             TraktMissingItem.source_name == source.name,

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -789,7 +789,9 @@ def order_collections_for_display(
         elif coll_order == "custom" and group_cfg and not group_cfg.smart:
             # Preserve the order defined in the group's collections list
             coll_list = group_cfg.collections
+            logger.debug("Custom order for group '%s': config list=%s, bucket before sort=%s", gn, coll_list, bucket)
             bucket.sort(key=lambda c: coll_list.index(c) if c in coll_list else len(coll_list))
+            logger.debug("Custom order for group '%s': bucket after sort=%s", gn, bucket)
         else:
             rng.shuffle(bucket)
 

--- a/homescreen_hero/core/rotation.py
+++ b/homescreen_hero/core/rotation.py
@@ -786,6 +786,10 @@ def order_collections_for_display(
         coll_order = group_cfg.collection_order if group_cfg else None
         if coll_order == "alpha":
             bucket.sort()
+        elif coll_order == "custom" and group_cfg and not group_cfg.smart:
+            # Preserve the order defined in the group's collections list
+            coll_list = group_cfg.collections
+            bucket.sort(key=lambda c: coll_list.index(c) if c in coll_list else len(coll_list))
         else:
             rng.shuffle(bucket)
 

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -465,9 +465,22 @@ def simulate_rotation_once(
         rotation_result.selected_collections,
     )
 
+    # Apply display ordering so simulation preview matches actual rotation order
+    from .rotation import order_collections_for_display
+    from .db import get_pinned_collections
+    pinned_collections = get_pinned_collections()
+    pinned_order = {p.collection_name: p.display_order for p in pinned_collections}
+    ordered = order_collections_for_display(
+        list(rotation_result.selected_collections),
+        config,
+        pinned_names=pinned_names,
+        pinned_order=pinned_order,
+        smart_group_collections=smart_group_collections,
+    )
+
     execution = RotationExecution(
         rotation=rotation_result,
-        applied_collections=list(rotation_result.selected_collections),
+        applied_collections=ordered,
         dry_run=True,
         simulation_id=simulation_id,
     )

--- a/homescreen_hero/core/service.py
+++ b/homescreen_hero/core/service.py
@@ -478,9 +478,38 @@ def simulate_rotation_once(
         smart_group_collections=smart_group_collections,
     )
 
+    # Sort chosen_collections per group to match display ordering
+    group_cfg_map = {g.name: g for g in config.groups}
+    for group_result in rotation_result.groups:
+        gcfg = group_cfg_map.get(group_result.group_name)
+        if not gcfg or not group_result.chosen_collections:
+            continue
+        if gcfg.collection_order == "alpha":
+            group_result.chosen_collections = sorted(group_result.chosen_collections)
+        elif gcfg.collection_order == "custom" and not gcfg.smart:
+            coll_list = gcfg.collections
+            group_result.chosen_collections = sorted(
+                group_result.chosen_collections,
+                key=lambda c: coll_list.index(c) if c in coll_list else len(coll_list),
+            )
+
+    # Group by library to match how Plex displays collections per-library section
+    enabled_libraries = [lib.name for lib in config.plex.libraries if lib.enabled]
+    library_grouped: list[str] = []
+    used = set()
+    for lib_name in enabled_libraries:
+        for name in ordered:
+            if name not in used and collection_library_map.get(name) == lib_name:
+                library_grouped.append(name)
+                used.add(name)
+    # Append any collections not found in a library (e.g. TV collections with only Movies enabled)
+    for name in ordered:
+        if name not in used:
+            library_grouped.append(name)
+
     execution = RotationExecution(
         rotation=rotation_result,
-        applied_collections=ordered,
+        applied_collections=library_grouped,
         dry_run=True,
         simulation_id=simulation_id,
     )

--- a/tests/test_plex_client.py
+++ b/tests/test_plex_client.py
@@ -1,0 +1,132 @@
+import logging
+
+from homescreen_hero.core.config.schema import (
+    AppConfig,
+    PlexLibraryConfig,
+    PlexSettings,
+    RotationSettings,
+)
+from homescreen_hero.core.integrations import plex_client
+
+
+class FakeHub:
+    def __init__(self, section, title: str, fail_first_move: bool = False):
+        self.section = section
+        self.title = title
+        self.identifier = title.replace(" ", "_")
+        self.fail_first_move = fail_first_move
+        self.move_calls = 0
+
+    def move(self, after=None):
+        self.move_calls += 1
+        if self.fail_first_move and self.move_calls == 1:
+            raise Exception("Simulated Plex API failure")
+
+        hubs = self.section._hubs
+        hubs.remove(self)
+        if after is None:
+            hubs.insert(0, self)
+            return
+
+        after_index = hubs.index(after)
+        hubs.insert(after_index + 1, self)
+
+
+class FakeSection:
+    def __init__(self, name: str, titles: list[str], fail_first_move_for: set[str] | None = None):
+        fail_first_move_for = fail_first_move_for or set()
+        self.title = name
+        self._hubs = [
+            FakeHub(self, title, fail_first_move=title in fail_first_move_for)
+            for title in titles
+        ]
+
+    def managedHubs(self):
+        return list(self._hubs)
+
+
+class FakeLibraryManager:
+    def __init__(self, sections: dict[str, FakeSection]):
+        self._sections = sections
+
+    def section(self, name: str) -> FakeSection:
+        return self._sections[name]
+
+
+class FakeServer:
+    def __init__(self, sections: dict[str, FakeSection]):
+        self.library = FakeLibraryManager(sections)
+
+
+def _make_config(*library_names: str) -> AppConfig:
+    return AppConfig(
+        plex=PlexSettings(
+            base_url="http://localhost:32400",
+            token="test-token",
+            libraries=[PlexLibraryConfig(name=name, enabled=True) for name in library_names],
+        ),
+        rotation=RotationSettings(
+            enabled=True,
+            max_collections=10,
+        ),
+        groups=[],
+    )
+
+
+def test_reorder_homescreen_collections_matches_requested_order(monkeypatch):
+    monkeypatch.setattr(plex_client.time, "sleep", lambda _seconds: None)
+
+    section = FakeSection("Movies", ["Gamma", "Delta", "Beta", "Alpha"])
+    server = FakeServer({"Movies": section})
+    config = _make_config("Movies")
+
+    applied = plex_client.reorder_homescreen_collections(
+        server,
+        config,
+        ["Alpha", "Beta", "Gamma"],
+    )
+
+    assert applied == ["Alpha", "Beta", "Gamma"]
+    assert [hub.title for hub in section.managedHubs()[:3]] == ["Alpha", "Beta", "Gamma"]
+
+
+def test_reorder_homescreen_collections_retries_when_first_pass_misorders(monkeypatch, caplog):
+    monkeypatch.setattr(plex_client.time, "sleep", lambda _seconds: None)
+
+    section = FakeSection(
+        "Movies",
+        ["Delta", "Gamma", "Beta", "Alpha"],
+        fail_first_move_for={"Beta"},
+    )
+    server = FakeServer({"Movies": section})
+    config = _make_config("Movies")
+
+    with caplog.at_level(logging.WARNING):
+        applied = plex_client.reorder_homescreen_collections(
+            server,
+            config,
+            ["Alpha", "Beta", "Gamma"],
+        )
+
+    assert applied == ["Alpha", "Beta", "Gamma"]
+    assert [hub.title for hub in section.managedHubs()[:3]] == ["Alpha", "Beta", "Gamma"]
+    assert "Managed hub order mismatch" in caplog.text
+
+
+def test_reorder_homescreen_collections_handles_each_library_separately(monkeypatch):
+    monkeypatch.setattr(plex_client.time, "sleep", lambda _seconds: None)
+
+    movies = FakeSection("Movies", ["Movie B", "Movie A"])
+    shows = FakeSection("Shows", ["Show B", "Show A"])
+    server = FakeServer({"Movies": movies, "Shows": shows})
+    config = _make_config("Movies", "Shows")
+
+    applied = plex_client.reorder_homescreen_collections(
+        server,
+        config,
+        ["Movie A", "Show A", "Movie B", "Show B"],
+    )
+
+    assert applied == ["Movie A", "Movie B", "Show A", "Show B"]
+    assert [hub.title for hub in movies.managedHubs()[:2]] == ["Movie A", "Movie B"]
+    assert [hub.title for hub in shows.managedHubs()[:2]] == ["Show A", "Show B"]


### PR DESCRIPTION
## Fix: Post-release bug fixes and reliability improvements

### Summary
A collection of bug fixes and small additions that came out of the v0.x release. The big ones are fixing a database error during syncs and making homescreen collection reordering actually reliable (Plex's API needs hand-holding with delays between moves).

### Major Changes
- Fixed a database error in all sync modules (Trakt, MDBList, TMDb, Letterboxd, AniList, MAL) where missing items were getting deleted prematurely because `autoflush=False` meant `last_seen` updates weren't written before the bulk delete query ran. Added explicit `session.flush()` calls before the delete step.
- Overhauled Plex homescreen reorder logic with per-library hub grouping, delays between moves (0.2s per move + 0.35s settle), verification after reordering, and automatic retry (up to 2 attempts). Plex's API was silently dropping moves when fired too fast.
- Fixed the simulation modal to display collections in the correct order, grouped by library to match how Plex actually renders the homescreen.
- Added `custom` as a new `collection_order` option in Group Settings, letting users manually specify the display order of collections within a group.

### Minor Changes
- Added reorder unit tests for the plex client
- Simulation preview now sorts chosen collections within each group result to match alpha/custom ordering