### PR TITLE
Feature: Add _FILE suffix support for HSH_* env vars (Docker secrets)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 # homescreen-hero Environment Variables
 # Copy this file to .env and fill in your sensitive values
+#
+# DOCKER SECRETS / FILE-BASED SECRETS
+# Any HSH_* variable can also be set via a _FILE suffix pointing to a file.
+# Example: HSH_PLEX_TOKEN_FILE=/run/secrets/plex_token
+# The app will read the secret from that file instead.
+# Do not set both HSH_X and HSH_X_FILE — this will cause an error.
 
 # ============================================
 # GENERAL SETTINGS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
       HSH_TAUTULLI_BASE_URL: ${HSH_TAUTULLI_BASE_URL:-}
       HSH_SEERR_API_KEY: ${HSH_SEERR_API_KEY:-}
       HSH_SEERR_BASE_URL: ${HSH_SEERR_BASE_URL:-}
+      # Docker secrets: use _FILE suffix to read secrets from files instead
+      # Example: HSH_PLEX_TOKEN_FILE: /run/secrets/plex_token
+      # See .env.example for details
     volumes:
       - ./data:/data
     restart: unless-stopped

--- a/homescreen_hero/core/config/loader.py
+++ b/homescreen_hero/core/config/loader.py
@@ -21,6 +21,36 @@ from .schema import (
 
 logger = logging.getLogger(__name__)
 
+
+def _resolve_env(var_name: str) -> str | None:
+    # Resolve an env var, supporting _FILE indirection for Docker secrets.
+    # e.g. HSH_PLEX_TOKEN_FILE=/run/secrets/plex_token reads the secret from file.
+    file_var = f"{var_name}_FILE"
+    from_file = os.getenv(file_var)
+    from_env = os.getenv(var_name)
+
+    if from_file and from_env:
+        raise ValueError(
+            f"Both {var_name} and {file_var} are set. Use only one."
+        )
+
+    if from_file:
+        path = Path(from_file)
+        if not path.is_file():
+            raise ValueError(
+                f"{file_var} points to '{from_file}' which is not a readable file"
+            )
+        value = path.read_text(encoding="utf-8").strip()
+        if not value:
+            raise ValueError(
+                f"{file_var} points to '{from_file}' which is empty"
+            )
+        logger.debug(f"Using {var_name} from {file_var} (file: {from_file})")
+        return value
+
+    return from_env
+
+
 # Load .env file if it exists (for local development)
 # Docker Compose will handle env vars automatically
 env_file = Path(".env")
@@ -95,7 +125,7 @@ def _read_raw_config(path: Path) -> dict:
 # Apply environment variable overrides for sensitive fields
 def _apply_env_overrides(config: AppConfig) -> AppConfig:
     # Plex URL override
-    plex_url = os.getenv("HSH_PLEX_URL")
+    plex_url = _resolve_env("HSH_PLEX_URL")
     if plex_url:
         logger.debug("Using Plex URL from HSH_PLEX_URL environment variable")
         config.plex.base_url = plex_url
@@ -105,7 +135,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
         )
 
     # Plex token override
-    plex_token = os.getenv("HSH_PLEX_TOKEN")
+    plex_token = _resolve_env("HSH_PLEX_TOKEN")
     if plex_token:
         logger.debug("Using Plex token from HSH_PLEX_TOKEN environment variable")
         config.plex.token = plex_token
@@ -120,7 +150,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
 
         # Password is only required when method allows password login
         if method in ("password", "both"):
-            auth_password = os.getenv("HSH_AUTH_PASSWORD")
+            auth_password = _resolve_env("HSH_AUTH_PASSWORD")
             if auth_password:
                 logger.debug("Using auth password from HSH_AUTH_PASSWORD environment variable")
                 config.auth.password = auth_password
@@ -131,7 +161,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
                 )
 
         # Secret key is always required when auth is enabled (used for JWT signing)
-        auth_secret = os.getenv("HSH_AUTH_SECRET_KEY")
+        auth_secret = _resolve_env("HSH_AUTH_SECRET_KEY")
         if auth_secret:
             logger.debug("Using auth secret key from HSH_AUTH_SECRET_KEY environment variable")
             config.auth.secret_key = auth_secret
@@ -141,7 +171,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             )
 
     # Trakt: auto-create from env vars if section missing
-    trakt_client_id = os.getenv("HSH_TRAKT_CLIENT_ID")
+    trakt_client_id = _resolve_env("HSH_TRAKT_CLIENT_ID")
     if not config.trakt and trakt_client_id:
         logger.debug("Auto-enabling Trakt from HSH_TRAKT_CLIENT_ID environment variable")
         config.trakt = TraktSettings(enabled=True, client_id=trakt_client_id)
@@ -155,7 +185,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             )
 
     # MDBList: auto-create from env vars if section missing
-    mdblist_api_key = os.getenv("HSH_MDBLIST_API_KEY")
+    mdblist_api_key = _resolve_env("HSH_MDBLIST_API_KEY")
     if not config.mdblist and mdblist_api_key:
         logger.debug("Auto-enabling MDBList from HSH_MDBLIST_API_KEY environment variable")
         config.mdblist = MDBListSettings(enabled=True, api_key=mdblist_api_key)
@@ -165,7 +195,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             config.mdblist.api_key = mdblist_api_key
 
     # TMDb: auto-create from env vars if section missing
-    tmdb_api_key = os.getenv("HSH_TMDB_API_KEY")
+    tmdb_api_key = _resolve_env("HSH_TMDB_API_KEY")
     if not config.tmdb and tmdb_api_key:
         logger.debug("Auto-enabling TMDb from HSH_TMDB_API_KEY environment variable")
         config.tmdb = TMDbSettings(enabled=True, api_key=tmdb_api_key)
@@ -175,8 +205,8 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             config.tmdb.api_key = tmdb_api_key
 
     # Tautulli: auto-create from env vars if section missing
-    tautulli_api_key = os.getenv("HSH_TAUTULLI_API_KEY")
-    tautulli_base_url = os.getenv("HSH_TAUTULLI_BASE_URL")
+    tautulli_api_key = _resolve_env("HSH_TAUTULLI_API_KEY")
+    tautulli_base_url = _resolve_env("HSH_TAUTULLI_BASE_URL")
     if not config.tautulli and tautulli_api_key:
         logger.debug("Auto-enabling Tautulli from HSH_TAUTULLI_API_KEY environment variable")
         kwargs = {"enabled": True, "api_key": tautulli_api_key}
@@ -198,7 +228,7 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             config.tautulli.base_url = tautulli_base_url
 
     # MAL: auto-create from env vars if section missing
-    mal_client_id = os.getenv("HSH_MAL_CLIENT_ID")
+    mal_client_id = _resolve_env("HSH_MAL_CLIENT_ID")
     if not config.mal and mal_client_id:
         logger.debug("Auto-enabling MAL from HSH_MAL_CLIENT_ID environment variable")
         config.mal = MALSettings(enabled=True, client_id=mal_client_id)
@@ -213,8 +243,8 @@ def _apply_env_overrides(config: AppConfig) -> AppConfig:
             )
 
     # Seerr: auto-create from env vars if section missing
-    seerr_api_key = os.getenv("HSH_SEERR_API_KEY")
-    seerr_base_url = os.getenv("HSH_SEERR_BASE_URL")
+    seerr_api_key = _resolve_env("HSH_SEERR_API_KEY")
+    seerr_base_url = _resolve_env("HSH_SEERR_BASE_URL")
     if not config.seerr and seerr_api_key:
         logger.debug("Auto-enabling Seerr from HSH_SEERR_API_KEY environment variable")
         kwargs = {"enabled": True, "api_key": seerr_api_key}

--- a/tests/test_env_file_support.py
+++ b/tests/test_env_file_support.py
@@ -1,0 +1,128 @@
+"""
+Tests for _FILE suffix support (Docker secrets) in env var resolution.
+"""
+import pytest
+from homescreen_hero.core.config.loader import _resolve_env, _apply_env_overrides
+from homescreen_hero.core.config.schema import AppConfig, PlexSettings, RotationSettings
+
+
+class TestResolveEnv:
+    """Tests for _resolve_env() helper."""
+
+    def test_returns_none_when_neither_set(self, monkeypatch):
+        monkeypatch.delenv("HSH_TEST_VAR", raising=False)
+        monkeypatch.delenv("HSH_TEST_VAR_FILE", raising=False)
+        assert _resolve_env("HSH_TEST_VAR") is None
+
+    def test_returns_env_var_value(self, monkeypatch):
+        monkeypatch.setenv("HSH_TEST_VAR", "my-secret")
+        monkeypatch.delenv("HSH_TEST_VAR_FILE", raising=False)
+        assert _resolve_env("HSH_TEST_VAR") == "my-secret"
+
+    def test_reads_file_content(self, monkeypatch, tmp_path):
+        secret_file = tmp_path / "secret.txt"
+        secret_file.write_text("file-secret")
+        monkeypatch.delenv("HSH_TEST_VAR", raising=False)
+        monkeypatch.setenv("HSH_TEST_VAR_FILE", str(secret_file))
+        assert _resolve_env("HSH_TEST_VAR") == "file-secret"
+
+    def test_strips_whitespace_from_file(self, monkeypatch, tmp_path):
+        secret_file = tmp_path / "secret.txt"
+        secret_file.write_text("  file-secret  \n\n")
+        monkeypatch.delenv("HSH_TEST_VAR", raising=False)
+        monkeypatch.setenv("HSH_TEST_VAR_FILE", str(secret_file))
+        assert _resolve_env("HSH_TEST_VAR") == "file-secret"
+
+    def test_errors_when_both_set(self, monkeypatch, tmp_path):
+        secret_file = tmp_path / "secret.txt"
+        secret_file.write_text("file-secret")
+        monkeypatch.setenv("HSH_TEST_VAR", "env-secret")
+        monkeypatch.setenv("HSH_TEST_VAR_FILE", str(secret_file))
+        with pytest.raises(ValueError, match="Both HSH_TEST_VAR and HSH_TEST_VAR_FILE are set"):
+            _resolve_env("HSH_TEST_VAR")
+
+    def test_errors_when_file_missing(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HSH_TEST_VAR", raising=False)
+        monkeypatch.setenv("HSH_TEST_VAR_FILE", str(tmp_path / "nonexistent.txt"))
+        with pytest.raises(ValueError, match="not a readable file"):
+            _resolve_env("HSH_TEST_VAR")
+
+    def test_errors_when_file_empty(self, monkeypatch, tmp_path):
+        secret_file = tmp_path / "secret.txt"
+        secret_file.write_text("   \n")
+        monkeypatch.delenv("HSH_TEST_VAR", raising=False)
+        monkeypatch.setenv("HSH_TEST_VAR_FILE", str(secret_file))
+        with pytest.raises(ValueError, match="which is empty"):
+            _resolve_env("HSH_TEST_VAR")
+
+
+# Clear all HSH_ env vars to avoid interference from the host environment
+ENV_VARS_TO_CLEAR = [
+    "HSH_PLEX_URL", "HSH_PLEX_URL_FILE",
+    "HSH_PLEX_TOKEN", "HSH_PLEX_TOKEN_FILE",
+    "HSH_AUTH_PASSWORD", "HSH_AUTH_PASSWORD_FILE",
+    "HSH_AUTH_SECRET_KEY", "HSH_AUTH_SECRET_KEY_FILE",
+    "HSH_TRAKT_CLIENT_ID", "HSH_TRAKT_CLIENT_ID_FILE",
+    "HSH_MDBLIST_API_KEY", "HSH_MDBLIST_API_KEY_FILE",
+    "HSH_TMDB_API_KEY", "HSH_TMDB_API_KEY_FILE",
+    "HSH_TAUTULLI_API_KEY", "HSH_TAUTULLI_API_KEY_FILE",
+    "HSH_TAUTULLI_BASE_URL", "HSH_TAUTULLI_BASE_URL_FILE",
+    "HSH_MAL_CLIENT_ID", "HSH_MAL_CLIENT_ID_FILE",
+    "HSH_SEERR_API_KEY", "HSH_SEERR_API_KEY_FILE",
+    "HSH_SEERR_BASE_URL", "HSH_SEERR_BASE_URL_FILE",
+]
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for key in ENV_VARS_TO_CLEAR:
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestApplyEnvOverridesWithFile:
+    """Integration tests: _apply_env_overrides works with _FILE variants."""
+
+    def _make_config(self, **overrides):
+        defaults = {
+            "plex": PlexSettings(
+                base_url="http://localhost:32400",
+                token="config-token",
+            ),
+            "rotation": RotationSettings(),
+            "groups": [],
+        }
+        defaults.update(overrides)
+        return AppConfig(**defaults)
+
+    def test_plex_token_from_file(self, monkeypatch, tmp_path, clean_env):
+        secret_file = tmp_path / "plex_token"
+        secret_file.write_text("file-token\n")
+        monkeypatch.setenv("HSH_PLEX_TOKEN_FILE", str(secret_file))
+
+        config = self._make_config(
+            plex=PlexSettings(base_url="http://localhost:32400", token="config-token")
+        )
+        result = _apply_env_overrides(config)
+        assert result.plex.token == "file-token"
+
+    def test_plex_url_from_file(self, monkeypatch, tmp_path, clean_env):
+        secret_file = tmp_path / "plex_url"
+        secret_file.write_text("http://plex-from-file:32400\n")
+        monkeypatch.setenv("HSH_PLEX_URL_FILE", str(secret_file))
+
+        config = self._make_config(
+            plex=PlexSettings(base_url="http://localhost:32400", token="tok")
+        )
+        result = _apply_env_overrides(config)
+        assert result.plex.base_url == "http://plex-from-file:32400"
+
+    def test_trakt_client_id_from_file(self, monkeypatch, tmp_path, clean_env):
+        secret_file = tmp_path / "trakt_id"
+        secret_file.write_text("trakt-from-file\n")
+        monkeypatch.setenv("HSH_TRAKT_CLIENT_ID_FILE", str(secret_file))
+
+        config = self._make_config()
+        result = _apply_env_overrides(config)
+        assert result.trakt is not None
+        assert result.trakt.client_id == "trakt-from-file"
+        assert result.trakt.enabled is True


### PR DESCRIPTION
## Feature: Add \_FILE suffix support for HSH\_\* env vars (Docker secrets)

### Summary
Adds `_FILE` indirection to all `HSH_*` environment variables, following the convention used by LinuxServer.io images and official Docker images (Postgres, MariaDB, etc.). Users can now set e.g. `HSH_PLEX_TOKEN_FILE=/run/secrets/plex_token` to read secrets from files instead of passing them directly as env var values. This enables native Docker Swarm secrets, Kubernetes secrets, and bind-mounted secret file workflows.

### Major Changes
- New `_resolve_env()` helper in `homescreen_hero/core/config/loader.py` that transparently supports `_FILE` indirection for all `HSH_*` env var lookups
- Errors if both `HSH_X` and `HSH_X_FILE` are set simultaneously (prevents ambiguity)
- File contents are stripped of surrounding whitespace (trailing newlines are common in secret files)
- Clear error messages for missing/empty secret files

### Minor Changes
- Documented `_FILE` pattern in `.env.example`
- Added comment in `docker-compose.yml` pointing to `_FILE` support

### Notes
- This is fully backwards-compatible — existing `HSH_*` env var usage is unchanged
- AI-assisted contribution (Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)