### PR TITLE
Feature: Poster backup and restore tool

### DIFF
--- a/homescreen-hero-ui/src/components/tools/PosterBackup.tsx
+++ b/homescreen-hero-ui/src/components/tools/PosterBackup.tsx
@@ -1,0 +1,503 @@
+import { useState, useEffect } from "react";
+import {
+    Loader2,
+    CheckCircle2,
+    AlertTriangle,
+    Check,
+    Image,
+    Film,
+    Tv,
+    Trash2,
+    RotateCcw,
+    HardDrive,
+    Clock,
+} from "lucide-react";
+import { fetchWithAuth } from "../../utils/api";
+import Toast from "../Toast";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogFooter,
+    DialogTitle,
+    DialogDescription,
+    DialogCloseButton,
+} from "@/components/ui/dialog";
+
+type PosterBackupProps = {
+    onClose: () => void;
+};
+
+type LibraryInfo = {
+    name: string;
+    type: string;
+    movie_count: number;
+    show_count: number;
+    collection_count: number;
+};
+
+type LibrarySelection = {
+    library_name: string;
+    include_movies: boolean;
+    include_shows: boolean;
+    include_collections: boolean;
+};
+
+type BackupSummary = {
+    id: string;
+    created_at: string;
+    total_posters: number;
+    movies: number;
+    shows: number;
+    collections: number;
+    size_mb: number;
+    libraries: string[];
+};
+
+type BackupResult = {
+    id: string;
+    total_posters: number;
+    movies: number;
+    shows: number;
+    collections: number;
+    errors: number;
+};
+
+type Progress = {
+    processed: number;
+    total: number;
+    title: string;
+};
+
+// SSE stream reader helper
+async function readSSEStream(
+    response: Response,
+    onEvent: (data: Record<string, unknown>) => void,
+) {
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split("\n\n");
+        buffer = events.pop() || "";
+
+        for (const event of events) {
+            if (!event.trim()) continue;
+            const dataMatch = event.match(/^data: (.+)$/m);
+            if (!dataMatch) continue;
+            try {
+                onEvent(JSON.parse(dataMatch[1]));
+            } catch {
+                // skip unparseable events
+            }
+        }
+    }
+}
+
+export default function PosterBackup({ onClose }: PosterBackupProps) {
+    const [libraries, setLibraries] = useState<LibraryInfo[]>([]);
+    const [selections, setSelections] = useState<Record<string, LibrarySelection>>({});
+    const [backups, setBackups] = useState<BackupSummary[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [backing, setBacking] = useState(false);
+    const [restoring, setRestoring] = useState<string | null>(null);
+    const [deleting, setDeleting] = useState<string | null>(null);
+    const [result, setResult] = useState<BackupResult | null>(null);
+    const [progress, setProgress] = useState<Progress | null>(null);
+    const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+
+    useEffect(() => {
+        Promise.all([
+            fetchWithAuth("/api/tools/poster-backup/libraries").then((r) => r.json()),
+            fetchWithAuth("/api/tools/poster-backup/list").then((r) => r.json()),
+        ])
+            .then(([libs, bkps]) => {
+                setLibraries(libs);
+                setBackups(bkps);
+                const sel: Record<string, LibrarySelection> = {};
+                for (const lib of libs) {
+                    sel[lib.name] = {
+                        library_name: lib.name,
+                        include_movies: lib.type === "movie",
+                        include_shows: lib.type === "show",
+                        include_collections: true,
+                    };
+                }
+                setSelections(sel);
+            })
+            .catch(() => setToast({ message: "Failed to load libraries", type: "error" }))
+            .finally(() => setLoading(false));
+    }, []);
+
+    const toggleSelection = (libName: string, field: keyof LibrarySelection) => {
+        setSelections((prev) => ({
+            ...prev,
+            [libName]: {
+                ...prev[libName],
+                [field]: !prev[libName][field],
+            },
+        }));
+    };
+
+    const hasAnySelected = Object.values(selections).some(
+        (s) => s.include_movies || s.include_shows || s.include_collections
+    );
+
+    const handleBackup = async () => {
+        const selected = Object.values(selections).filter(
+            (s) => s.include_movies || s.include_shows || s.include_collections
+        );
+        if (selected.length === 0) return;
+
+        setBacking(true);
+        setResult(null);
+        setProgress(null);
+        try {
+            const r = await fetchWithAuth("/api/tools/poster-backup/start", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ libraries: selected }),
+            });
+            if (!r.ok) {
+                const text = await r.text();
+                throw new Error(text || "Backup failed");
+            }
+
+            await readSSEStream(r, (data) => {
+                if (data.type === "progress") {
+                    setProgress({
+                        processed: data.processed as number,
+                        total: data.total as number,
+                        title: data.title as string,
+                    });
+                } else if (data.type === "complete") {
+                    const res = data as unknown as BackupResult;
+                    setResult(res);
+                    setToast({ message: `Backed up ${res.total_posters} posters`, type: "success" });
+                } else if (data.type === "error") {
+                    throw new Error(data.message as string);
+                }
+            });
+
+            // Refresh backup list
+            const listR = await fetchWithAuth("/api/tools/poster-backup/list");
+            setBackups(await listR.json());
+        } catch (e) {
+            setToast({ message: String(e), type: "error" });
+        } finally {
+            setBacking(false);
+            setProgress(null);
+        }
+    };
+
+    const handleRestore = async (backupId: string) => {
+        setRestoring(backupId);
+        setProgress(null);
+        try {
+            const r = await fetchWithAuth(`/api/tools/poster-backup/restore/${backupId}`, {
+                method: "POST",
+            });
+            if (!r.ok) throw new Error(await r.text());
+
+            let finalResult = { total_restored: 0, errors: 0 };
+            await readSSEStream(r, (data) => {
+                if (data.type === "progress") {
+                    setProgress({
+                        processed: data.processed as number,
+                        total: data.total as number,
+                        title: data.title as string,
+                    });
+                } else if (data.type === "complete") {
+                    finalResult = { total_restored: data.total_restored as number, errors: data.errors as number };
+                }
+            });
+
+            setToast({
+                message: `Restored ${finalResult.total_restored} posters${finalResult.errors > 0 ? ` (${finalResult.errors} errors)` : ""}`,
+                type: finalResult.errors > 0 ? "error" : "success",
+            });
+        } catch (e) {
+            setToast({ message: String(e), type: "error" });
+        } finally {
+            setRestoring(null);
+            setProgress(null);
+        }
+    };
+
+    const handleDelete = async (backupId: string) => {
+        setDeleting(backupId);
+        try {
+            const r = await fetchWithAuth(`/api/tools/poster-backup/${backupId}`, {
+                method: "DELETE",
+            });
+            if (!r.ok) throw new Error(await r.text());
+            setBackups((prev) => prev.filter((b) => b.id !== backupId));
+            setToast({ message: "Backup deleted", type: "success" });
+        } catch (e) {
+            setToast({ message: String(e), type: "error" });
+        } finally {
+            setDeleting(null);
+        }
+    };
+
+    const formatDate = (iso: string) => {
+        try {
+            return new Date(iso).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+            });
+        } catch {
+            return iso;
+        }
+    };
+
+    const isWorking = backing || restoring !== null;
+    const progressPct = progress ? Math.round((progress.processed / progress.total) * 100) : 0;
+
+    return (
+        <>
+            <Dialog open onOpenChange={(open) => { if (!open && !isWorking) onClose(); }}>
+                <DialogContent className="max-w-2xl">
+                    <DialogHeader>
+                        <div>
+                            <DialogTitle>Poster Backup / Restore</DialogTitle>
+                            <DialogDescription>
+                                Backup and restore your Plex posters for movies, shows, and collections.
+                            </DialogDescription>
+                        </div>
+                        <DialogCloseButton />
+                    </DialogHeader>
+
+                    <div className="p-6 space-y-6 overflow-y-auto max-h-[60vh] scrollbar-hover-only">
+                        {loading ? (
+                            <div className="flex items-center justify-center py-12">
+                                <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+                            </div>
+                        ) : (
+                            <>
+                                {/* Progress Bar */}
+                                {isWorking && progress && (
+                                    <div className="space-y-2">
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="text-slate-300">
+                                                {backing ? "Backing up" : "Restoring"}: {progress.title}
+                                            </span>
+                                            <span className="text-slate-400 tabular-nums">
+                                                {progress.processed} / {progress.total}
+                                            </span>
+                                        </div>
+                                        <div className="h-2 w-full rounded-full bg-slate-800 overflow-hidden">
+                                            <div
+                                                className="h-full rounded-full bg-primary transition-all duration-300 ease-out"
+                                                style={{ width: `${progressPct}%` }}
+                                            />
+                                        </div>
+                                        <p className="text-xs text-slate-500 text-right">{progressPct}%</p>
+                                    </div>
+                                )}
+
+                                {/* Library Selection (hidden during work) */}
+                                {!isWorking && (
+                                    <div>
+                                        <h3 className="text-sm font-semibold text-white mb-3">Select What to Back Up</h3>
+                                        <div className="space-y-2">
+                                            {libraries.map((lib) => {
+                                                const sel = selections[lib.name];
+                                                if (!sel) return null;
+                                                return (
+                                                    <div
+                                                        key={lib.name}
+                                                        className="rounded-lg border border-slate-800/60 bg-slate-900/50 p-4"
+                                                    >
+                                                        <div className="flex items-center gap-2 mb-3">
+                                                            {lib.type === "movie" ? (
+                                                                <Film className="h-4 w-4 text-slate-400" />
+                                                            ) : (
+                                                                <Tv className="h-4 w-4 text-slate-400" />
+                                                            )}
+                                                            <span className="text-sm font-medium text-white">{lib.name}</span>
+                                                            <span className="text-xs text-slate-500">
+                                                                {lib.type === "movie" ? `${lib.movie_count} movies` : `${lib.show_count} shows`}
+                                                                {lib.collection_count > 0 && ` · ${lib.collection_count} collections`}
+                                                            </span>
+                                                        </div>
+                                                        <div className="flex items-center gap-4">
+                                                            {lib.type === "movie" && (
+                                                                <label className="flex items-center gap-2 cursor-pointer" onClick={() => toggleSelection(lib.name, "include_movies")}>
+                                                                    <div className={`w-4 h-4 rounded border flex items-center justify-center transition-all flex-shrink-0 ${sel.include_movies ? "bg-primary border-primary" : "border-slate-600"}`}>
+                                                                        {sel.include_movies && <Check size={12} className="text-white" />}
+                                                                    </div>
+                                                                    <span className="text-sm text-slate-300">Movies</span>
+                                                                </label>
+                                                            )}
+                                                            {lib.type === "show" && (
+                                                                <label className="flex items-center gap-2 cursor-pointer" onClick={() => toggleSelection(lib.name, "include_shows")}>
+                                                                    <div className={`w-4 h-4 rounded border flex items-center justify-center transition-all flex-shrink-0 ${sel.include_shows ? "bg-primary border-primary" : "border-slate-600"}`}>
+                                                                        {sel.include_shows && <Check size={12} className="text-white" />}
+                                                                    </div>
+                                                                    <span className="text-sm text-slate-300">Shows</span>
+                                                                </label>
+                                                            )}
+                                                            {lib.collection_count > 0 && (
+                                                                <label className="flex items-center gap-2 cursor-pointer" onClick={() => toggleSelection(lib.name, "include_collections")}>
+                                                                    <div className={`w-4 h-4 rounded border flex items-center justify-center transition-all flex-shrink-0 ${sel.include_collections ? "bg-primary border-primary" : "border-slate-600"}`}>
+                                                                        {sel.include_collections && <Check size={12} className="text-white" />}
+                                                                    </div>
+                                                                    <span className="text-sm text-slate-300">Collections</span>
+                                                                </label>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
+                                )}
+
+                                {/* Backup Result */}
+                                {result && (
+                                    <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+                                        <div className="flex items-center gap-2.5 mb-3">
+                                            <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />
+                                            <p className="text-sm font-medium text-emerald-300">Backup complete</p>
+                                        </div>
+                                        <div className="grid grid-cols-4 gap-3">
+                                            <div className="text-center">
+                                                <p className="text-lg font-semibold text-white">{result.total_posters}</p>
+                                                <p className="text-xs text-slate-400">total</p>
+                                            </div>
+                                            <div className="text-center">
+                                                <p className="text-lg font-semibold text-white">{result.movies}</p>
+                                                <p className="text-xs text-slate-400">movies</p>
+                                            </div>
+                                            <div className="text-center">
+                                                <p className="text-lg font-semibold text-white">{result.shows}</p>
+                                                <p className="text-xs text-slate-400">shows</p>
+                                            </div>
+                                            <div className="text-center">
+                                                <p className="text-lg font-semibold text-white">{result.collections}</p>
+                                                <p className="text-xs text-slate-400">collections</p>
+                                            </div>
+                                        </div>
+                                        {result.errors > 0 && (
+                                            <div className="flex items-center gap-2 mt-3">
+                                                <AlertTriangle className="h-3.5 w-3.5 text-amber-400" />
+                                                <p className="text-xs text-amber-300">{result.errors} poster{result.errors !== 1 ? "s" : ""} failed to download</p>
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Existing Backups */}
+                                {backups.length > 0 && !isWorking && (
+                                    <div>
+                                        <h3 className="text-sm font-semibold text-white mb-3">Previous Backups</h3>
+                                        <div className="space-y-2">
+                                            {backups.map((backup) => (
+                                                <div
+                                                    key={backup.id}
+                                                    className="rounded-lg border border-slate-800/60 bg-slate-900/50 p-4"
+                                                >
+                                                    <div className="flex items-center justify-between">
+                                                        <div className="space-y-1">
+                                                            <div className="flex items-center gap-2">
+                                                                <Clock className="h-3.5 w-3.5 text-slate-500" />
+                                                                <span className="text-sm font-medium text-white">
+                                                                    {formatDate(backup.created_at)}
+                                                                </span>
+                                                            </div>
+                                                            <div className="flex items-center gap-3 text-xs text-slate-400">
+                                                                <span className="flex items-center gap-1">
+                                                                    <Image className="h-3 w-3" />
+                                                                    {backup.total_posters} posters
+                                                                </span>
+                                                                {backup.movies > 0 && <span>{backup.movies} movies</span>}
+                                                                {backup.shows > 0 && <span>{backup.shows} shows</span>}
+                                                                {backup.collections > 0 && <span>{backup.collections} collections</span>}
+                                                                <span className="flex items-center gap-1">
+                                                                    <HardDrive className="h-3 w-3" />
+                                                                    {backup.size_mb} MB
+                                                                </span>
+                                                            </div>
+                                                            <div className="text-xs text-slate-500">
+                                                                {backup.libraries.join(", ")}
+                                                            </div>
+                                                        </div>
+                                                        <div className="flex items-center gap-2">
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => handleRestore(backup.id)}
+                                                                disabled={restoring !== null || deleting !== null}
+                                                                className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs font-medium text-slate-300 hover:bg-slate-700 transition-colors disabled:opacity-50 flex items-center gap-1.5"
+                                                            >
+                                                                <RotateCcw className="h-3 w-3" />
+                                                                Restore
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => handleDelete(backup.id)}
+                                                                disabled={restoring !== null || deleting !== null}
+                                                                className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/20 hover:border-red-500/40 transition-colors disabled:opacity-50 flex items-center gap-1.5"
+                                                            >
+                                                                {deleting === backup.id ? (
+                                                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                                                ) : (
+                                                                    <Trash2 className="h-3 w-3" />
+                                                                )}
+                                                                {deleting === backup.id ? "Deleting..." : "Delete"}
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </div>
+
+                    <DialogFooter>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            disabled={isWorking}
+                            className="rounded-lg border border-slate-700 bg-slate-800 px-4 py-2 text-sm font-medium text-slate-300 hover:bg-slate-700 transition-colors disabled:opacity-50"
+                        >
+                            {result ? "Done" : "Cancel"}
+                        </button>
+                        {!result && (
+                            <button
+                                type="button"
+                                onClick={handleBackup}
+                                disabled={isWorking || !hasAnySelected || loading}
+                                className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-hover disabled:opacity-50 transition-colors flex items-center gap-2"
+                            >
+                                {backing && <Loader2 className="h-4 w-4 animate-spin" />}
+                                {backing ? "Backing Up..." : "Back Up Now"}
+                            </button>
+                        )}
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {toast && (
+                <Toast
+                    message={toast.message}
+                    type={toast.type}
+                    onClose={() => setToast(null)}
+                />
+            )}
+        </>
+    );
+}

--- a/homescreen-hero-ui/src/pages/ToolsPage.tsx
+++ b/homescreen-hero-ui/src/pages/ToolsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Calendar, Wrench, History, FileSearch, Users, ArrowLeftRight, ShieldOff } from "lucide-react";
+import { Calendar, Wrench, History, FileSearch, Users, ArrowLeftRight, ShieldOff, Image } from "lucide-react";
 import ToolCard from "../components/tools/ToolCard";
 import DateAddedEditor from "../components/tools/DateAddedEditor";
 import WatchHistoryCleaner from "../components/tools/WatchHistoryCleaner";
@@ -7,6 +7,7 @@ import UnwatchedReport from "../components/tools/UnwatchedReport";
 import CopyWatchHistory from "../components/tools/CopyWatchHistory";
 import CollectionImportExport from "../components/tools/CollectionImportExport";
 import ClearUserTargeting from "../components/tools/ClearUserTargeting";
+import PosterBackup from "../components/tools/PosterBackup";
 
 type Tool = {
     id: string;
@@ -51,6 +52,12 @@ const tools: Tool[] = [
         title: "Clear User Targeting Labels",
         description: "Remove all hsh-hide labels and reset user filter settings",
         icon: ShieldOff,
+    },
+    {
+        id: "poster-backup",
+        title: "Poster Backup / Restore",
+        description: "Backup and restore your Plex posters for movies, shows, and collections",
+        icon: Image,
     },
 ];
 
@@ -106,6 +113,9 @@ export default function ToolsPage() {
             )}
             {activeTool === "clear-user-targeting" && (
                 <ClearUserTargeting onClose={() => setActiveTool(null)} />
+            )}
+            {activeTool === "poster-backup" && (
+                <PosterBackup onClose={() => setActiveTool(null)} />
             )}
         </div>
     );

--- a/homescreen_hero/web/app.py
+++ b/homescreen_hero/web/app.py
@@ -31,6 +31,7 @@ from homescreen_hero.web.routers import (
     version_router,
     library_stats_router,
     user_targeting_router,
+    poster_backup_router,
 )
 from homescreen_hero.web.routers.version import get_current_version
 from homescreen_hero.web.routers.collections import invalidate_collections_cache
@@ -70,6 +71,7 @@ def create_app() -> FastAPI:
     app.include_router(version_router, prefix="/api")
     app.include_router(library_stats_router, prefix="/api")
     app.include_router(user_targeting_router, prefix="/api")
+    app.include_router(poster_backup_router, prefix="/api")
 
     # Frontend (serve only if build exists)
     logger.info(

--- a/homescreen_hero/web/routers/__init__.py
+++ b/homescreen_hero/web/routers/__init__.py
@@ -15,6 +15,7 @@ from .collection_io import router as collection_io_router
 from .version import router as version_router
 from .library_stats import router as library_stats_router
 from .user_targeting import router as user_targeting_router
+from .poster_backup import router as poster_backup_router
 
 __all__ = [
     "analytics_router",
@@ -27,6 +28,7 @@ __all__ = [
     "integrations_router",
     "library_stats_router",
     "logs_router",
+    "poster_backup_router",
     "rotation_router",
     "seerr_router",
     "tools_router",

--- a/homescreen_hero/web/routers/poster_backup.py
+++ b/homescreen_hero/web/routers/poster_backup.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+from fastapi import APIRouter, HTTPException, Depends
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from homescreen_hero.core.config.loader import load_config
+from homescreen_hero.core.integrations.plex_client import (
+    get_plex_server,
+    get_library_collections,
+)
+from homescreen_hero.core.auth import CurrentUser, require_admin
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/tools/poster-backup", tags=["tools"])
+
+BACKUP_DIR_NAME = "poster-backups"
+
+
+def _get_backup_root() -> Path:
+    data_dir = Path(os.getenv("HSH_DATA_DIR", "data"))
+    backup_root = data_dir / BACKUP_DIR_NAME
+    backup_root.mkdir(parents=True, exist_ok=True)
+    return backup_root
+
+
+# Request / Response models
+
+class BackupLibrarySelection(BaseModel):
+    library_name: str
+    include_movies: bool = False
+    include_shows: bool = False
+    include_collections: bool = False
+
+
+class StartBackupRequest(BaseModel):
+    libraries: List[BackupLibrarySelection]
+
+
+class LibraryInfo(BaseModel):
+    name: str
+    type: str  # "movie" or "show"
+    movie_count: int = 0
+    show_count: int = 0
+    collection_count: int = 0
+
+
+class BackupSummary(BaseModel):
+    id: str
+    created_at: str
+    total_posters: int
+    movies: int
+    shows: int
+    collections: int
+    size_mb: float
+    libraries: List[str]
+
+
+class BackupResult(BaseModel):
+    id: str
+    total_posters: int
+    movies: int
+    shows: int
+    collections: int
+    errors: int
+
+
+class RestoreResult(BaseModel):
+    total_restored: int
+    errors: int
+
+
+# Endpoints
+
+@router.get("/libraries", response_model=List[LibraryInfo])
+def get_libraries_for_backup(
+    _current_user: CurrentUser = Depends(require_admin),
+) -> List[LibraryInfo]:
+    config = load_config()
+    server = get_plex_server(config)
+
+    libraries = []
+    for lib_config in config.plex.libraries:
+        if not lib_config.enabled:
+            continue
+        try:
+            section = server.library.section(lib_config.name)
+            lib_type = section.type  # "movie" or "show"
+
+            collections = section.collections()
+
+            libraries.append(LibraryInfo(
+                name=lib_config.name,
+                type=lib_type,
+                movie_count=section.totalSize if lib_type == "movie" else 0,
+                show_count=section.totalSize if lib_type == "show" else 0,
+                collection_count=len(collections),
+            ))
+        except Exception as e:
+            logger.warning("Failed to load library %s: %s", lib_config.name, e)
+
+    return libraries
+
+
+@router.post("/start")
+def start_backup(
+    request: StartBackupRequest,
+    _current_user: CurrentUser = Depends(require_admin),
+):
+    if not request.libraries:
+        raise HTTPException(status_code=400, detail="No libraries selected")
+
+    def generate_events():
+        config = load_config()
+        server = get_plex_server(config)
+        http_session = requests.Session()
+        http_session.verify = False
+
+        # First pass: count total items to back up
+        total_items = 0
+        lib_work = []  # (lib_selection, section, items_list, collections_list)
+
+        for lib_selection in request.libraries:
+            try:
+                section = server.library.section(lib_selection.library_name)
+            except Exception as e:
+                logger.error("Library %s not found: %s", lib_selection.library_name, e)
+                continue
+
+            lib_type = section.type
+            items_list = []
+            collections_list = []
+
+            if (lib_type == "movie" and lib_selection.include_movies) or \
+               (lib_type == "show" and lib_selection.include_shows):
+                items_list = section.all()
+                total_items += len(items_list)
+
+            if lib_selection.include_collections:
+                collections_list = section.collections()
+                total_items += len(collections_list)
+
+            lib_work.append((lib_selection, section, items_list, collections_list))
+
+        if total_items == 0:
+            yield f"data: {json.dumps({'type': 'error', 'message': 'No items found to back up'})}\n\n"
+            return
+
+        # Send initial count
+        yield f"data: {json.dumps({'type': 'start', 'total': total_items})}\n\n"
+
+        timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        backup_dir = _get_backup_root() / timestamp
+
+        manifest = {
+            "created_at": datetime.now().isoformat(),
+            "libraries": [],
+            "items": [],
+        }
+
+        counts = {"movies": 0, "shows": 0, "collections": 0, "errors": 0}
+        processed = 0
+
+        for lib_selection, section, items_list, collections_list in lib_work:
+            manifest["libraries"].append(lib_selection.library_name)
+            lib_type = section.type
+
+            # Back up movie/show posters
+            if items_list:
+                category = "movies" if lib_type == "movie" else "shows"
+                category_dir = backup_dir / category
+                category_dir.mkdir(parents=True, exist_ok=True)
+
+                for item in items_list:
+                    processed += 1
+                    if not getattr(item, "thumb", None):
+                        yield f"data: {json.dumps({'type': 'progress', 'processed': processed, 'total': total_items, 'title': item.title, 'skipped': True})}\n\n"
+                        continue
+                    try:
+                        thumb_url = server.url(item.thumb, includeToken=True)
+                        img_data = http_session.get(thumb_url, timeout=15).content
+                        filename = f"{item.ratingKey}.jpg"
+                        (category_dir / filename).write_bytes(img_data)
+
+                        manifest["items"].append({
+                            "type": category.rstrip("s"),
+                            "rating_key": str(item.ratingKey),
+                            "title": item.title,
+                            "year": getattr(item, "year", None),
+                            "library": lib_selection.library_name,
+                            "filename": f"{category}/{filename}",
+                        })
+                        counts[category] += 1
+                    except Exception as e:
+                        logger.warning("Failed to backup poster for %s: %s", item.title, e)
+                        counts["errors"] += 1
+
+                    yield f"data: {json.dumps({'type': 'progress', 'processed': processed, 'total': total_items, 'title': item.title})}\n\n"
+
+            # Back up collection posters
+            if collections_list:
+                collections_dir = backup_dir / "collections"
+                collections_dir.mkdir(parents=True, exist_ok=True)
+
+                for col in collections_list:
+                    processed += 1
+                    if not getattr(col, "thumb", None):
+                        yield f"data: {json.dumps({'type': 'progress', 'processed': processed, 'total': total_items, 'title': col.title, 'skipped': True})}\n\n"
+                        continue
+                    try:
+                        thumb_url = server.url(col.thumb, includeToken=True)
+                        img_data = http_session.get(thumb_url, timeout=15).content
+                        filename = f"{col.ratingKey}.jpg"
+                        (collections_dir / filename).write_bytes(img_data)
+
+                        manifest["items"].append({
+                            "type": "collection",
+                            "rating_key": str(col.ratingKey),
+                            "title": col.title,
+                            "library": lib_selection.library_name,
+                            "filename": f"collections/{filename}",
+                        })
+                        counts["collections"] += 1
+                    except Exception as e:
+                        logger.warning("Failed to backup poster for collection %s: %s", col.title, e)
+                        counts["errors"] += 1
+
+                    yield f"data: {json.dumps({'type': 'progress', 'processed': processed, 'total': total_items, 'title': col.title})}\n\n"
+
+        total = counts["movies"] + counts["shows"] + counts["collections"]
+
+        if total == 0:
+            if backup_dir.exists():
+                shutil.rmtree(backup_dir)
+            yield f"data: {json.dumps({'type': 'error', 'message': 'No posters found to back up'})}\n\n"
+            return
+
+        (backup_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+        yield f"data: {json.dumps({'type': 'complete', 'id': timestamp, 'total_posters': total, 'movies': counts['movies'], 'shows': counts['shows'], 'collections': counts['collections'], 'errors': counts['errors']})}\n\n"
+
+    return StreamingResponse(
+        generate_events(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
+@router.get("/list", response_model=List[BackupSummary])
+def list_backups(
+    _current_user: CurrentUser = Depends(require_admin),
+) -> List[BackupSummary]:
+    backup_root = _get_backup_root()
+    backups = []
+
+    for entry in sorted(backup_root.iterdir(), reverse=True):
+        if not entry.is_dir():
+            continue
+
+        manifest_path = entry / "manifest.json"
+        if not manifest_path.exists():
+            continue
+
+        try:
+            manifest = json.loads(manifest_path.read_text())
+
+            # Count by type
+            movies = sum(1 for i in manifest["items"] if i["type"] == "movie")
+            shows = sum(1 for i in manifest["items"] if i["type"] == "show")
+            collections = sum(1 for i in manifest["items"] if i["type"] == "collection")
+
+            # Calculate total size
+            total_bytes = sum(
+                f.stat().st_size
+                for f in entry.rglob("*")
+                if f.is_file()
+            )
+
+            backups.append(BackupSummary(
+                id=entry.name,
+                created_at=manifest.get("created_at", ""),
+                total_posters=movies + shows + collections,
+                movies=movies,
+                shows=shows,
+                collections=collections,
+                size_mb=round(total_bytes / (1024 * 1024), 1),
+                libraries=manifest.get("libraries", []),
+            ))
+        except Exception as e:
+            logger.warning("Failed to read backup %s: %s", entry.name, e)
+
+    return backups
+
+
+@router.post("/restore/{backup_id}")
+def restore_backup(
+    backup_id: str,
+    _current_user: CurrentUser = Depends(require_admin),
+):
+    backup_dir = _get_backup_root() / backup_id
+    manifest_path = backup_dir / "manifest.json"
+
+    if not manifest_path.exists():
+        raise HTTPException(status_code=404, detail="Backup not found")
+
+    def generate_events():
+        manifest = json.loads(manifest_path.read_text())
+        config = load_config()
+        server = get_plex_server(config)
+
+        total = len(manifest["items"])
+        yield f"data: {json.dumps({'type': 'start', 'total': total})}\n\n"
+
+        restored = 0
+        errors = 0
+
+        for idx, item_entry in enumerate(manifest["items"], 1):
+            poster_path = backup_dir / item_entry["filename"]
+            if not poster_path.exists():
+                errors += 1
+                yield f"data: {json.dumps({'type': 'progress', 'processed': idx, 'total': total, 'title': item_entry.get('title', 'unknown')})}\n\n"
+                continue
+
+            try:
+                rating_key = item_entry["rating_key"]
+                item_type = item_entry["type"]
+
+                if item_type == "collection":
+                    section = server.library.section(item_entry["library"])
+                    target = None
+                    for col in section.collections():
+                        if str(col.ratingKey) == rating_key:
+                            target = col
+                            break
+                    if not target:
+                        logger.warning("Collection %s not found, skipping", item_entry["title"])
+                        errors += 1
+                        yield f"data: {json.dumps({'type': 'progress', 'processed': idx, 'total': total, 'title': item_entry.get('title', 'unknown')})}\n\n"
+                        continue
+                else:
+                    target = server.fetchItem(int(rating_key))
+
+                target.uploadPoster(filepath=str(poster_path))
+                restored += 1
+                time.sleep(0.1)
+
+            except Exception as e:
+                logger.warning(
+                    "Failed to restore poster for %s (%s): %s",
+                    item_entry.get("title", "unknown"),
+                    item_entry.get("type", "unknown"),
+                    e,
+                )
+                errors += 1
+
+            yield f"data: {json.dumps({'type': 'progress', 'processed': idx, 'total': total, 'title': item_entry.get('title', 'unknown')})}\n\n"
+
+        yield f"data: {json.dumps({'type': 'complete', 'total_restored': restored, 'errors': errors})}\n\n"
+
+    return StreamingResponse(
+        generate_events(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
+@router.delete("/{backup_id}")
+def delete_backup(
+    backup_id: str,
+    _current_user: CurrentUser = Depends(require_admin),
+) -> dict:
+    backup_dir = _get_backup_root() / backup_id
+    if not backup_dir.exists():
+        raise HTTPException(status_code=404, detail="Backup not found")
+
+    shutil.rmtree(backup_dir)
+    return {"success": True, "message": f"Backup {backup_id} deleted"}


### PR DESCRIPTION
### Summary
Adds a new tool to the Tools page that lets users back up and restore posters for movies, shows, and collections. Users pick which libraries and content types to include, hit backup, and the posters get saved to disk with a manifest. Previous backups are listed with restore and delete options.

### Major Changes
- New backend router (`poster_backup.py`) with SSE-streamed endpoints for backup and restore, plus list and delete endpoints
- New `PosterBackup.tsx` frontend component with library/type selection, real-time progress bar during backup and restore, and a backup history list
- Backups stored in `data/poster-backups/{timestamp}/` with a `manifest.json` mapping rating keys to poster files
- Registered new router and added Poster Backup card to the Tools page